### PR TITLE
🎨 Palette: [UX improvement] Add ARIA attributes and improve keyboard accessibility in sidebar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-04 - Accessible Collapsible Sections in Sidebar
+**Learning:** By wrapping the chevron and title text of accordion sections (like Data Sources, Data Series, Data Views) in a native `<button aria-expanded="...">` instead of relying on an `onClick` attached to a semantic `div`, we dramatically improve keyboard accessibility and screen reader support without changing visual layout or behavior.
+**Action:** When creating or modifying collapsible UI sections, always ensure the toggle area is a `<button>` tag with `aria-expanded` reflecting the state, and use standard styling resets (`background: none`, `border: none`, `font: inherit`) to preserve the intended design system appearance.

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -215,11 +215,11 @@ export const Sidebar: React.FC = () => {
           
           <div className="section">
             <div className="section-title" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', userSelect: 'none' }}>
-              <div onClick={() => toggleSection('sources')} style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', flex: 1 }}>
+              <button onClick={() => toggleSection('sources')} aria-expanded={openSections.sources} style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', flex: 1, background: 'none', border: 'none', padding: 0, textAlign: 'left', font: 'inherit', color: 'inherit' }}>
                 <ChevronRight size={14} style={{ marginRight: '4px', transition: 'transform 0.15s', transform: openSections.sources ? 'rotate(90deg)' : 'none' }} />
                 <FilePlus size={14} style={{ marginRight: '5px' }} />
                 Data Sources
-              </div>
+              </button>
               <button
                 disabled={isImporting}
                 onClick={() => fileInputRef.current?.click()}
@@ -269,6 +269,7 @@ export const Sidebar: React.FC = () => {
                       <input
                         type="text"
                         name={`column-filter-${d.id}`}
+                        aria-label={`Filter columns for ${d.name}`}
                         autoComplete="off"
                         placeholder="Filter..."
                         value={columnFilters[d.id] || ''}
@@ -276,11 +277,13 @@ export const Sidebar: React.FC = () => {
                         style={{ width: '100%', padding: '4px 22px 4px 6px', fontSize: '12px', border: '1px solid #ced4da', borderRadius: '3px', boxSizing: 'border-box', outline: 'none' }}
                       />
                       {columnFilters[d.id] && (
-                        <X
-                          size={14}
-                          style={{ position: 'absolute', right: '6px', cursor: 'pointer', color: '#999' }}
+                        <button
                           onClick={() => setColumnFilters({ ...columnFilters, [d.id]: '' })}
-                        />
+                          aria-label="Clear filter"
+                          style={{ position: 'absolute', right: '4px', background: 'none', border: 'none', padding: '2px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                        >
+                          <X size={14} style={{ color: '#999' }} />
+                        </button>
                       )}
                     </div>
                     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
@@ -307,15 +310,16 @@ export const Sidebar: React.FC = () => {
 
           <div className="section">
             <div className="section-title" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', userSelect: 'none' }}>
-              <div onClick={() => toggleSection('series')} style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', flex: 1 }}>
+              <button onClick={() => toggleSection('series')} aria-expanded={openSections.series} style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', flex: 1, background: 'none', border: 'none', padding: 0, textAlign: 'left', font: 'inherit', color: 'inherit' }}>
                 <ChevronRight size={14} style={{ marginRight: '4px', transition: 'transform 0.15s', transform: openSections.series ? 'rotate(90deg)' : 'none' }} />
                 <Layout size={14} style={{ marginRight: '5px' }} />
                 Data Series
-              </div>
+              </button>
               <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
                 <span style={{ fontSize: '10px', color: '#666' }}>Global X:</span>
                 <select
                   name="global-x-column"
+                  aria-label="Global X Column"
                   value={globalXColumn}
                   onChange={(e) => setGlobalXColumn(e.target.value)}
                   style={{ fontSize: '10px', padding: '1px', border: '1px solid #ced4da', borderRadius: '3px', width: '80px' }}
@@ -351,12 +355,12 @@ export const Sidebar: React.FC = () => {
           </div>
 
           <div className="section">
-            <div className="section-title" onClick={() => toggleSection('views')} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', cursor: 'pointer', userSelect: 'none' }}>
-              <div style={{ display: 'flex', alignItems: 'center' }}>
+            <div className="section-title" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', userSelect: 'none' }}>
+              <button onClick={() => toggleSection('views')} aria-expanded={openSections.views} style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', flex: 1, background: 'none', border: 'none', padding: 0, textAlign: 'left', font: 'inherit', color: 'inherit' }}>
                 <ChevronRight size={14} style={{ marginRight: '4px', transition: 'transform 0.15s', transform: openSections.views ? 'rotate(90deg)' : 'none' }} />
                 <Eye size={14} style={{ marginRight: '5px' }} />
                 Data Views
-              </div>
+              </button>
               <button
                 onClick={(e) => { e.stopPropagation(); saveView(''); }}
                 style={{ padding: '4px 12px', cursor: 'pointer', background: '#007bff', color: '#fff', border: 'none', borderRadius: '4px', fontWeight: 'bold', fontSize: '12px' }}
@@ -378,6 +382,7 @@ export const Sidebar: React.FC = () => {
                         <input
                           autoFocus
                           name="view-name"
+                          aria-label="Rename view"
                           autoComplete="off"
                           value={tempViewName}
                           onChange={(e) => setTempViewName(e.target.value)}

--- a/src/components/Sidebar/SeriesConfig.tsx
+++ b/src/components/Sidebar/SeriesConfig.tsx
@@ -65,6 +65,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
       <input
         type="color"
         name={`series-color-${series.id}`}
+        aria-label={`Color for ${series.name || series.yColumn}`}
         value={series.lineColor}
         onInput={(e) => {
           const color = (e.target as HTMLInputElement).value;
@@ -131,6 +132,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
       {/* Y Column Selector */}
       <select
         name={`series-y-column-${series.id}`}
+        aria-label={`Y Column for ${series.name || series.yColumn}`}
         value={series.yColumn}
         onChange={(e) => handleUpdate({ yColumn: e.target.value })}
         style={{ width: '80px', fontSize: '9px', padding: '0', height: '18px', minWidth: 0, flexShrink: 1 }}
@@ -156,6 +158,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
           <input
             autoFocus
             name={`series-title-${series.id}`}
+            aria-label="Rename series"
             autoComplete="off"
             defaultValue={series.name || series.yColumn}
             onBlur={(e) => { handleUpdate({ name: e.target.value }); setIsEditingTitle(false); }}


### PR DESCRIPTION
💡 **What**:
- Converted non-semantic `<div onClick={...}>` wrappers used for sidebar accordion toggles into native `<button>` elements equipped with `aria-expanded` attributes.
- Wrapped the standalone 'Clear filter' `<X>` icon in a native button element.
- Added descriptive `aria-label`s to previously unlabelled text inputs and dropdowns (`globalXColumn` selector, `view-name` input, column filter input).
- Added corresponding `aria-label`s to the SeriesConfig component inputs (Color picker, Y-column selector, Series rename input).

🎯 **Why**:
Users heavily rely on the sidebar for navigating datasets, managing series, and interacting with layout configurations. Before this change, the collapsable menus, certain inputs, and icon-only buttons lacked standard keyboard navigability and semantic meaning, frustrating keyboard-reliant and screen reader users. This update enforces an inclusive UI without altering any core logic or disrupting the visual layout.

📸 **Before/After**:
No visual changes apply—CSS resets (`background: none`, `border: none`, `font: inherit`) were utilized to preserve existing styles while bringing structure into standard compliance.

♿ **Accessibility**:
These improvements specifically address missing ARIA labels and ensure key navigational components (accordion dropdowns, form clears) reside within semantic boundaries that accurately reflect interaction capabilities to assistive technologies.

---
*PR created automatically by Jules for task [15670047365664862819](https://jules.google.com/task/15670047365664862819) started by @michaelkrisper*