### PR TITLE
🧪 test: improve error handling test coverage for IndexedDB in persistence.ts

### DIFF
--- a/src/services/__tests__/persistence.test.ts
+++ b/src/services/__tests__/persistence.test.ts
@@ -39,4 +39,31 @@ describe('persistence error handling', () => {
 
     await expect(persistence.saveDataset(dataset)).rejects.toThrow('QuotaExceededError');
   });
+
+  it('should propagate errors if db.get fails', async () => {
+    const mockDb = {
+      get: vi.fn().mockRejectedValueOnce(new Error('Read failed')),
+    };
+    openDBMock.mockResolvedValueOnce(mockDb);
+
+    await expect(persistence.loadDataset('1')).rejects.toThrow('Read failed');
+  });
+
+  it('should propagate errors if db.getAll fails', async () => {
+    const mockDb = {
+      getAll: vi.fn().mockRejectedValueOnce(new Error('Read all failed')),
+    };
+    openDBMock.mockResolvedValueOnce(mockDb);
+
+    await expect(persistence.getAllDatasets()).rejects.toThrow('Read all failed');
+  });
+
+  it('should propagate errors if db.delete fails', async () => {
+    const mockDb = {
+      delete: vi.fn().mockRejectedValueOnce(new Error('Delete failed')),
+    };
+    openDBMock.mockResolvedValueOnce(mockDb);
+
+    await expect(persistence.deleteDataset('1')).rejects.toThrow('Delete failed');
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added tests for the missing error handling scenarios in `src/services/persistence.ts` specifically when interacting with IndexedDB.
📊 **Coverage:** Covered scenarios where `openDB` fails to initialize, and where specific methods like `db.put` (e.g. QuotaExceededError), `db.get`, `db.getAll`, and `db.delete` fail and propagate errors up to the caller.
✨ **Result:** Improved test coverage for database interactions and ensures that errors are properly propagated from the storage layer.

---
*PR created automatically by Jules for task [15048329400368034524](https://jules.google.com/task/15048329400368034524) started by @michaelkrisper*