### PR TITLE
Fix X-Axis Zoom and Refinements

### DIFF
--- a/src/components/Layout/ImportSettingsDialog.tsx
+++ b/src/components/Layout/ImportSettingsDialog.tsx
@@ -21,6 +21,7 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
   const [decimalPoint, setDecimalPoint] = useState<string>('.');
   const [startRow, setStartRow] = useState<number>(1);
   const [columnConfigs, setColumnConfigs] = useState<ColumnConfig[]>([]);
+  const [xAxisColumn, setXAxisColumn] = useState<string>('');
 
   // Auto-detect delimiter on mount
   useEffect(() => {
@@ -98,6 +99,14 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
         return { index, name, type, dateFormat };
       });
       setColumnConfigs(newConfigs);
+
+      // Auto-set default X-axis if not already set or no longer valid
+      const nonIgnored = newConfigs.filter(c => c.type !== 'ignore');
+      if (nonIgnored.length > 0 && (!xAxisColumn || !nonIgnored.find(c => c.name === xAxisColumn))) {
+        // Prefer 'date' columns
+        const dateCol = nonIgnored.find(c => c.type === 'date');
+        setXAxisColumn(dateCol?.name || nonIgnored[0].name);
+      }
     }
   }, [previewData.headers]); // Only re-run if headers (structure) change
 
@@ -157,6 +166,18 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
               onChange={e => setStartRow(parseInt(e.target.value) || 1)}
               style={{ width: '100%', padding: '4px', borderRadius: '4px', border: '1px solid #ced4da' }}
             />
+          </div>
+          <div>
+            <label style={{ display: 'block', fontSize: '12px', fontWeight: 'bold', marginBottom: '4px' }}>X-Axis Column</label>
+            <select
+              value={xAxisColumn}
+              onChange={e => setXAxisColumn(e.target.value)}
+              style={{ width: '100%', padding: '4px', borderRadius: '4px', border: '1px solid #ced4da' }}
+            >
+              {columnConfigs.filter(c => c.type !== 'ignore').map(c => (
+                <option key={c.index} value={c.name}>{c.name}</option>
+              ))}
+            </select>
           </div>
         </div>
 
@@ -225,7 +246,7 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
             Cancel
           </button>
           <button
-            onClick={() => onConfirm({ delimiter, decimalPoint, startRow, columnConfigs })}
+            onClick={() => onConfirm({ delimiter, decimalPoint, startRow, columnConfigs, xAxisColumn })}
             style={{ padding: '8px 16px', borderRadius: '4px', border: 'none', background: '#007bff', color: '#fff', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '6px' }}
           >
             <Check size={16} /> Import Data

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -273,6 +273,21 @@ export const Sidebar: React.FC = () => {
                           aria-label="Cycle X-Axis">
                           {parseInt(d.xAxisId?.split('-')[1]) || 1}
                         </button>
+                        <select
+                          name={`dataset-x-mode-${d.id}`}
+                          aria-label={`X Axis Mode for ${d.name}`}
+                          value={xAxes.find(a => a.id === (d.xAxisId || 'axis-1'))?.xMode || 'date'}
+                          onChange={(e) => {
+                            const axisId = d.xAxisId || 'axis-1';
+                            const { updateXAxis } = useGraphStore.getState();
+                            updateXAxis(axisId, { xMode: e.target.value as 'date' | 'numeric' });
+                          }}
+                          style={{ width: '45px', fontSize: '9px', padding: '1px', height: '18px', minWidth: 0, flexShrink: 1, border: '1px solid #e3f2fd', color: '#1976d2', borderRadius: '2px' }}
+                          title="X-Axis Mode (Time / Decimal)"
+                        >
+                          <option value="date">Time</option>
+                          <option value="numeric">Dec.</option>
+                        </select>
                       </div>
 
                       <div style={{ fontSize: '0.75rem', color: '#666' }}>{d.rowCount.toLocaleString()} rows</div>

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -1180,7 +1180,7 @@ const ChartContainer: React.FC = () => {
       <AxesLayer xAxes={xAxesLayout} yAxes={activeYAxes} width={width} height={height} padding={padding} leftAxes={leftAxes} rightAxes={rightAxes} series={series} axisLayout={axisLayout} allXAxes={xAxes} />
 
       {activeXAxesUsed.map((axis, idx) => {
-        const baseY = idx * 60;
+        const baseY = (activeXAxesUsed.length - 1 - idx) * 60;
         return <div key={`wheel-x-${axis.id}`} onWheel={(e) => { e.stopPropagation(); handleWheel(e, { xAxisId: axis.id }); }} onMouseDown={(e) => { e.stopPropagation(); handleMouseDown(e, { xAxisId: axis.id }); }} onDoubleClick={(e) => { e.stopPropagation(); handleAutoScaleX(axis.id); }} style={{ position: 'absolute', bottom: baseY, left: padding.left, right: padding.right, height: 60, cursor: 'ew-resize', zIndex: 20 }} />;
       })}
 

--- a/src/hooks/useDataImport.ts
+++ b/src/hooks/useDataImport.ts
@@ -47,6 +47,9 @@ export const useDataImport = () => {
         const prefix = `${letter}: `;
         ds.name = `${letter} - ${ds.name}`;
         ds.columns = ds.columns.map(c => `${prefix}${c}`);
+        if (ds.xAxisColumn) {
+          ds.xAxisColumn = `${prefix}${ds.xAxisColumn}`;
+        }
 
         await persistence.saveDataset(ds);
         addDataset(ds);

--- a/src/types/import.ts
+++ b/src/types/import.ts
@@ -12,4 +12,5 @@ export interface ImportSettings {
   decimalPoint: string;
   startRow: number;
   columnConfigs: ColumnConfig[];
+  xAxisColumn?: string;
 }

--- a/src/workers/data-parser.worker.ts
+++ b/src/workers/data-parser.worker.ts
@@ -49,6 +49,7 @@ self.onmessage = async (event) => {
       name: file.name,
       columns: columns,
       rowCount: rowCount,
+      xAxisColumn: settings?.xAxisColumn,
       data: columns.map((colName, colIdx) => {
         const config = settings?.columnConfigs?.find((c: any) => c.name === colName || (c.name === nonIgnoredConfigs[colIdx]?.name));
         const isPotentialX = config?.type === 'date' || colIdx === 0 || colName.toLowerCase().includes('time') || colName.toLowerCase().includes('date');


### PR DESCRIPTION
This PR addresses a bug where X-axis interaction was reversed when multiple X-axes were present. It also introduces refinements to the data import and management workflow:
1. **X-axis Interaction Fix**: Corrected the calculation of interaction zones in `ChartContainer.tsx` to match the visual rendering order of multiple X-axes.
2. **Import Refinement**: Added an "X-Axis Column" dropdown to the `ImportSettingsDialog`. This allows users to explicitly choose which column serves as the X-axis for a new dataset. The system also attempts to auto-select a date column by default.
3. **Sidebar Refinement**: Added a new dropdown in the Sidebar next to each dataset's X-axis assignment to toggle between 'Time' and 'Decimal' display modes for that axis.
4. **Data Handling**: Updated the `data-parser.worker.ts` and `useDataImport.ts` hook to ensure the selected X-axis column is properly passed through and prefixed (e.g., "A: Timestamp").

All tests passed and visual verification confirmed the UI changes.

Fixes #78

---
*PR created automatically by Jules for task [8263857059171046982](https://jules.google.com/task/8263857059171046982) started by @michaelkrisper*