### PR TITLE
Remove unused variable 'x' in ChartContainer.tsx

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -1083,7 +1083,7 @@ const ChartContainer: React.FC = () => {
       const touch = e.touches[0];
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return;
-      const x = touch.clientX - rect.left, y = touch.clientY - rect.top;
+      const y = touch.clientY - rect.top;
 
       if (isDoubleTap) {
         if (target === 'all') {


### PR DESCRIPTION
Removed the unused variable `x` in the `handleTouchStart` function within `src/components/Plot/ChartContainer.tsx`. This variable was calculated but not used in any subsequent logic, leading to a TypeScript compiler error (TS6133). The fix ensures that the project can be built successfully. Verified with `pnpm run build` and `pnpm test`.

Fixes #82

---
*PR created automatically by Jules for task [1364519766397774662](https://jules.google.com/task/1364519766397774662) started by @michaelkrisper*