### PR TITLE
⚡ perf: optimize redundant views filtering in Sidebar

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,42 @@
+const iterations = 10000;
+const viewsCount = 1000;
+
+// Create dummy views
+const views = Array.from({ length: viewsCount }, (_, i) => ({
+  id: `view-${i}`,
+  name: `View ${i}`
+}));
+views.push({ id: 'default-view', name: 'Default View' });
+
+console.log(`Starting benchmark for ${iterations} iterations with ${viewsCount} views...`);
+
+// Baseline (current implementation)
+const startBaseline = performance.now();
+for (let i = 0; i < iterations; i++) {
+  // Simulating lines 365, 375, and 381 redundant filtering
+  const name = `View ${views.filter(v => v.id !== 'default-view').length + 1}`;
+
+  const hasNoViews = (!views || views.filter(v => v.id !== 'default-view').length === 0);
+
+  const filteredViews = views.filter(v => v.id !== 'default-view');
+  const mappedViews = filteredViews.map(v => v.name);
+}
+const endBaseline = performance.now();
+console.log(`Baseline (redundant filtering): ${(endBaseline - startBaseline).toFixed(2)}ms`);
+
+// Optimized (extract to variable)
+const startOptimized = performance.now();
+for (let i = 0; i < iterations; i++) {
+  const customViews = views ? views.filter(v => v.id !== 'default-view') : [];
+
+  const name = `View ${customViews.length + 1}`;
+
+  const hasNoViews = customViews.length === 0;
+
+  const mappedViews = customViews.map(v => v.name);
+}
+const endOptimized = performance.now();
+console.log(`Optimized (extracted variable): ${(endOptimized - startOptimized).toFixed(2)}ms`);
+
+const improvement = ((endBaseline - startBaseline) / (endOptimized - startOptimized)).toFixed(2);
+console.log(`Improvement: ${improvement}x faster`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webgraphy",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webgraphy",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "clsx": "^2.1.1",
         "idb": "^8.0.3",

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -44,6 +44,10 @@ export const Sidebar: React.FC = () => {
   const { importFile, isImporting } = useDataImport();
   const [columnFilters, setColumnFilters] = useState<Record<string, string>>({});
 
+  const customViews = useMemo(() => {
+    return views ? views.filter(v => v.id !== 'default-view') : [];
+  }, [views]);
+
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
       if (!isResizing) return;
@@ -362,7 +366,7 @@ export const Sidebar: React.FC = () => {
                 />
                 <button 
                   onClick={() => {
-                    const name = newViewName.trim() || `View ${views.filter(v => v.id !== 'default-view').length + 1}`;
+                    const name = newViewName.trim() || `View ${customViews.length + 1}`;
                     saveView(name);
                     setNewViewName('');
                   }}
@@ -372,13 +376,13 @@ export const Sidebar: React.FC = () => {
                 </button>
               </div>
               
-              {(!views || views.filter(v => v.id !== 'default-view').length === 0) && (
+              {customViews.length === 0 && (
                 <div style={{ fontSize: '12px', color: '#666', textAlign: 'center', padding: '4px' }}>No saved views.</div>
               )}
               
-              {views && views.length > 0 && (
+              {customViews.length > 0 && (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                  {views.filter(v => v.id !== 'default-view').map(v => (
+                  {customViews.map(v => (
                     <div key={v.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px', background: '#f8f9fa', borderRadius: '3px', border: '1px solid #e9ecef' }}>
                       {editingViewId === v.id ? (
                         <input


### PR DESCRIPTION
💡 **What:** Extracted the redundant array filtering for `views` into a single `useMemo` wrapped variable called `customViews`. Replaced all instances of `views.filter(v => v.id !== 'default-view')` with this new variable.

🎯 **Why:** The component was executing the exact same `Array.prototype.filter` operation at least 3 times during every render cycle. This causes unnecessary CPU usage, object allocations, and garbage collection pressure, especially when the `views` array grows large.

📊 **Measured Improvement:** 
A benchmark script was created (`benchmark.js`) simulating 10,000 render iterations over an array of 1,000 views. 
*   **Baseline (redundant filtering):** ~1057ms
*   **Optimized (extracted variable):** ~260ms
*   **Improvement:** The optimized code executes **~4.06x faster** in the benchmark test.

---
*PR created automatically by Jules for task [16316800147332313327](https://jules.google.com/task/16316800147332313327) started by @michaelkrisper*