### PR TITLE
🔒 Fix XSS in SVG Export

### DIFF
--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -4,6 +4,20 @@ import { lttb } from '../utils/lttb';
 
 const AXIS_WIDTH_BASE = 15; // Ticks, gap, and safe margin
 
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#039;',
+  '=': '&#061;'
+};
+
+const escapeHTML = (str: string | undefined | null): string => {
+  if (!str) return '';
+  return String(str).replace(/[&<>"'=]/g, (s) => HTML_ESCAPE_MAP[s] || s);
+};
+
 /**
  * exportToSVG (v2.4 - Dynamic Spacing & Decimal Alignment)
  * Generates a high-quality SVG that matches the PlotArea visuals exactly.
@@ -108,13 +122,13 @@ export const exportToSVG = (
     if (screenPoints.length > 1 && s.lineStyle !== 'none') {
       const pathData = screenPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
       let dashArray = ''; if (s.lineStyle === 'dashed') dashArray = 'stroke-dasharray="8,6"'; else if (s.lineStyle === 'dotted') dashArray = 'stroke-dasharray="2,4"';
-      svg += `<path d="${pathData}" fill="none" stroke="${s.lineColor}" stroke-width="1" ${dashArray} />`;
+      svg += `<path d="${pathData}" fill="none" stroke="${escapeHTML(s.lineColor)}" stroke-width="1" ${dashArray} />`;
     }
     if (s.pointStyle !== 'none') {
       screenPoints.forEach(p => {
-        if (s.pointStyle === 'circle') svg += `<circle cx="${p.x}" cy="${p.y}" r="2.5" fill="${s.pointColor}" />`;
-        else if (s.pointStyle === 'square') svg += `<rect x="${p.x - 2.5}" y="${p.y - 2.5}" width="5" height="5" fill="${s.pointColor}" />`;
-        else if (s.pointStyle === 'cross') svg += `<path d="M ${p.x - 2.5} ${p.y - 2.5} L ${p.x + 2.5} ${p.y + 2.5} M ${p.x + 2.5} ${p.y - 2.5} L ${p.x - 2.5} ${p.y + 2.5}" stroke="${s.pointColor}" stroke-width="1" />`;
+        if (s.pointStyle === 'circle') svg += `<circle cx="${p.x}" cy="${p.y}" r="2.5" fill="${escapeHTML(s.pointColor)}" />`;
+        else if (s.pointStyle === 'square') svg += `<rect x="${p.x - 2.5}" y="${p.y - 2.5}" width="5" height="5" fill="${escapeHTML(s.pointColor)}" />`;
+        else if (s.pointStyle === 'cross') svg += `<path d="M ${p.x - 2.5} ${p.y - 2.5} L ${p.x + 2.5} ${p.y + 2.5} M ${p.x + 2.5} ${p.y - 2.5} L ${p.x - 2.5} ${p.y + 2.5}" stroke="${escapeHTML(s.pointColor)}" stroke-width="1" />`;
       });
     }
   });
@@ -130,7 +144,7 @@ export const exportToSVG = (
     const label = xMode === 'date' ? formatDate(t, xStep) : t.toFixed(xPrecision);
     svg += `<text x="${x}" y="${height - padding.bottom + 18}" text-anchor="middle" font-size="9" fill="#666">${label}</text>`;
   }
-  svg += `<text x="${padding.left + chartWidth / 2}" y="${height - 5}" text-anchor="middle" font-size="12" font-weight="bold" fill="#333">${axisTitles.x}</text>`;
+  svg += `<text x="${padding.left + chartWidth / 2}" y="${height - 5}" text-anchor="middle" font-size="12" font-weight="bold" fill="#333">${escapeHTML(axisTitles.x)}</text>`;
 
   activeYAxes.forEach(axis => {
     const isLeft = axis.position === 'left', sideIdx = isLeft ? leftAxes.indexOf(axis) : rightAxes.indexOf(axis);
@@ -167,7 +181,7 @@ export const exportToSVG = (
     const estW = Math.min(chartHeight, title.length * 6 + 8);
     svg += `<g transform="translate(${titleX}, ${titleY}) rotate(${rotate})">`;
     svg += `<rect x="-${estW / 2}" y="-8" width="${estW}" height="16" fill="rgba(255, 255, 255, 0.8)" rx="2" />`;
-    svg += `<text x="0" y="4" text-anchor="middle" font-size="10" font-weight="bold" fill="${axisSeries[0]?.lineColor || '#333'}">${title}</text></g>`;
+    svg += `<text x="0" y="4" text-anchor="middle" font-size="10" font-weight="bold" fill="${escapeHTML(axisSeries[0]?.lineColor || '#333')}">${escapeHTML(title)}</text></g>`;
   });
 
   svg += `</svg>`; return svg;


### PR DESCRIPTION
🎯 **What:** This PR fixes a Cross-Site Scripting (XSS) vulnerability in the SVG export functionality.

⚠️ **Risk:** User-controlled data, such as axis titles, series names, and colors, were directly interpolated into the SVG string without any escaping. An attacker could provide malicious input (e.g., via a crafted dataset or saved view) containing `<script>` tags or malicious event handlers (e.g., `onerror`), which would be executed when a user views or downloads the generated SVG.

🛡️ **Solution:** I implemented a robust `escapeHTML` utility in `src/services/export.ts` that escapes the following characters: `&`, `<`, `>`, `"`, `'`, and `=`. This utility is now applied to all identified user-controlled variables in the `exportToSVG` function, ensuring that any malicious input is rendered as literal text within the SVG, thereby neutralizing the XSS vector. The fix was verified using a reproduction script that confirmed malicious tags and attributes are now correctly escaped.

---
*PR created automatically by Jules for task [5947079844182291161](https://jules.google.com/task/5947079844182291161) started by @michaelkrisper*