### PR TITLE
Improve smartphone responsiveness and landscape layout

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -33,8 +33,8 @@ export const Sidebar: React.FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
 
-  const [width, setWidth] = useState(450);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [width, setWidth] = useState(() => Math.min(450, window.innerWidth * 0.85));
+  const [isCollapsed, setIsCollapsed] = useState(() => window.innerWidth < 768 || window.innerHeight < 500);
   const [isResizing, setIsResizing] = useState(false);
   const [openSections, setOpenSections] = useState({ sources: true, series: true, views: true });
   const toggleSection = (key: keyof typeof openSections) => setOpenSections(s => ({ ...s, [key]: !s[key] }));
@@ -75,6 +75,15 @@ export const Sidebar: React.FC = () => {
       document.removeEventListener('mouseup', handleMouseUp);
     };
   }, [isResizing]);
+
+  // Handle auto-resize on window resize (especially orientation change)
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(prev => Math.min(prev, window.innerWidth * 0.9));
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const handleExportSVG = () => {
     const plotContainer = document.querySelector('.plot-area') as HTMLElement;

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -5,7 +5,8 @@ import { useGraphStore } from '../../store/useGraphStore';
 import { type YAxisConfig, type XAxisConfig, type SeriesConfig, type Dataset } from '../../services/persistence';
 import { getTimeStep, generateTimeTicks, generateSecondaryLabels, formatFullDate, type TimeTick, type SecondaryLabel } from '../../utils/time';
 
-const BASE_PADDING = { top: 20, right: 20, bottom: 60, left: 20 };
+const BASE_PADDING_DESKTOP = { top: 20, right: 20, bottom: 60, left: 20 };
+const BASE_PADDING_MOBILE = { top: 10, right: 10, bottom: 40, left: 10 };
 
 type XTicks =
   | { result: number[]; step: number; precision: number; isXDate: false; secondaryLabels?: undefined }
@@ -125,7 +126,9 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
         {xAxes.map((axis, idx) => {
           const axisConf = allXAxes.find(a => a.id === axis.id)!;
           const vp = { xMin: axisConf.min, xMax: axisConf.max, yMin: 0, yMax: 100, width, height, padding };
-          const y = height - padding.bottom + idx * 60;
+          const isMobile = width < 768 || height < 500;
+          const xAxisHeight = isMobile ? 40 : 60;
+          const y = height - padding.bottom + idx * xAxisHeight;
 
           return (
             <g key={`x-axis-spine-${axis.id}`}>
@@ -237,7 +240,9 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
         {xAxes.map((axis, axisIdx) => {
           const axisConf = allXAxes.find(a => a.id === axis.id)!;
           const vp = { xMin: axisConf.min, xMax: axisConf.max, yMin: 0, yMax: 100, width, height, padding };
-          const baseY = padding.bottom - axisIdx * 60;
+          const isMobile = width < 768 || height < 500;
+          const xAxisHeight = isMobile ? 40 : 60;
+          const baseY = padding.bottom - axisIdx * xAxisHeight;
           
           return (
             <React.Fragment key={`x-labels-${axis.id}`}>
@@ -259,8 +264,8 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
                     <div key={`sl-${axis.id}-${sl.timestamp}`} style={{
                       position: 'absolute',
                       left: x,
-                      bottom: baseY - 38,
-                      fontSize: '10px',
+                      bottom: isMobile ? baseY - 28 : baseY - 38,
+                      fontSize: isMobile ? '8px' : '10px',
                       fontWeight: 'bold',
                       color: axis.color,
                       backgroundColor: 'rgba(255,255,255,0.8)',
@@ -281,9 +286,9 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
                 const { x } = worldToScreen(timestamp, 0, vp);
                 if (x < padding.left || x > width - padding.right) return null;
                 const label = typeof t === 'number' ? (Math.abs(t) < 1e-12 ? '0' : t.toFixed(axis.ticks.precision)) : t.label;
-                return <div key={`xl-${axis.id}-${timestamp}`} style={{ position: 'absolute', left: x, bottom: baseY - 22, transform: 'translateX(-50%)', fontSize: '9px', color: axis.color }}>{label}</div>;
+                return <div key={`xl-${axis.id}-${timestamp}`} style={{ position: 'absolute', left: x, bottom: isMobile ? baseY - 16 : baseY - 22, transform: 'translateX(-50%)', fontSize: isMobile ? '8px' : '9px', color: axis.color }}>{label}</div>;
               })}
-              <div style={{ position: 'absolute', bottom: baseY - 52, left: padding.left + (width - padding.left - padding.right) / 2, transform: 'translateX(-50%)', fontSize: '10px', fontWeight: 'bold', color: axis.color, whiteSpace: 'nowrap', maxWidth: width - padding.left - padding.right, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              <div style={{ position: 'absolute', bottom: isMobile ? baseY - 34 : baseY - 52, left: padding.left + (width - padding.left - padding.right) / 2, transform: 'translateX(-50%)', fontSize: isMobile ? '8px' : '10px', fontWeight: 'bold', color: axis.color, whiteSpace: 'nowrap', maxWidth: width - padding.left - padding.right, overflow: 'hidden', textOverflow: 'ellipsis' }}>
                 {axis.title}
               </div>
             </React.Fragment>
@@ -708,12 +713,17 @@ const ChartContainer: React.FC = () => {
 
   const leftAxes = useMemo(() => activeYAxes.filter(a => a.position === 'left'), [activeYAxes]);
   const rightAxes = useMemo(() => activeYAxes.filter(a => a.position === 'right'), [activeYAxes]);
+
+  const isMobile = width < 768 || height < 500;
+  const xAxisHeight = isMobile ? 40 : 60;
+
   const padding = useMemo(() => {
+    const base = isMobile ? BASE_PADDING_MOBILE : BASE_PADDING_DESKTOP;
     const leftSum = leftAxes.reduce((sum, a) => sum + (axisLayout[a.id]?.total || 40), 0);
     const rightSum = rightAxes.reduce((sum, a) => sum + (axisLayout[a.id]?.total || 40), 0);
-    const bottomExtra = Math.max(0, (activeXAxesUsed.length - 1) * 60);
-    return { ...BASE_PADDING, left: BASE_PADDING.left + leftSum, right: BASE_PADDING.right + rightSum, bottom: BASE_PADDING.bottom + bottomExtra };
-  }, [leftAxes, rightAxes, axisLayout, activeXAxesUsed]);
+    const bottomExtra = Math.max(0, (activeXAxesUsed.length - 1) * xAxisHeight);
+    return { ...base, left: base.left + leftSum, right: base.right + rightSum, bottom: base.bottom + bottomExtra };
+  }, [leftAxes, rightAxes, axisLayout, activeXAxesUsed, isMobile, xAxisHeight]);
 
   const chartWidth = Math.max(0, width - padding.left - padding.right), chartHeight = Math.max(0, height - padding.top - padding.bottom);
 
@@ -1284,8 +1294,10 @@ const ChartContainer: React.FC = () => {
       <AxesLayer xAxes={xAxesLayout} yAxes={activeYAxes} width={width} height={height} padding={padding} leftAxes={leftAxes} rightAxes={rightAxes} series={series} axisLayout={axisLayout} allXAxes={xAxes} />
 
       {activeXAxesUsed.map((axis, idx) => {
-        const baseY = (activeXAxesUsed.length - 1 - idx) * 60;
-        return <div key={`wheel-x-${axis.id}`} onWheel={(e) => { e.stopPropagation(); handleWheel(e, { xAxisId: axis.id }); }} onMouseDown={(e) => { e.stopPropagation(); handleMouseDown(e, { xAxisId: axis.id }); }} onTouchStart={(e) => { e.stopPropagation(); handleTouchStart(e, { xAxisId: axis.id }); }} onDoubleClick={(e) => { e.stopPropagation(); handleAutoScaleX(axis.id); }} style={{ position: 'absolute', bottom: baseY, left: padding.left, right: padding.right, height: 60, cursor: 'ew-resize', zIndex: 20 }} />;
+        const isMobile = width < 768 || height < 500;
+        const xAxisHeight = isMobile ? 40 : 60;
+        const baseY = (activeXAxesUsed.length - 1 - idx) * xAxisHeight;
+        return <div key={`wheel-x-${axis.id}`} onWheel={(e) => { e.stopPropagation(); handleWheel(e, { xAxisId: axis.id }); }} onMouseDown={(e) => { e.stopPropagation(); handleMouseDown(e, { xAxisId: axis.id }); }} onTouchStart={(e) => { e.stopPropagation(); handleTouchStart(e, { xAxisId: axis.id }); }} onDoubleClick={(e) => { e.stopPropagation(); handleAutoScaleX(axis.id); }} style={{ position: 'absolute', bottom: baseY, left: padding.left, right: padding.right, height: xAxisHeight, cursor: 'ew-resize', zIndex: 20 }} />;
       })}
 
       {activeYAxes.map((axis) => {

--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,7 @@ body, html, #root {
   flex-direction: column;
   height: 100%;
   overflow-y: auto;
+  transition: width 0.3s ease-in-out, padding 0.3s ease-in-out;
 }
 
 .sidebar-content {
@@ -74,6 +75,13 @@ body, html, #root {
   border-bottom: 2px solid var(--text-color);
 }
 
+@media (max-width: 768px) {
+  .sidebar h2 {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+  }
+}
+
 .section-title {
   font-weight: bold;
   font-size: 0.9rem;
@@ -81,6 +89,14 @@ body, html, #root {
   margin-top: 0.8rem;
   margin-bottom: 0.5rem;
   color: #495057;
+}
+
+@media (max-width: 768px) {
+  .section-title {
+    font-size: 0.8rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.3rem;
+  }
 }
 
 details > summary {


### PR DESCRIPTION
This change optimizes the application for smartphones by introducing a responsive "mobile" mode. When the viewport width is < 768px or the height is < 500px (common for mobile landscape), the following adjustments are applied:
1. The sidebar is collapsed by default to maximize the chart area.
2. The sidebar width is capped at 90% of the viewport width.
3. Chart padding is reduced (top/bottom from 20/60 to 10/40), and X-axis interaction zones/labels are scaled down from 60px to 40px.
4. CSS media queries reduce font sizes and margins for sidebar elements.
5. Smooth transitions are added for sidebar resizing and collapsing.

Verification was performed using Playwright screenshots in both portrait and landscape mobile viewports, confirming that the UI is now fully usable on small screens.

Fixes #85

---
*PR created automatically by Jules for task [10795482221955764154](https://jules.google.com/task/10795482221955764154) started by @michaelkrisper*