### PR TITLE
🧪 test: add unit tests for LTTB area maximization logic

### DIFF
--- a/src/utils/lttb.test.ts
+++ b/src/utils/lttb.test.ts
@@ -64,5 +64,50 @@ describe('LTTB (Largest-Triangle-Three-Buckets)', () => {
       expect(result[0]).toEqual(sampleData[0]);
       expect(result[result.length - 1]).toEqual(sampleData[sampleData.length - 1]);
     });
+
+    it('selects data points that maximize the effective area (preserves peaks)', () => {
+      // Data with a sharp peak in the first bucket
+      const peakData = [
+        { x: 0, y: 0 },
+        { x: 1, y: 1 },
+        { x: 2, y: 10 }, // Sharp peak
+        { x: 3, y: 0 },
+        { x: 4, y: 0 },
+        { x: 5, y: 0 },
+      ];
+
+      // Threshold 4 means 2 middle buckets of size 2.
+      // Bucket 1: indices 1, 2
+      // Bucket 2: indices 3, 4
+      const result = lttb(peakData, 4);
+
+      expect(result).toEqual([
+        { x: 0, y: 0 },   // First point
+        { x: 2, y: 10 },  // Peak from Bucket 1
+        { x: 3, y: 0 },   // Selected from Bucket 2
+        { x: 5, y: 0 },   // Last point
+      ]);
+    });
+
+    it('selects data points that maximize the effective area (preserves valleys)', () => {
+      // Data with a sharp valley in the first bucket
+      const valleyData = [
+        { x: 0, y: 10 },
+        { x: 1, y: 9 },
+        { x: 2, y: 0 },  // Sharp valley
+        { x: 3, y: 10 },
+        { x: 4, y: 10 },
+        { x: 5, y: 10 },
+      ];
+
+      const result = lttb(valleyData, 4);
+
+      expect(result).toEqual([
+        { x: 0, y: 10 },  // First point
+        { x: 2, y: 0 },   // Valley from Bucket 1
+        { x: 3, y: 10 },  // Selected from Bucket 2
+        { x: 5, y: 10 },  // Last point
+      ]);
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** The unit tests for the LTTB algorithm previously only tested edge conditions (array length matching threshold, empty data, etc). This adds tests to verify the core functionality of the LTTB algorithm.
📊 **Coverage:** Added test cases with specific small datasets known to contain sharp peaks and valleys. Asserts that LTTB specifically picks the expected points instead of taking simple averages or arbitrary samples. Added `@vitest/coverage-v8` dev dependency to allow checking test coverage in CI.
✨ **Result:** Improved confidence in the LTTB downsampling utility, ensuring the area-maximizing mathematical core of the algorithm behaves correctly. Coverage reports can now be generated reliably.

---
*PR created automatically by Jules for task [276875422009919](https://jules.google.com/task/276875422009919) started by @michaelkrisper*