### PR TITLE
🧪 [testing improvement] Add IndexedDB error handling tests

### DIFF
--- a/src/services/__tests__/persistence.test.ts
+++ b/src/services/__tests__/persistence.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Dataset } from '../persistence';
+
+vi.mock('idb', () => ({
+  openDB: vi.fn(),
+}));
+
+describe('persistence error handling', () => {
+  let persistence: typeof import('../persistence').persistence;
+  let openDBMock: any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    // Dynamically import idb mock and persistence module
+    const idbMock = await import('idb');
+    openDBMock = vi.mocked(idbMock.openDB);
+
+    const persistenceModule = await import('../persistence');
+    persistence = persistenceModule.persistence;
+  });
+
+  it('should propagate error when openDB fails', async () => {
+    openDBMock.mockRejectedValueOnce(new Error('Failed to open IndexedDB'));
+
+    const dataset: Dataset = { id: '1', name: 'test', columns: [], data: [], rowCount: 0 };
+
+    await expect(persistence.saveDataset(dataset)).rejects.toThrow('Failed to open IndexedDB');
+  });
+
+  it('should propagate error when quota exceeded', async () => {
+    const mockDb = {
+      put: vi.fn().mockRejectedValueOnce(new DOMException('QuotaExceededError')),
+    };
+    openDBMock.mockResolvedValueOnce(mockDb);
+
+    const dataset: Dataset = { id: '1', name: 'test', columns: [], data: [], rowCount: 0 };
+
+    await expect(persistence.saveDataset(dataset)).rejects.toThrow('QuotaExceededError');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The application lacked explicit tests for verifying how `src/services/persistence.ts` handles IndexedDB failures, such as connection rejections or quota exceeded errors, which are critical for robust offline-capable operations.

📊 **Coverage:** What scenarios are now tested
- Added test to verify `saveDataset` correctly propagates an error when the internal `openDB` initialization fails.
- Added test to ensure `saveDataset` properly surfaces `DOMException` 'QuotaExceededError' errors when the IndexedDB quota is reached during a `put` operation.
- Both tests employ `vi.resetModules()` to prevent state leakage, ensuring module-level db connections reset between tests.

✨ **Result:** The improvement in test coverage
The persistence layer is now hardened and correctly verifies behavior when `idb` interacts with underlying storage boundaries, improving predictability and reducing bug surface area for edge cases.

---
*PR created automatically by Jules for task [3240360995057381632](https://jules.google.com/task/3240360995057381632) started by @michaelkrisper*