### PR TITLE
🧹 Fix any usage for saveTimeout and saveState in useGraphStore

### DIFF
--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -227,7 +227,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
   }
 }));
 
-let saveTimeout: any = null;
+let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 function debouncedSaveState() {
   if (saveTimeout) clearTimeout(saveTimeout);
   saveTimeout = setTimeout(() => {
@@ -237,7 +237,7 @@ function debouncedSaveState() {
   }, 1000);
 }
 
-function saveState(state: any) {
+function saveState(state: GraphState) {
   const appState: AppState = {
     viewportX: state.viewportX,
     yAxes: state.yAxes,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the use of `any` for `saveTimeout` and the `state` parameter in `saveState`.
💡 **Why:** This improves maintainability and readability by leveraging TypeScript's type checking system. Using `ReturnType<typeof setTimeout>` is a robust way to type timeout identifiers across different environments.
✅ **Verification:** The changes were manually verified for syntax correctness. A code review was conducted and approved.
✨ **Result:** Enhanced type safety in `src/store/useGraphStore.ts`.

---
*PR created automatically by Jules for task [13317149106673472138](https://jules.google.com/task/13317149106673472138) started by @michaelkrisper*