### PR TITLE
🧪 Add unit tests for formatDate helper

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -1,28 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { downloadFile } from '../export';
+import { downloadFile, formatDate } from '../export';
 
 describe('downloadFile', () => {
   const mockClick = vi.fn();
-  let originalCreateElement: typeof document.createElement;
-  let originalCreateObjectURL: typeof URL.createObjectURL;
 
   beforeEach(() => {
-    // Save originals
-    if (typeof document !== 'undefined') {
-      originalCreateElement = document.createElement;
-    }
-    if (typeof URL !== 'undefined') {
-      originalCreateObjectURL = URL.createObjectURL;
-    }
-
-    // Mock anchor element
-    const mockAnchor = {
-      href: '',
-      download: '',
-      click: mockClick,
-    };
-
-    // Mock document
+    const mockAnchor = { href: '', download: '', click: mockClick };
     const documentMock = {
       createElement: vi.fn((tag: string) => {
         if (tag === 'a') return mockAnchor;
@@ -30,17 +13,8 @@ describe('downloadFile', () => {
       }),
     };
     vi.stubGlobal('document', documentMock);
-
-    // Mock URL
-    const urlMock = {
-      createObjectURL: vi.fn(() => 'blob:mock-url'),
-    };
-    vi.stubGlobal('URL', urlMock);
-
-    // Mock Blob
-    class MockBlob {
-      constructor(public content: any[], public options: any) {}
-    }
+    vi.stubGlobal('URL', { createObjectURL: vi.fn(() => 'blob:mock-url') });
+    class MockBlob { constructor(public content: any[], public options: any) {} }
     vi.stubGlobal('Blob', MockBlob);
   });
 
@@ -51,37 +25,52 @@ describe('downloadFile', () => {
 
   it('should handle data URLs correctly', () => {
     const content = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
-    const fileName = 'test.png';
-    const contentType = 'image/png';
-
-    downloadFile(content, fileName, contentType);
+    downloadFile(content, 'test.png', 'image/png');
 
     const doc = document as any;
     expect(doc.createElement).toHaveBeenCalledWith('a');
-
-    // Check if properties on the mock element are set correctly
     const a = doc.createElement('a');
     expect(a.href).toBe(content);
-    expect(a.download).toBe(fileName);
+    expect(a.download).toBe('test.png');
     expect(mockClick).toHaveBeenCalled();
     expect(URL.createObjectURL).not.toHaveBeenCalled();
   });
 
   it('should handle normal strings using Blob correctly', () => {
-    const content = 'Hello, world!';
-    const fileName = 'test.txt';
-    const contentType = 'text/plain';
-
-    downloadFile(content, fileName, contentType);
+    downloadFile('Hello, world!', 'test.txt', 'text/plain');
 
     const doc = document as any;
     expect(doc.createElement).toHaveBeenCalledWith('a');
-
     expect(URL.createObjectURL).toHaveBeenCalled();
-
     const a = doc.createElement('a');
     expect(a.href).toBe('blob:mock-url');
-    expect(a.download).toBe(fileName);
+    expect(a.download).toBe('test.txt');
     expect(mockClick).toHaveBeenCalled();
+  });
+});
+
+describe('formatDate', () => {
+  it('formats correctly for daily steps (>= 86400)', () => {
+    const date = new Date(2023, 0, 15, 12, 0, 0);
+    const val = Math.floor(date.getTime() / 1000);
+    expect(formatDate(val, 86400)).toBe('15.1.');
+    expect(formatDate(val, 90000)).toBe('15.1.');
+  });
+
+  it('formats correctly for hourly steps (>= 3600 but < 86400)', () => {
+    const date = new Date(2023, 0, 15, 9, 30, 0);
+    const val = Math.floor(date.getTime() / 1000);
+    expect(formatDate(val, 3600)).toBe('9:00');
+    expect(formatDate(val, 7200)).toBe('9:00');
+  });
+
+  it('formats correctly for minute steps (< 3600)', () => {
+    const date1 = new Date(2023, 0, 15, 9, 5, 0);
+    const val1 = Math.floor(date1.getTime() / 1000);
+    expect(formatDate(val1, 60)).toBe('09:05');
+
+    const date2 = new Date(2023, 0, 15, 14, 30, 0);
+    const val2 = Math.floor(date2.getTime() / 1000);
+    expect(formatDate(val2, 1)).toBe('14:30');
   });
 });

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -188,7 +188,7 @@ export const exportToSVG = (
   svg += `</svg>`; return svg;
 };
 
-const formatDate = (val: number, step: number) => {
+export const formatDate = (val: number, step: number) => {
   const d = new Date(val * 1000);
   if (step >= 86400) return d.getDate() + '.' + (d.getMonth() + 1) + '.';
   if (step >= 3600) return d.getHours() + ':00';


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `formatDate` helper in `src/services/export.ts` which lacked test coverage, by exporting it and writing timezone-independent tests.
📊 **Coverage:** Covered daily (`>= 86400`), hourly (`>= 3600`) and sub-hourly (`< 3600`) scenarios, resolving the testing gap.
✨ **Result:** Improved test coverage and maintainability.

---
*PR created automatically by Jules for task [11310652420435412139](https://jules.google.com/task/11310652420435412139) started by @michaelkrisper*