### PR TITLE
Fix dashed and dotted line rendering precision and scaling

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.0
@@ -146,6 +149,10 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -416,8 +423,30 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -565,12 +594,23 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -686,6 +726,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -693,6 +737,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   electron-to-chromium@1.5.331:
     resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
@@ -1095,6 +1142,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1213,6 +1264,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1224,6 +1279,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -1637,6 +1695,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -1861,10 +1921,33 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2053,11 +2136,19 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-union@2.1.0: {}
 
@@ -2157,11 +2248,15 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   electron-to-chromium@1.5.331: {}
 
@@ -2553,6 +2648,8 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2659,6 +2756,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
@@ -2667,6 +2770,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react@19.2.4: {}
 

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -21,6 +21,7 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, yA
   const [program, setProgram] = useState<WebGLProgram | null>(null);
   const [locations, setLocations] = useState<any>({});
   const buffersRef = useRef<Map<string, WebGLBuffer>>(new Map());
+  const segParamsRef = useRef<Map<string, string>>(new Map());
 
   // Global shared buffer to avoid per-segment array allocations
   // Using module-level variable to persist across renders and components
@@ -53,9 +54,9 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, yA
       uniform vec4 u_padding;
       uniform vec2 u_resolution;
       uniform float u_point_size;
-      varying float v_t;
-      varying float v_len;
-      varying float v_dist_start;
+      varying highp float v_t;
+      varying highp float v_len;
+      varying highp float v_dist_start;
 
       vec2 toScreen(vec2 pos) {
         float dx = u_rel_viewport_x.y - u_rel_viewport_x.x;
@@ -83,14 +84,15 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, yA
       uniform vec4 u_color;
       uniform int u_point_style;
       uniform int u_line_style;
-      varying float v_t;
-      varying float v_len;
-      varying float v_dist_start;
+      uniform float u_dpr;
+      varying highp float v_t;
+      varying highp float v_len;
+      varying highp float v_dist_start;
       void main() {
         if (u_point_style == -1) {
           if (u_line_style > 0) {
-            float dashLen = (u_line_style == 1) ? 8.0 : 2.0;
-            float gapLen = (u_line_style == 1) ? 6.0 : 4.0;
+            float dashLen = ((u_line_style == 1) ? 8.0 : 2.0) * u_dpr;
+            float gapLen = ((u_line_style == 1) ? 6.0 : 4.0) * u_dpr;
             float period = dashLen + gapLen;
             float dist = v_dist_start + v_t * v_len;
             if (mod(dist, period) > dashLen) discard;
@@ -122,6 +124,7 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, yA
       colorLoc: gl.getUniformLocation(pg, 'u_color'),
       styleLoc: gl.getUniformLocation(pg, 'u_point_style'),
       lineStyleLoc: gl.getUniformLocation(pg, 'u_line_style'),
+      dprLoc: gl.getUniformLocation(pg, 'u_dpr'),
       sizeLoc: gl.getUniformLocation(pg, 'u_point_size'),
       posLoc: gl.getAttribLocation(pg, 'a_position'),
       otherLoc: gl.getAttribLocation(pg, 'a_other'),
@@ -182,6 +185,7 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, yA
     const locs = locations;
     gl.uniform4f(locs.padLoc, padding.top * dpr, padding.right * dpr, padding.bottom * dpr, padding.left * dpr);
     gl.uniform2f(locs.resLoc, pw, ph);
+    gl.uniform1f(locs.dprLoc, dpr);
 
     seriesMetadata.forEach(({ series: s, ds, axis, xIdx, yIdx }) => {
       const colX = ds.data[xIdx];
@@ -244,30 +248,44 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, yA
           gl.drawArrays(gl.LINE_STRIP, 0, numPoints);
         } else {
           const segBufferKey = `seg-${ds.id}-${xIdx}-${yIdx}-lod${lodLevel}`;
+          const paramKey = `${viewportX.min}-${viewportX.max}-${axis.min}-${axis.max}-${chartWidth}-${chartHeight}-${dpr}`;
           let segBuffer = buffersRef.current.get(segBufferKey);
           if (!segBuffer) {
             segBuffer = gl.createBuffer()!;
+            buffersRef.current.set(segBufferKey, segBuffer);
+          }
+
+          if (segParamsRef.current.get(segBufferKey) !== paramKey) {
             // Per vertex: pos(2) + other(2) + t(1) + dist_start(1) = 6 floats, stride 24
             const reqSize = (numPoints - 1) * 12;
             const sharedArr = getSharedBuffer(reqSize);
-            // Compute screen-space cumulative arc length so dash phase is in pixels
+            // Compute screen-space cumulative arc length in physical pixels
             const xRange = (viewportX.max - viewportX.min) || 1;
             const yRange = (axis.max - axis.min) || 1;
+            const pChartWidth = chartWidth * dpr;
+            const pChartHeight = chartHeight * dpr;
+            const dashLen = ((lStyle === 1) ? 8.0 : 2.0) * dpr;
+            const gapLen = ((lStyle === 1) ? 6.0 : 4.0) * dpr;
+            const period = dashLen + gapLen;
+
             let cumDist = 0;
             for (let i = 0; i < numPoints - 1; i++) {
               const ax = xLOD[i], ay = yLOD[i], bx = xLOD[i + 1], by = yLOD[i + 1];
-              const screenDx = (bx - ax) / xRange * chartWidth;
-              const screenDy = (by - ay) / yRange * chartHeight;
+              const screenDx = (bx - ax) / xRange * pChartWidth;
+              const screenDy = (by - ay) / yRange * pChartHeight;
               const segScreenLen = Math.sqrt(screenDx * screenDx + screenDy * screenDy);
               const off = i * 12;
-              sharedArr[off]     = ax; sharedArr[off + 1] = ay; sharedArr[off + 2] = bx; sharedArr[off + 3] = by; sharedArr[off + 4] = 0; sharedArr[off + 5] = cumDist;
-              sharedArr[off + 6] = bx; sharedArr[off + 7] = by; sharedArr[off + 8] = ax; sharedArr[off + 9] = ay; sharedArr[off + 10] = 1; sharedArr[off + 11] = cumDist;
+              const startDist = cumDist % period;
+              sharedArr[off]     = ax; sharedArr[off + 1] = ay; sharedArr[off + 2] = bx; sharedArr[off + 3] = by; sharedArr[off + 4] = 0; sharedArr[off + 5] = startDist;
+              sharedArr[off + 6] = bx; sharedArr[off + 7] = by; sharedArr[off + 8] = ax; sharedArr[off + 9] = ay; sharedArr[off + 10] = 1; sharedArr[off + 11] = startDist;
               cumDist += segScreenLen;
             }
             gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
-            gl.bufferData(gl.ARRAY_BUFFER, sharedArr.subarray(0, reqSize), gl.STATIC_DRAW);
-            buffersRef.current.set(segBufferKey, segBuffer);
-          } else gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
+            gl.bufferData(gl.ARRAY_BUFFER, sharedArr.subarray(0, reqSize), gl.STREAM_DRAW);
+            segParamsRef.current.set(segBufferKey, paramKey);
+          } else {
+            gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
+          }
 
           gl.enableVertexAttribArray(locs.posLoc);
           gl.vertexAttribPointer(locs.posLoc, 2, gl.FLOAT, false, 24, 0);


### PR DESCRIPTION
Dashed and dotted lines were appearing solid when data points were very close in screen space because the pattern phase was not correctly maintained across segments and lacked sufficient precision for small increments. 

This change fixes the issue by:
1. Upgrading precision for distance-related varying variables to `highp` in both vertex and fragment shaders.
2. Making the line patterns aware of the `devicePixelRatio` to ensure consistent appearance across different screen densities.
3. Dynamically recalculating the cumulative distance of line segments in physical pixels on the CPU whenever the viewport or chart dimensions change.
4. Applying a modular operation (`cumDist % period`) to the starting distance of each segment before passing it to the shader. This ensures that the distance value used for the dash pattern remains small, preserving floating-point precision even for lines with many points or across wide viewports.
5. Updating the segment buffer using `gl.STREAM_DRAW` to reflect viewport changes during pan and zoom interactions.

Frontend verification confirmed that dashed and dotted patterns are now clearly visible and stable even when zoomed in or when data points are densely clustered.

Fixes #65

---
*PR created automatically by Jules for task [2473283676843479581](https://jules.google.com/task/2473283676843479581) started by @michaelkrisper*