### PR TITLE
Fix Zoom-Selection not working in ChartContainer

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -834,8 +834,9 @@ const ChartContainer: React.FC = () => {
     if (zoomBoxStartRef.current && containerRef.current) {
       const mx = Math.max(padding.left, Math.min(width - padding.right, mouseX));
       const my = Math.max(padding.top, Math.min(height - padding.bottom, mouseY));
-      const newBox = { ...zoomBoxStartRef.current, endX: mx, endY: my };
-      setZoomBoxState(newBox);
+      zoomBoxStartRef.current.endX = mx;
+      zoomBoxStartRef.current.endY = my;
+      setZoomBoxState({ ...zoomBoxStartRef.current });
       return;
     }
     if (!panTarget || !lastMousePos.current) return;


### PR DESCRIPTION
Fixed a bug where the zoom-selection box (drawn with CTRL + drag) did not result in a zoomed view. The issue was caused by stale coordinates in `zoomBoxStartRef.current` during the `handleMouseMoveRaw` event. I updated the code to persist the current mouse position in the ref so that the `handleMouseUp` function can correctly calculate and apply the new viewport. Verified with Playwright screenshots and existing tests.

Fixes #1

---
*PR created automatically by Jules for task [3070319037439079805](https://jules.google.com/task/3070319037439079805) started by @michaelkrisper*