### PR TITLE
Align Data Views and Footer to Bottom of Sidebar

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -367,7 +367,7 @@ export const Sidebar: React.FC = () => {
             </div>}
           </div>
 
-          <div className="section">
+          <div className="section" style={{ marginTop: 'auto', paddingTop: '0.5rem', borderTop: '1px solid #dee2e6' }}>
             <div className="section-title" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', userSelect: 'none' }}>
               <button onClick={() => toggleSection('views')} aria-expanded={openSections.views} style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', flex: 1, background: 'none', border: 'none', padding: 0, textAlign: 'left', font: 'inherit', color: 'inherit' }}>
                 <ChevronRight size={14} style={{ marginRight: '4px', transition: 'transform 0.15s', transform: openSections.views ? 'rotate(90deg)' : 'none' }} />
@@ -447,7 +447,7 @@ export const Sidebar: React.FC = () => {
             </div>}
           </div>
 
-          <div className="section" style={{ marginTop: 'auto', paddingTop: '0.5rem', borderTop: '1px solid #dee2e6' }}>
+          <div className="section" style={{ paddingTop: '0.5rem', borderTop: '1px solid #dee2e6' }}>
             <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
               <button
                 onClick={handleExportSVG}


### PR DESCRIPTION
Reorganized the sidebar layout in `src/components/Layout/Sidebar.tsx` to meet the requested vertical alignment. 

Key changes:
- Applied `marginTop: 'auto'` to the "Data Views" section container to push it and all subsequent sections to the bottom of the sidebar.
- Removed `marginTop: 'auto'` from the Export/Reset button section.
- Added `borderTop` and `paddingTop` to the "Data Views" section to provide a clear visual separator from the top sections.
- Verified the layout with a Playwright screenshot, confirming 'Data Source' and 'Data Series' remain at the top while 'Data Views', Export/Reset buttons, and the version/imprint footer are pinned to the bottom.
- Ensured no regressions by running the test suite and linting.

Fixes #68

---
*PR created automatically by Jules for task [5538187389986327477](https://jules.google.com/task/5538187389986327477) started by @michaelkrisper*