### PR TITLE
🧪 Add integration tests for data parsing worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDataImport } from '../useDataImport';
+import { useGraphStore } from '../../store/useGraphStore';
+import { persistence } from '../../services/persistence';
+
+// Mock the graph store
+vi.mock('../../store/useGraphStore', () => ({
+  useGraphStore: Object.assign(
+    vi.fn(() => ({
+      addDataset: vi.fn(),
+    })),
+    {
+      getState: vi.fn(() => ({
+        datasets: [],
+      })),
+    }
+  ),
+}));
+
+// Mock persistence
+vi.mock('../../services/persistence', () => ({
+  persistence: {
+    saveDataset: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock URL.createObjectURL since JSDOM might not have it
+if (typeof URL.createObjectURL === 'undefined') {
+  URL.createObjectURL = vi.fn(() => 'blob:test-url');
+}
+
+// Global variable to keep track of the mock worker instance
+let mockWorkerInstance: any = null;
+
+describe('useDataImport hook', () => {
+  let originalWorker: typeof Worker;
+  const mockAddDataset = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup store mock
+    (useGraphStore as any).mockImplementation(() => ({
+      addDataset: mockAddDataset,
+    }));
+    (useGraphStore.getState as any).mockReturnValue({
+      datasets: [],
+    });
+
+    // Mock Worker
+    originalWorker = global.Worker;
+    const MockWorker = vi.fn().mockImplementation(function(this: any) {
+      this.postMessage = vi.fn();
+      this.terminate = vi.fn();
+      mockWorkerInstance = this;
+      return this;
+    });
+    global.Worker = MockWorker as any;
+  });
+
+  afterEach(() => {
+    global.Worker = originalWorker;
+    mockWorkerInstance = null;
+  });
+
+  it('should initialize correctly', () => {
+    const { result } = renderHook(() => useDataImport());
+    expect(result.current.isImporting).toBe(false);
+    expect(result.current.error).toBe(null);
+    expect(result.current.pendingFile).toBe(null);
+  });
+
+  it('should set pending file on initiateImport', async () => {
+    const { result } = renderHook(() => useDataImport());
+
+    // Create a mock file
+    const fileContent = 'A,B\n1,2';
+    const file = new File([fileContent], 'test.csv', { type: 'text/csv' });
+
+    // Override readAsText directly since FileReader in JSDOM handles slices fine
+    // but just to make it fast and synchronous in act
+    const originalFileReader = global.FileReader;
+    class MockFileReader {
+      onload: any;
+      readAsText(blob: Blob) {
+        setTimeout(() => {
+          this.onload({ target: { result: 'preview data' } });
+        }, 10);
+      }
+    }
+    global.FileReader = MockFileReader as any;
+
+    act(() => {
+      result.current.importFile(file);
+    });
+
+    // Wait for the mock reader to finish
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 20));
+    });
+
+    expect(result.current.pendingFile).not.toBeNull();
+    expect(result.current.pendingFile?.file).toBe(file);
+    expect(result.current.pendingFile?.type).toBe('csv');
+    expect(result.current.pendingFile?.preview).toBe('preview data');
+
+    global.FileReader = originalFileReader;
+  });
+
+  it('should cancel import correctly', () => {
+    const { result } = renderHook(() => useDataImport());
+
+    // Directly inject a pending file state using act by forcing a re-render or mocking initial state isn't easy here,
+    // so let's call the actual hook method but mock the file reader synchronous
+    const file = new File([''], 'test.csv', { type: 'text/csv' });
+
+    const originalFileReader = global.FileReader;
+    class MockFileReader {
+      onload: any;
+      readAsText() {
+        this.onload({ target: { result: 'data' } });
+      }
+    }
+    global.FileReader = MockFileReader as any;
+
+    act(() => {
+      result.current.importFile(file);
+    });
+
+    expect(result.current.pendingFile).not.toBeNull();
+
+    act(() => {
+      result.current.cancelImport();
+    });
+
+    expect(result.current.pendingFile).toBeNull();
+    global.FileReader = originalFileReader;
+  });
+
+  it('should process import with worker successfully', async () => {
+    const { result } = renderHook(() => useDataImport());
+
+    // Setup pending file
+    const file = new File([''], 'test.csv', { type: 'text/csv' });
+    const originalFileReader = global.FileReader;
+    class MockFileReader {
+      onload: any;
+      readAsText() {
+        this.onload({ target: { result: 'data' } });
+      }
+    }
+    global.FileReader = MockFileReader as any;
+
+    act(() => {
+      result.current.importFile(file);
+    });
+
+    expect(result.current.pendingFile).not.toBeNull();
+
+    // Call confirmImport
+    const settings = { delimiter: ',', decimalPoint: '.', startRow: 1, columnConfigs: [] };
+
+    act(() => {
+      result.current.confirmImport(settings as any);
+    });
+
+    expect(result.current.isImporting).toBe(true);
+    expect(global.Worker).toHaveBeenCalled();
+    expect(mockWorkerInstance.postMessage).toHaveBeenCalledWith({
+      file,
+      type: 'csv',
+      settings
+    });
+
+    // Simulate worker success message
+    const mockDataset = {
+      id: 'ds-1',
+      name: 'test.csv',
+      columns: ['Col1'],
+      rowCount: 10,
+      data: []
+    };
+
+    await act(async () => {
+      await mockWorkerInstance.onmessage({
+        data: {
+          type: 'success',
+          dataset: mockDataset
+        }
+      } as MessageEvent);
+    });
+
+    expect(persistence.saveDataset).toHaveBeenCalled();
+    expect(mockAddDataset).toHaveBeenCalled();
+    expect(mockAddDataset.mock.calls[0][0].name).toBe('A - test.csv');
+    expect(mockAddDataset.mock.calls[0][0].columns[0]).toBe('A: Col1');
+    expect(result.current.isImporting).toBe(false);
+    expect(result.current.pendingFile).toBeNull();
+    expect(mockWorkerInstance.terminate).toHaveBeenCalled();
+
+    global.FileReader = originalFileReader;
+  });
+
+  it('should handle worker errors', async () => {
+    const { result } = renderHook(() => useDataImport());
+
+    const file = new File([''], 'test.json', { type: 'application/json' });
+    const originalFileReader = global.FileReader;
+    class MockFileReader {
+      onload: any;
+      readAsText() {
+        this.onload({ target: { result: 'data' } });
+      }
+    }
+    global.FileReader = MockFileReader as any;
+
+    act(() => {
+      result.current.importFile(file);
+    });
+
+    const settings = { delimiter: ',', decimalPoint: '.', startRow: 1, columnConfigs: [] };
+
+    act(() => {
+      result.current.confirmImport(settings as any);
+    });
+
+    expect(result.current.isImporting).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    // Simulate worker error message
+    const errorMessage = 'Failed to parse JSON';
+
+    await act(async () => {
+      await mockWorkerInstance.onmessage({
+        data: {
+          type: 'error',
+          error: errorMessage
+        }
+      } as MessageEvent);
+    });
+
+    expect(result.current.isImporting).toBe(false);
+    expect(result.current.error).toBe(errorMessage);
+    expect(mockWorkerInstance.terminate).toHaveBeenCalled();
+    expect(persistence.saveDataset).not.toHaveBeenCalled();
+    expect(mockAddDataset).not.toHaveBeenCalled();
+
+    global.FileReader = originalFileReader;
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
   base: './',
   test: {
     environment: 'jsdom',
+    globals: true,
   }
 })


### PR DESCRIPTION
Added missing integration tests for `useDataImport` hook to cover worker initialization, success, and error processing logic as well as file initialization. Configured Vitest to run react hooks with jsdom.

Note regarding code review: The provided snippet in the task description was slightly outdated compared to the actual file content on disk. The on-disk `useDataImport.ts` returns `{ importFile: initiateImport, confirmImport, cancelImport, ... }` where `confirmImport` is indeed the function that initializes the Worker, and there are `pendingFile` states. The tests correctly model this actual on-disk behavior.

---
*PR created automatically by Jules for task [13531879121079816633](https://jules.google.com/task/13531879121079816633) started by @michaelkrisper*