### PR TITLE
⚡ Bolt: [performance improvement] Pre-calculate column configurations in data parser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - O(N) Array Operations in High-Frequency Loops
 **Learning:** `Array.find` and `Array.indexOf` inside React render hooks (like `useEffect` in `WebGLRenderer`) and high-frequency event handlers (like `mousemove` snapping in `ChartContainer`) cause noticeable overhead when interacting with the chart.
 **Action:** Always pre-calculate and cache dependency data (like mapping Series to Datasets/Axes and resolving column indices) using `useMemo` before these high-frequency loops execute.
+## 2025-04-04 - [Optimize Array.find and fix hidden bug in data parser worker]
+**Learning:** In `data-parser.worker.ts`, an inner loop had an `Array.find` call that included an `Array.filter` operation. This caused O(N * M^2) time complexity. Additionally, the condition `settings.columnConfigs.filter(...)[colIdx]?.name === colName` was loop invariant and implicitly broken - it always matched on the first iteration of the find loop if the index matched, meaning only the first config was returned.
+**Action:** Always extract static array operations (like filtering non-ignored configs) out of loop conditions, both for O(N^2) performance wins and to prevent subtle variable shadowing/invariant bugs. Ensure the loop predicate strictly compares the current iterated item (e.g. `c.name`).

--- a/src/workers/data-parser.worker.ts
+++ b/src/workers/data-parser.worker.ts
@@ -43,13 +43,16 @@ self.onmessage = async (event) => {
 
     const lodLevels = generateSynchronizedLOD(relativeData, rowCount);
 
+    // ⚡ Bolt Optimization: Pre-calculate non-ignored configs to avoid O(N) array filtering operations inside .find() in the inner loop
+    const nonIgnoredConfigs = settings?.columnConfigs ? settings.columnConfigs.filter((cc: any) => cc.type !== 'ignore') : [];
+
     const dataset = {
       id: crypto.randomUUID(),
       name: file.name,
       columns: columns,
       rowCount: rowCount,
       data: columns.map((colName, colIdx) => {
-        const config = settings?.columnConfigs?.find((c: any) => c.name === colName || (settings.columnConfigs.filter((cc: any) => cc.type !== 'ignore')[colIdx]?.name === colName));
+        const config = settings?.columnConfigs?.find((c: any) => c.name === colName || (c.name === nonIgnoredConfigs[colIdx]?.name));
         const isPotentialX = config?.type === 'date' || colIdx === 0 || colName.toLowerCase().includes('time') || colName.toLowerCase().includes('date');
         return {
           isFloat64: isPotentialX,


### PR DESCRIPTION
💡 What: Pre-calculated the `nonIgnoredConfigs` array outside the `columns.map` and `Array.find` loops in `src/workers/data-parser.worker.ts`. Updated the inner `.find` condition to use `c.name` instead of loop-invariant logic.
🎯 Why: In datasets with many columns, the nested `.filter` call created massive O(N * M²) overhead, severely hurting import performance. The old logic also contained a bug where the right-hand side of the `||` in the `.find` was independent of the current array item, returning index 0 incorrectly.
📊 Impact: Significant reduction in time to parse files with many columns. Complexity drops from O(N * M²) to O(N * M). The parse accuracy is also restored.
🔬 Measurement: Verify by running `pnpm test` and observing `parser.test.ts` still passes successfully, while import time of files with a large number of columns is measurably faster.

---
*PR created automatically by Jules for task [4342247290938038194](https://jules.google.com/task/4342247290938038194) started by @michaelkrisper*