### PR TITLE
Restore last seen view on application reload

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -560,7 +560,16 @@ const ChartContainer: React.FC = () => {
   useEffect(() => {
     if (!isLoaded) return;
     const state = useGraphStore.getState();
-    if (state.series.length === 0 && state.datasets.length === 0) { wasEmptyRef.current = true; return; }
+    if (state.series.length === 0 && state.datasets.length === 0) {
+      wasEmptyRef.current = true;
+      return;
+    }
+
+    // Check if we should skip the initial auto-scale because we loaded state
+    const isDefaultViewport = state.viewportX.min === 0 && state.viewportX.max === 100;
+    if (wasEmptyRef.current && !isDefaultViewport) {
+       wasEmptyRef.current = false;
+    }
 
     // AGGRESSIVE AUTO-SCALE: If current viewport is way off data bounds, reset it.
     let shouldReset = wasEmptyRef.current;


### PR DESCRIPTION
Fixed the bug where the application would always auto-scale to the full dataset on reload. The application now correctly restores the last seen zoom levels and axis scales by detecting restored state and skipping the initial auto-scale trigger.

Fixes #2

---
*PR created automatically by Jules for task [10172816619632132936](https://jules.google.com/task/10172816619632132936) started by @michaelkrisper*