### PR TITLE
X-axis: Day / Week / Month precision with two-line labels

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -3,6 +3,7 @@ import { worldToScreen, screenToWorld } from '../../utils/coords';
 import { WebGLRenderer } from './WebGLRenderer';
 import { useGraphStore } from '../../store/useGraphStore';
 import { type Dataset } from '../../services/persistence';
+import { getTimeStep, generateTimeTicks, generateSecondaryLabels, formatFullDate } from '../../utils/time';
 
 const BASE_PADDING = { top: 20, right: 20, bottom: 50, left: 20 };
 
@@ -11,9 +12,10 @@ type PanTarget = 'all' | 'x' | { yAxisId: string };
 const GridLines = React.memo(({ xTicks, yAxes, viewportX, width, height, padding, viewportRef }: any) => {
   return (
     <svg width="100%" height="100%" style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 0 }}>
-      {xTicks.result.map((t: number) => {
-        const { x } = worldToScreen(t, 0, viewportRef);
-        return <line key={`gx-${t}`} x1={x} y1={padding.top} x2={x} y2={height - padding.bottom} stroke="#f0f0f0" strokeWidth="1" />;
+      {xTicks.result.map((t: any) => {
+        const timestamp = typeof t === 'number' ? t : t.timestamp;
+        const { x } = worldToScreen(timestamp, 0, viewportRef);
+        return <line key={`gx-${timestamp}`} x1={x} y1={padding.top} x2={x} y2={height - padding.bottom} stroke="#f0f0f0" strokeWidth="1" />;
       })}
       {yAxes.map((axis: any) => {
         if (!axis.showGrid || height <= padding.top + padding.bottom) return null;
@@ -40,7 +42,7 @@ const GridLines = React.memo(({ xTicks, yAxes, viewportX, width, height, padding
   );
 });
 
-const AxesLayer = React.memo(({ xTicks, yAxes, viewportX, width, height, padding, leftAxes, rightAxes, viewportRef, isXDate, formatDate, series, axisLayout }: any) => {
+const AxesLayer = React.memo(({ xTicks, yAxes, viewportX, width, height, padding, leftAxes, rightAxes, viewportRef, series, axisLayout }: any) => {
   return (
     <>
       <svg width="100%" height="100%" style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 6 }}>
@@ -102,10 +104,10 @@ const AxesLayer = React.memo(({ xTicks, yAxes, viewportX, width, height, padding
           return null;
         })()}
 
-        {xTicks.result.map((t: number) => {
-          const { x } = worldToScreen(t, 0, viewportRef);
+        {xTicks.result.map((t: any) => {
+          const { x } = worldToScreen(typeof t === 'number' ? t : t.timestamp, 0, viewportRef);
           if (x < padding.left || x > width - padding.right) return null;
-          return <line key={`xt-${t}`} x1={x} y1={height - padding.bottom} x2={x} y2={height - padding.bottom + 6} stroke="#333" strokeWidth="1" />;
+          return <line key={`xt-${typeof t === 'number' ? t : t.timestamp}`} x1={x} y1={height - padding.bottom} x2={x} y2={height - padding.bottom + 6} stroke="#333" strokeWidth="1" />;
         })}
         {yAxes.map((axis: any) => {
           const isLeft = axis.position === 'left', sideIdx = isLeft ? leftAxes.indexOf(axis) : rightAxes.indexOf(axis);
@@ -156,67 +158,47 @@ const AxesLayer = React.memo(({ xTicks, yAxes, viewportX, width, height, padding
         })}
       </svg>
       <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 7 }}>
-        {isXDate && xTicks.step < 86400 && (() => {
-          const dayLabels = [];
-          const startTimestamp = viewportX.min;
-          const endTimestamp = viewportX.max;
+        {xTicks.secondaryLabels && xTicks.secondaryLabels.map((sl: any, idx: number) => {
+          const nextSl = xTicks.secondaryLabels[idx + 1];
+          const { x: currentX } = worldToScreen(sl.timestamp, 0, viewportRef);
+          const { x: nextX } = nextSl ? worldToScreen(nextSl.timestamp, 0, viewportRef) : { x: width - padding.right + 200 };
           
-          // Find all day transitions relevant to the current view
-          // Start with the day containing the left edge
-          const firstDate = new Date(startTimestamp * 1000);
-          firstDate.setHours(0, 0, 0, 0);
-          let currentMidnight = firstDate.getTime() / 1000;
+          const labelWidth = sl.label.length * 7;
+          const paddingLeft = padding.left + 5;
           
-          // We look at transitions from currentMidnight until we pass endTimestamp
-          // Plus one extra to "push" the last visible one if needed
-          while (currentMidnight <= endTimestamp) {
-            const nextMidnight = currentMidnight + 86400;
-            const { x: currentX } = worldToScreen(currentMidnight, 0, viewportRef);
-            const { x: nextX } = worldToScreen(nextMidnight, 0, viewportRef);
-            
-            const labelWidth = 70; // Approximate width of "DD.MM.YYYY" label
-            const paddingLeft = padding.left + 5;
-            
-            // This day's label should be at paddingLeft, UNLESS its midnight transition 
-            // is already to the right of paddingLeft.
-            // AND it should be pushed left by the next day's transition.
-            let x = Math.max(currentX + 5, paddingLeft);
-            
-            // If the next midnight is coming, push this label out
-            if (nextX < x + labelWidth) {
-              x = nextX - labelWidth;
-            }
-
-            // Only render if some part of the label area is visible
-            if (x + labelWidth > padding.left && x < width - padding.right) {
-              dayLabels.push(
-                <div key={`day-${currentMidnight}`} style={{ 
-                  position: 'absolute', 
-                  left: x, 
-                  bottom: padding.bottom - 35, 
-                  fontSize: '10px', 
-                  fontWeight: 'bold', 
-                  color: '#333',
-                  backgroundColor: 'rgba(255,255,255,0.8)',
-                  padding: '1px 4px',
-                  borderRadius: '2px',
-                  whiteSpace: 'nowrap',
-                  borderLeft: currentX > padding.left ? '2px solid #333' : 'none',
-                  zIndex: 10
-                }}>
-                  {new Date(currentMidnight * 1000).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })}
-                </div>
-              );
-            }
-            currentMidnight = nextMidnight;
+          let x = Math.max(currentX + 5, paddingLeft);
+          if (nextX < x + labelWidth + 10) {
+            x = nextX - labelWidth - 10;
           }
-          return dayLabels;
-        })()}
-        {xTicks.result.map((t: number) => {
-          const { x } = worldToScreen(t, 0, viewportRef);
+
+          if (x + labelWidth > padding.left && x < width - padding.right) {
+            return (
+              <div key={`sl-${sl.timestamp}`} style={{
+                position: 'absolute',
+                left: x,
+                bottom: padding.bottom - 35,
+                fontSize: '10px',
+                fontWeight: 'bold',
+                color: '#333',
+                backgroundColor: 'rgba(255,255,255,0.8)',
+                padding: '1px 4px',
+                borderRadius: '2px',
+                whiteSpace: 'nowrap',
+                borderLeft: currentX > padding.left ? '2px solid #333' : 'none',
+                zIndex: 10
+              }}>
+                {sl.label}
+              </div>
+            );
+          }
+          return null;
+        })}
+        {xTicks.result.map((t: any) => {
+          const timestamp = typeof t === 'number' ? t : t.timestamp;
+          const { x } = worldToScreen(timestamp, 0, viewportRef);
           if (x < padding.left || x > width - padding.right) return null;
-          const label = isXDate ? formatDate(t, xTicks.step) : (Math.abs(t) < 1e-12 ? '0' : t.toFixed(xTicks.precision));
-          return <div key={`xl-${t}`} style={{ position: 'absolute', left: x, bottom: padding.bottom - 20, transform: 'translateX(-50%)', fontSize: '9px', color: '#666' }}>{label}</div>;
+          const label = typeof t === 'number' ? (Math.abs(t) < 1e-12 ? '0' : t.toFixed(xTicks.precision)) : t.label;
+          return <div key={`xl-${timestamp}`} style={{ position: 'absolute', left: x, bottom: padding.bottom - 20, transform: 'translateX(-50%)', fontSize: '9px', color: '#666' }}>{label}</div>;
         })}
         {yAxes.map((axis: any) => {
           const isLeft = axis.position === 'left', sideIdx = isLeft ? leftAxes.indexOf(axis) : rightAxes.indexOf(axis);
@@ -382,7 +364,7 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
   const isTooltipBelow = pos.y + maxExpectedHeight + 20 < height;
 
   const xLabel = xMode === 'date'
-    ? new Date(xWorld * 1000).toLocaleString('de-DE', { hour: '2-digit', minute: '2-digit', second: '2-digit', fractionalSecondDigits: 3 })
+    ? formatFullDate(xWorld)
     : parseFloat(xWorld.toPrecision(7)).toString();
 
   return (
@@ -952,32 +934,28 @@ const ChartContainer: React.FC = () => {
   const xTicks = useMemo(() => {
     const isXDate = useGraphStore.getState().xMode === 'date', range = viewportX.max - viewportX.min;
     if (range <= 0 || chartWidth <= 0) return { result: [], step: 1, precision: 0, isXDate };
-    const maxTicks = Math.max(2, Math.floor(chartWidth / 60));
-    let step = range / maxTicks;
-    let precision = 0;
+
     if (!isXDate) {
+      const maxTicks = Math.max(2, Math.floor(chartWidth / 60));
+      let step = range / maxTicks;
       const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(step) || 1)));
       const normalizedStep = step / magnitude;
       const finalStep = normalizedStep < 1.5 ? 1 : normalizedStep < 3 ? 2 : normalizedStep < 7 ? 5 : 10;
       step = finalStep * magnitude;
       if (step <= 0) return { result: [], step: 1, precision: 0, isXDate };
-      precision = Math.max(0, -Math.floor(Math.log10(step)));
+      const precision = Math.max(0, -Math.floor(Math.log10(step)));
+      const firstTick = Math.ceil(viewportX.min / step) * step, result = [];
+      for (let t = firstTick; t <= viewportX.max; t += step) { if (result.length > 100) break; result.push(t); }
+      return { result, step, precision, isXDate };
     } else {
-      const intervals = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 21600, 43200, 86400, 172800, 259200, 432000, 604800, 1209600, 2592000];
-      step = intervals.find(i => i > step) || intervals[intervals.length - 1];
+      const timeStep = getTimeStep(range, Math.max(2, Math.floor(chartWidth / 80)));
+      const ticks = generateTimeTicks(viewportX.min, viewportX.max, timeStep);
+      const secondaryLabels = generateSecondaryLabels(viewportX.min, viewportX.max, timeStep);
+      return { result: ticks, isXDate, secondaryLabels };
     }
-    const firstTick = Math.ceil(viewportX.min / step) * step, result = [];
-    for (let t = firstTick; t <= viewportX.max; t += step) { if (result.length > 100) break; result.push(t); }
-    return { result, step, precision, isXDate };
   }, [viewportX.min, viewportX.max, chartWidth]);
 
   const viewportRef = useMemo(() => ({ xMin: viewportX.min, xMax: viewportX.max, yMin: 0, yMax: 100, width, height, padding }), [viewportX, width, height, padding]);
-  const formatDate = useCallback((val: number, step: number) => {
-    const d = new Date(val * 1000);
-    if (step >= 86400) return d.getDate() + '.' + (d.getMonth()+1) + '.';
-    if (step >= 3600) return d.getHours() + ':00';
-    return String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
-  }, []);
 
   return (
     <main className="plot-area" ref={containerRef} onMouseDown={(e) => handleMouseDown(e, 'all')} onWheel={(e) => handleWheel(e, 'all')} style={{ position: 'relative', cursor: panTarget ? 'grabbing' : (zoomBoxState || isCtrlPressed ? 'zoom-in' : 'crosshair'), backgroundColor: '#fff', overflow: 'hidden' }}>
@@ -986,7 +964,7 @@ const ChartContainer: React.FC = () => {
       <div style={{ position: 'absolute', inset: 0, zIndex: 1 }}>
         <WebGLRenderer datasets={useGraphStore.getState().datasets} series={series} yAxes={yAxes} viewportX={viewportX} width={width} height={height} padding={padding} />
       </div>
-      <AxesLayer xTicks={xTicks} yAxes={activeYAxes} viewportX={viewportX} width={width} height={height} padding={padding} leftAxes={leftAxes} rightAxes={rightAxes} viewportRef={viewportRef} isXDate={xTicks.isXDate} formatDate={formatDate} series={series} axisLayout={axisLayout} />
+      <AxesLayer xTicks={xTicks} yAxes={activeYAxes} viewportX={viewportX} width={width} height={height} padding={padding} leftAxes={leftAxes} rightAxes={rightAxes} viewportRef={viewportRef} series={series} axisLayout={axisLayout} />
       <div onWheel={(e) => { e.stopPropagation(); handleWheel(e, 'x'); }} onMouseDown={(e) => { e.stopPropagation(); handleMouseDown(e, 'x'); }} onDoubleClick={(e) => { e.stopPropagation(); handleAutoScaleX(); }} style={{ position: 'absolute', bottom: 0, left: padding.left, right: padding.right, height: padding.bottom, cursor: 'ew-resize', zIndex: 20 }} />
       {activeYAxes.map((axis) => {
         const isLeft = axis.position === 'left', sideIdx = isLeft ? leftAxes.indexOf(axis) : rightAxes.indexOf(axis);
@@ -1001,7 +979,7 @@ const ChartContainer: React.FC = () => {
         }
         return <div key={`wheel-${axis.id}`} onWheel={(e) => { e.stopPropagation(); handleWheel(e, { yAxisId: axis.id }); }} onMouseDown={(e) => { e.stopPropagation(); handleMouseDown(e, { yAxisId: axis.id }); }} onDoubleClick={(e) => { e.stopPropagation(); const rect = containerRef.current?.getBoundingClientRect(); const mouseY = rect ? e.clientY - rect.top : undefined; handleAutoScaleY(axis.id, mouseY, e.ctrlKey); }} style={{ position: 'absolute', left: xPos, top: padding.top, width: axisMetrics.total, bottom: padding.bottom, cursor: 'ns-resize', zIndex: 20 }} />;
       })}
-      <Crosshair containerRef={containerRef} padding={padding} width={width} height={height} isPanning={!!panTarget || !!zoomBoxState} yAxes={activeYAxes} viewportX={viewportX} xMode={useGraphStore.getState().xMode} formatDate={formatDate} datasets={useGraphStore.getState().datasets} series={series} />
+      <Crosshair containerRef={containerRef} padding={padding} width={width} height={height} isPanning={!!panTarget || !!zoomBoxState} yAxes={activeYAxes} viewportX={viewportX} xMode={useGraphStore.getState().xMode} datasets={useGraphStore.getState().datasets} series={series} />
       {zoomBoxState && <svg width="100%" height="100%" style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 30 }}><rect x={Math.min(zoomBoxState.startX, zoomBoxState.endX)} y={Math.min(zoomBoxState.startY, zoomBoxState.endY)} width={Math.abs(zoomBoxState.endX - zoomBoxState.startX)} height={Math.abs(zoomBoxState.endY - zoomBoxState.startY)} fill="rgba(0, 123, 255, 0.2)" stroke="#007bff" strokeWidth="1" /></svg>}
       {editingXTitle ? (
         <input autoFocus name="x-axis-title" autoComplete="off" defaultValue={useGraphStore.getState().axisTitles.x} onBlur={(e) => { useGraphStore.getState().setAxisTitles(e.target.value, useGraphStore.getState().axisTitles.y); setEditingXTitle(false); }} onKeyDown={(e) => { if (e.key === 'Enter') { useGraphStore.getState().setAxisTitles(e.currentTarget.value, useGraphStore.getState().axisTitles.y); setEditingXTitle(false); } }} style={{ position: 'absolute', bottom: '5px', left: '50%', transform: 'translateX(-50%)', zIndex: 30, textAlign: 'center', fontWeight: 'bold' }} />

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,259 @@
+export type TimeUnit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+
+export interface TimeStep {
+  unit: TimeUnit;
+  value: number;
+}
+
+export interface TimeTick {
+  timestamp: number;
+  label: string;
+}
+
+const UNIT_SECONDS = {
+  second: 1,
+  minute: 60,
+  hour: 3600,
+  day: 86400,
+  week: 604800,
+  month: 2592000, // Approximate
+  year: 31536000, // Approximate
+};
+
+const TIME_STEPS: TimeStep[] = [
+  { unit: 'second', value: 1 },
+  { unit: 'second', value: 2 },
+  { unit: 'second', value: 5 },
+  { unit: 'second', value: 10 },
+  { unit: 'second', value: 15 },
+  { unit: 'second', value: 30 },
+  { unit: 'minute', value: 1 },
+  { unit: 'minute', value: 2 },
+  { unit: 'minute', value: 5 },
+  { unit: 'minute', value: 10 },
+  { unit: 'minute', value: 15 },
+  { unit: 'minute', value: 30 },
+  { unit: 'hour', value: 1 },
+  { unit: 'hour', value: 2 },
+  { unit: 'hour', value: 3 },
+  { unit: 'hour', value: 4 },
+  { unit: 'hour', value: 6 },
+  { unit: 'hour', value: 12 },
+  { unit: 'day', value: 1 },
+  { unit: 'day', value: 2 },
+  { unit: 'day', value: 3 },
+  { unit: 'day', value: 5 },
+  { unit: 'week', value: 1 },
+  { unit: 'month', value: 1 },
+  { unit: 'month', value: 2 },
+  { unit: 'month', value: 3 },
+  { unit: 'month', value: 4 },
+  { unit: 'month', value: 6 },
+  { unit: 'year', value: 1 },
+  { unit: 'year', value: 2 },
+  { unit: 'year', value: 5 },
+  { unit: 'year', value: 10 },
+  { unit: 'year', value: 20 },
+  { unit: 'year', value: 50 },
+  { unit: 'year', value: 100 },
+];
+
+export function getTimeStep(rangeSeconds: number, maxTicks: number): TimeStep {
+  const idealStep = rangeSeconds / maxTicks;
+  for (const step of TIME_STEPS) {
+    const stepSeconds = step.unit === 'month' ? 2592000 * step.value :
+                        step.unit === 'year' ? 31536000 * step.value :
+                        UNIT_SECONDS[step.unit] * step.value;
+    if (stepSeconds >= idealStep) return step;
+  }
+  return TIME_STEPS[TIME_STEPS.length - 1];
+}
+
+export function generateTimeTicks(min: number, max: number, step: TimeStep): TimeTick[] {
+  const ticks: TimeTick[] = [];
+  const { unit, value } = step;
+
+  if (unit === 'second' || unit === 'minute' || unit === 'hour' || unit === 'day') {
+    // For these units, we can start with a Date at 'min' and align it
+    const d = new Date(min * 1000);
+    if (unit === 'minute') d.setSeconds(0, 0);
+    else if (unit === 'hour') d.setMinutes(0, 0, 0);
+    else if (unit === 'day') d.setHours(0, 0, 0, 0);
+    else d.setMilliseconds(0);
+
+    let current = d.getTime() / 1000;
+    if (current < min) {
+        // Step forward until we hit or pass min
+        if (unit === 'second') current += value;
+        else if (unit === 'minute') current += 60 * value;
+        else if (unit === 'hour') current += 3600 * value;
+        else if (unit === 'day') {
+            d.setDate(d.getDate() + value);
+            current = d.getTime() / 1000;
+        }
+    }
+
+    while (current <= max) {
+      ticks.push({
+        timestamp: current,
+        label: formatPrimaryLabel(current, unit),
+      });
+
+      if (unit === 'day') {
+        d.setDate(d.getDate() + value);
+        current = d.getTime() / 1000;
+      } else {
+        current += UNIT_SECONDS[unit] * value;
+      }
+      if (ticks.length > 200) break;
+    }
+  } else if (unit === 'week') {
+    const d = new Date(min * 1000);
+    d.setHours(0, 0, 0, 0);
+    const day = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+    const diff = (day === 0 ? -6 : 1 - day); // Move to previous Monday
+    d.setDate(d.getDate() + diff);
+
+    let current = d.getTime() / 1000;
+    while (current <= max) {
+      if (current >= min) {
+        ticks.push({
+          timestamp: current,
+          label: formatPrimaryLabel(current, unit),
+        });
+      }
+      d.setDate(d.getDate() + 7 * value);
+      current = d.getTime() / 1000;
+      if (ticks.length > 200) break;
+    }
+  } else if (unit === 'month') {
+    const d = new Date(min * 1000);
+    d.setHours(0, 0, 0, 0);
+    d.setUTCDate(1); // UTC to avoid DST issues when setting to 1st of month
+    d.setHours(0, 0, 0, 0); // Back to local midnight
+    d.setDate(1);
+
+    let current = d.getTime() / 1000;
+    while (current <= max) {
+      if (current >= min) {
+        ticks.push({
+          timestamp: current,
+          label: formatPrimaryLabel(current, unit),
+        });
+      }
+      d.setMonth(d.getMonth() + value);
+      current = d.getTime() / 1000;
+      if (ticks.length > 200) break;
+    }
+  } else if (unit === 'year') {
+    const d = new Date(min * 1000);
+    d.setHours(0, 0, 0, 0);
+    d.setMonth(0, 1);
+
+    let current = d.getTime() / 1000;
+    while (current <= max) {
+      if (current >= min) {
+        ticks.push({
+          timestamp: current,
+          label: formatPrimaryLabel(current, unit),
+        });
+      }
+      d.setFullYear(d.getFullYear() + value);
+      current = d.getTime() / 1000;
+      if (ticks.length > 200) break;
+    }
+  }
+
+  return ticks;
+}
+
+function formatPrimaryLabel(ts: number, unit: TimeUnit): string {
+  const d = new Date(ts * 1000);
+  const pad = (n: number) => String(n).padStart(2, '0');
+
+  switch (unit) {
+    case 'second':
+      return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+    case 'minute':
+      return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    case 'hour':
+      return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    case 'day':
+      return `${d.getDate()}.`;
+    case 'week':
+      return `${d.getDate()}.${d.getMonth() + 1}.`;
+    case 'month':
+      return d.toLocaleDateString('de-DE', { month: 'short' });
+    case 'year':
+      return String(d.getFullYear());
+    default:
+      return '';
+  }
+}
+
+export interface SecondaryLabel {
+  timestamp: number;
+  label: string;
+}
+
+export function generateSecondaryLabels(min: number, max: number, step: TimeStep): SecondaryLabel[] {
+  const labels: SecondaryLabel[] = [];
+  const { unit } = step;
+
+  if (unit === 'second' || unit === 'minute' || unit === 'hour') {
+    const d = new Date(min * 1000);
+    d.setHours(0, 0, 0, 0);
+    let current = d.getTime() / 1000;
+    while (current <= max) {
+      labels.push({
+        timestamp: current,
+        label: new Date(current * 1000).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' }),
+      });
+      d.setDate(d.getDate() + 1);
+      current = d.getTime() / 1000;
+      if (labels.length > 100) break;
+    }
+  } else if (unit === 'day' || unit === 'week') {
+    const d = new Date(min * 1000);
+    d.setHours(0, 0, 0, 0);
+    d.setDate(1);
+    let current = d.getTime() / 1000;
+    while (current <= max) {
+      labels.push({
+        timestamp: current,
+        label: new Date(current * 1000).toLocaleDateString('de-DE', { month: 'long', year: 'numeric' }),
+      });
+      d.setMonth(d.getMonth() + 1);
+      current = d.getTime() / 1000;
+      if (labels.length > 100) break;
+    }
+  } else if (unit === 'month') {
+    const d = new Date(min * 1000);
+    d.setHours(0, 0, 0, 0);
+    d.setMonth(0, 1);
+    let current = d.getTime() / 1000;
+    while (current <= max) {
+      labels.push({
+        timestamp: current,
+        label: String(new Date(current * 1000).getFullYear()),
+      });
+      d.setFullYear(d.getFullYear() + 1);
+      current = d.getTime() / 1000;
+      if (labels.length > 100) break;
+    }
+  }
+
+  return labels;
+}
+
+export function formatFullDate(ts: number): string {
+    return new Date(ts * 1000).toLocaleString('de-DE', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        fractionalSecondDigits: 3
+    });
+}


### PR DESCRIPTION
This change enhances the X-axis for date-based data. It introduces a multi-level tick generation strategy that chooses appropriate units based on zoom level. Ticks are now aligned with local calendar boundaries (e.g., midnight, first of the month, and Mondays for weeks). A new secondary label line provides the broader time context (e.g., showing the date when viewing hours, or the month when viewing days), and these labels use a sticky positioning logic to remain visible at the edge of the viewport during panning. The implementation uses local time to ensure consistency with the user's environment.

Fixes #12

---
*PR created automatically by Jules for task [14628867125817710969](https://jules.google.com/task/14628867125817710969) started by @michaelkrisper*