### PR TITLE
🧹 [code health improvement] Fix empty if-block in data parser worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webgraphy",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webgraphy",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "clsx": "^2.1.1",
         "idb": "^8.0.3",

--- a/src/workers/data-parser.worker.ts
+++ b/src/workers/data-parser.worker.ts
@@ -129,6 +129,7 @@ function generateSynchronizedLOD(relativeData: { data: Float32Array, refPoint: n
     if (nextIndices.length >= currentIndices.length / 2 && nextIndices.length > 2000) {
       // If reduction is not significant, stop to prevent too many levels
       // (This can happen if there are many columns with different peaks)
+      break;
     }
   }
   


### PR DESCRIPTION
🎯 **What:**
Added a missing `break;` statement inside an empty `if` block in `src/workers/data-parser.worker.ts` around line 129.

💡 **Why:**
The previous code had an empty block which failed to stop the LOD processing loop, potentially creating too many levels unnecessarily. The comment clearly indicated that it should stop if reduction is not significant. Adding `break` fulfills this intent, improving logic correctness, resource efficiency, and codebase readability.

✅ **Verification:**
Ran `npm run build` and `npm run lint` and the application compiled correctly without introducing regressions. Checked the relevant data parser worker tests.

✨ **Result:**
The LOD generation algorithm now correctly halts if row reduction is minimal, saving computational time and preventing runaway processing loops.

---
*PR created automatically by Jules for task [5529330229325177249](https://jules.google.com/task/5529330229325177249) started by @michaelkrisper*