### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons for accessibility

### DIFF
--- a/src/components/Layout/HelpModal.tsx
+++ b/src/components/Layout/HelpModal.tsx
@@ -43,6 +43,7 @@ export const HelpModal: React.FC<HelpModalProps> = ({ onClose }) => {
       }}>
         <button
           onClick={onClose}
+          aria-label="Close Help"
           style={{
             position: 'absolute',
             top: '16px',

--- a/src/components/Layout/ImprintModal.tsx
+++ b/src/components/Layout/ImprintModal.tsx
@@ -33,6 +33,7 @@ export const ImprintModal: React.FC<ImprintModalProps> = ({ onClose }) => {
       }}>
         <button 
           onClick={onClose}
+          aria-label="Close Imprint"
           style={{
             position: 'absolute',
             top: '16px',

--- a/src/components/Layout/LicenseModal.tsx
+++ b/src/components/Layout/LicenseModal.tsx
@@ -33,6 +33,7 @@ export const LicenseModal: React.FC<LicenseModalProps> = ({ onClose }) => {
       }}>
         <button 
           onClick={onClose}
+          aria-label="Close License"
           style={{
             position: 'absolute',
             top: '16px',

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -202,6 +202,7 @@ export const Sidebar: React.FC = () => {
               <button 
                 onClick={() => setShowHelp(true)}
                 title="Help & Interactions"
+                aria-label="Help & Interactions"
                 style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '0', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#007bff' }}
               >
                 <HelpCircle size={18} />
@@ -325,6 +326,7 @@ export const Sidebar: React.FC = () => {
                   onClick={() => setXMode(xMode === 'date' ? 'numeric' : 'date')}
                   style={{ padding: '2px', cursor: 'pointer', background: '#f8f9fa', border: '1px solid #ced4da', borderRadius: '3px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                   title={`X-Mode: ${xMode === 'date' ? 'Date/Time' : 'Numeric'}`}
+                  aria-label="Toggle X-Mode"
                 >
                   {xMode === 'date' ? <Clock size={12} /> : <Hash size={12} />}
                 </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to multiple icon-only buttons across the app.
🎯 Why: To improve screen reader accessibility and overall UX for users relying on assistive technology.
♿ Accessibility:
- The "Help & Interactions" button in the Sidebar now has an accessible name.
- The "Toggle X-Mode" button in the Sidebar now has an accessible name.
- The close (X) buttons in `HelpModal.tsx`, `ImprintModal.tsx`, and `LicenseModal.tsx` now clearly indicate their purpose to screen readers.

---
*PR created automatically by Jules for task [6633678976580437091](https://jules.google.com/task/6633678976580437091) started by @michaelkrisper*