### PR TITLE
Fix line disappearance on zoom

### DIFF
--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -200,27 +200,29 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, xA
       let startIdx = 0;
       let endIdx = xData.length - 1;
 
-      // Find first point in viewport
+      // Find last point <= xAxis.min (to include segment crossing left boundary)
       let low = 0, high = xData.length - 1;
+      startIdx = 0;
       while (low <= high) {
         const mid = (low + high) >>> 1;
-        if (xData[mid] + xRef >= xAxis.min) {
+        if (xData[mid] + xRef <= xAxis.min) {
           startIdx = mid;
-          high = mid - 1;
-        } else {
           low = mid + 1;
+        } else {
+          high = mid - 1;
         }
       }
-      
-      // Find last point in viewport
+
+      // Find first point >= xAxis.max (to include segment crossing right boundary)
       low = 0; high = xData.length - 1;
+      endIdx = xData.length - 1;
       while (low <= high) {
         const mid = (low + high) >>> 1;
-        if (xData[mid] + xRef <= xAxis.max) {
+        if (xData[mid] + xRef >= xAxis.max) {
           endIdx = mid;
-          low = mid + 1;
-        } else {
           high = mid - 1;
+        } else {
+          low = mid + 1;
         }
       }
 


### PR DESCRIPTION
This change fixes a bug where line segments would disappear when zooming in if their endpoints were outside the current viewport. By including one extra point on each side of the visible range in the binary search, we ensure that segments crossing the viewport boundaries are correctly included in the downsampling and rendering process.

Fixes #73

---
*PR created automatically by Jules for task [4828917730749831373](https://jules.google.com/task/4828917730749831373) started by @michaelkrisper*