### PR TITLE
Data View on existing Data Source

### DIFF
--- a/src/components/Layout/DataViewModal.tsx
+++ b/src/components/Layout/DataViewModal.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { X } from 'lucide-react';
+import { type Dataset } from '../../services/persistence';
+import { formatFullDate } from '../../utils/time';
+
+interface DataViewModalProps {
+  dataset: Dataset;
+  onClose: () => void;
+}
+
+/**
+ * DataViewModal Component
+ * Displays a table of the dataset's values (up to 100 rows).
+ */
+export const DataViewModal: React.FC<DataViewModalProps> = ({ dataset, onClose }) => {
+  const maxRows = Math.min(dataset.rowCount, 100);
+  const rows = Array.from({ length: maxRows }, (_, i) => i);
+
+  return (
+    <div style={{
+      position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+      backgroundColor: 'rgba(0, 0, 0, 0.5)', display: 'flex',
+      alignItems: 'center', justifyContent: 'center', zIndex: 9999, backdropFilter: 'blur(2px)'
+    }}>
+      <div style={{
+        backgroundColor: '#fff', padding: '24px', borderRadius: '8px',
+        maxWidth: '1000px', width: '95%', maxHeight: '90vh', overflowY: 'auto',
+        boxShadow: '0 4px 20px rgba(0,0,0,0.15)', display: 'flex', flexDirection: 'column'
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
+          <h2 style={{ margin: 0 }}>Data Source: {dataset.name}</h2>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer' }} aria-label="Close dialog">
+            <X size={20} />
+          </button>
+        </div>
+
+        <div style={{ marginBottom: '10px', fontSize: '14px', color: '#666' }}>
+          Showing first {maxRows} of {dataset.rowCount.toLocaleString()} rows.
+        </div>
+
+        <div style={{ overflowX: 'auto', border: '1px solid #dee2e6', borderRadius: '4px' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
+            <thead>
+              <tr style={{ backgroundColor: '#f8f9fa', borderBottom: '2px solid #dee2e6' }}>
+                {dataset.columns.map((col, i) => (
+                  <th key={i} style={{ border: '1px solid #dee2e6', padding: '8px', textAlign: 'left', whiteSpace: 'nowrap' }}>
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(rowIndex => (
+                <tr key={rowIndex} style={{ borderBottom: '1px solid #eee' }}>
+                  {dataset.data.map((colData, colIndex) => {
+                    const rawValue = colData.levels[0][rowIndex];
+                    const absoluteValue = rawValue + colData.refPoint;
+
+                    let displayValue: string;
+                    if (colData.isFloat64 && !isNaN(absoluteValue)) {
+                      displayValue = formatFullDate(absoluteValue);
+                    } else if (isNaN(absoluteValue)) {
+                      displayValue = 'NaN';
+                    } else {
+                      // Format numbers with up to 4 decimal places
+                      displayValue = Number.isInteger(absoluteValue)
+                        ? absoluteValue.toString()
+                        : absoluteValue.toFixed(4).replace(/\.?0+$/, '');
+                    }
+
+                    return (
+                      <td key={colIndex} style={{ border: '1px solid #dee2e6', padding: '8px' }}>
+                        {displayValue}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '20px' }}>
+          <button
+            onClick={onClose}
+            style={{ padding: '8px 24px', borderRadius: '4px', border: '1px solid #ced4da', background: '#fff', cursor: 'pointer', fontWeight: 'bold' }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { SeriesConfigUI } from '../Sidebar/SeriesConfig';
 import { persistence } from '../../services/persistence';
 import { FilePlus, Layout, Trash2, ChevronRight, Clock, Hash, HelpCircle, X, Eye, FileImage, Image, RotateCcw } from 'lucide-react';
 import { ImportSettingsDialog } from './ImportSettingsDialog';
+import { DataViewModal } from './DataViewModal';
 
 import { exportToSVG, exportToPNG, downloadFile } from '../../services/export';
 import { ImprintModal } from './ImprintModal';
@@ -28,6 +29,7 @@ export const Sidebar: React.FC = () => {
   const [showImprint, setShowImprint] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [showLicense, setShowLicense] = useState(false);
+  const [viewingDatasetId, setViewingDatasetId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const allColumns = useMemo(() => {
@@ -43,6 +45,10 @@ export const Sidebar: React.FC = () => {
   const toggleSection = (key: keyof typeof openSections) => setOpenSections(s => ({ ...s, [key]: !s[key] }));
   const { importFile, confirmImport, cancelImport, pendingFile, isImporting } = useDataImport();
   const [columnFilters, setColumnFilters] = useState<Record<string, string>>({});
+
+  const selectedDatasetForView = useMemo(() => {
+    return datasets.find(d => d.id === viewingDatasetId);
+  }, [datasets, viewingDatasetId]);
 
   const customViews = useMemo(() => {
     return views ? views.filter(v => v.id !== 'default-view') : [];
@@ -244,7 +250,13 @@ export const Sidebar: React.FC = () => {
               {datasets.map(d => (
                 <div key={d.id} style={{ padding: '8px', border: '1px solid #dee2e6', borderRadius: '4px', background: '#fff', marginBottom: '8px' }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
-                    <div style={{ fontWeight: 'bold', fontSize: '0.9rem', flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', marginRight: '8px' }} title={d.name}>{d.name}</div>
+                    <div
+                      onDoubleClick={() => setViewingDatasetId(d.id)}
+                      style={{ fontWeight: 'bold', fontSize: '0.9rem', flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', marginRight: '8px', cursor: 'pointer', userSelect: 'none' }}
+                      title={`${d.name} (Double-click to view data table)`}
+                    >
+                      {d.name}
+                    </div>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                       <div style={{ fontSize: '0.75rem', color: '#666' }}>{d.rowCount.toLocaleString()} rows</div>
                       <button 
@@ -516,6 +528,12 @@ export const Sidebar: React.FC = () => {
           fileType={pendingFile.type}
           onConfirm={confirmImport}
           onCancel={cancelImport}
+        />
+      )}
+      {selectedDatasetForView && (
+        <DataViewModal
+          dataset={selectedDatasetForView}
+          onClose={() => setViewingDatasetId(null)}
         />
       )}
     </>


### PR DESCRIPTION
This PR implements the requested feature to view the data table of an existing data source. 

Key changes:
- Created a new `DataViewModal` component that renders a table of dataset values (up to 100 rows).
- Reconstructs absolute data points by adding the column's `refPoint` to its relative values.
- Formats date/time columns (identified by `isFloat64`) using the `formatFullDate` utility.
- Added a `onDoubleClick` handler to dataset titles in the `Sidebar` to trigger the modal.
- Improved UX by adding a tooltip to dataset titles indicating the double-click action.

Verified with unit tests and a Playwright visual verification script.

Fixes #61

---
*PR created automatically by Jules for task [14158497814864961952](https://jules.google.com/task/14158497814864961952) started by @michaelkrisper*