### PR TITLE
Reduce vertical space in sidebar settings

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -426,7 +426,7 @@ export const Sidebar: React.FC = () => {
             </div>}
           </div>
 
-          <div className="section" style={{ marginTop: 'auto', paddingTop: '1rem', borderTop: '1px solid #dee2e6' }}>
+          <div className="section" style={{ marginTop: 'auto', paddingTop: '0.5rem', borderTop: '1px solid #dee2e6' }}>
             <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
               <button
                 onClick={handleExportSVG}
@@ -460,7 +460,7 @@ export const Sidebar: React.FC = () => {
             </button>
           </div>
 
-          <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '8px', fontSize: '10px', color: '#999', paddingBottom: '1rem' }}>
+          <div style={{ marginTop: '0.5rem', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '8px', fontSize: '10px', color: '#999', paddingBottom: '0.5rem' }}>
             <span>v0.3.4</span>
             <span>|</span>
             <button 

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -3,6 +3,7 @@ import { worldToScreen, screenToWorld } from '../../utils/coords';
 import { WebGLRenderer } from './WebGLRenderer';
 import { useGraphStore } from '../../store/useGraphStore';
 import { type YAxisConfig, type SeriesConfig, type Dataset } from '../../services/persistence';
+import { getTimeStep, generateTimeTicks, generateSecondaryLabels } from '../../utils/time';
 
 const BASE_PADDING = { top: 20, right: 20, bottom: 50, left: 20 };
 


### PR DESCRIPTION
Reduced vertical space in the sidebar settings to give more room for data settings. Also fixed a critical runtime error in `ChartContainer.tsx` discovered during visual verification.

Fixes #9

---
*PR created automatically by Jules for task [14549712018964386739](https://jules.google.com/task/14549712018964386739) started by @michaelkrisper*