### PR TITLE
X-Axis Renaming Restricted to Label Area

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -1006,7 +1006,7 @@ const ChartContainer: React.FC = () => {
       {editingXTitle ? (
         <input autoFocus name="x-axis-title" autoComplete="off" defaultValue={useGraphStore.getState().axisTitles.x} onBlur={(e) => { useGraphStore.getState().setAxisTitles(e.target.value, useGraphStore.getState().axisTitles.y); setEditingXTitle(false); }} onKeyDown={(e) => { if (e.key === 'Enter') { useGraphStore.getState().setAxisTitles(e.currentTarget.value, useGraphStore.getState().axisTitles.y); setEditingXTitle(false); } }} style={{ position: 'absolute', bottom: '5px', left: '50%', transform: 'translateX(-50%)', zIndex: 30, textAlign: 'center', fontWeight: 'bold' }} />
       ) : (
-        <div onClick={() => setEditingXTitle(true)} style={{ position: 'absolute', bottom: '5px', width: '100%', textAlign: 'center', pointerEvents: 'auto', cursor: 'text', fontWeight: 'bold', zIndex: 25 }}>{useGraphStore.getState().axisTitles.x}</div>
+        <div onClick={() => setEditingXTitle(true)} style={{ position: 'absolute', bottom: '5px', left: '50%', transform: 'translateX(-50%)', pointerEvents: 'auto', cursor: 'text', fontWeight: 'bold', zIndex: 25, whiteSpace: 'nowrap' }}>{useGraphStore.getState().axisTitles.x}</div>
       )}
     </main>
   );


### PR DESCRIPTION
The X-axis title was previously contained within a `div` that spanned the entire width of the plot area (`width: '100%'`), making it renamable by clicking anywhere on that bottom row. This change restricts the clickable area to only the label's actual text by using absolute positioning with `left: '50%'` and a centering transform. This improvement prevents unintentional renaming triggers while maintaining accessibility and ease of use when directly interacting with the label.

Fixes #6

---
*PR created automatically by Jules for task [17334386630558099060](https://jules.google.com/task/17334386630558099060) started by @michaelkrisper*