### PR TITLE
Implement axis-specific pinch-to-zoom on mobile

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -1122,7 +1122,7 @@ const ChartContainer: React.FC = () => {
       lastTouchPos.current = { x: touch.clientX, y: touch.clientY };
     } else if (e.touches.length === 2) {
       isPanningRef.current = false;
-      setPanTarget(null);
+      setPanTarget(prev => (prev && prev !== 'all') ? prev : target);
       const t1 = e.touches[0], t2 = e.touches[1];
       lastPinchDist.current = Math.hypot(t1.clientX - t2.clientX, t1.clientY - t2.clientY);
     }
@@ -1149,7 +1149,7 @@ const ChartContainer: React.FC = () => {
 
       const centerX = (t1.clientX + t2.clientX) / 2 - rect.left;
       const centerY = (t1.clientY + t2.clientY) / 2 - rect.top;
-      performZoom(zoomFactor, centerX, centerY, 'all');
+      performZoom(zoomFactor, centerX, centerY, panTarget || 'all');
     }
   }, [panTarget, performPan, performZoom]);
 
@@ -1176,6 +1176,21 @@ const ChartContainer: React.FC = () => {
     performPan(dx, dy, panTarget, e.altKey);
   }, [panTarget, padding, width, height, getHoveredAxis, performPan]);
 
+  const handleTouchEnd = useCallback((e: TouchEvent) => {
+    if (e.touches.length === 0) {
+      isPanningRef.current = false;
+      setPanTarget(null);
+      lastTouchPos.current = null;
+      lastPinchDist.current = null;
+    } else if (e.touches.length === 1) {
+      // Transition from pinch to pan
+      const touch = e.touches[0];
+      lastTouchPos.current = { x: touch.clientX, y: touch.clientY };
+      isPanningRef.current = true;
+      lastPinchDist.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     const handleMouseUp = () => {
       if (zoomBoxStartRef.current) {
@@ -1200,12 +1215,6 @@ const ChartContainer: React.FC = () => {
       isPanningRef.current = false;
       setPanTarget(null);
     };
-    const handleTouchEnd = () => {
-      isPanningRef.current = false;
-      setPanTarget(null);
-      lastTouchPos.current = null;
-      lastPinchDist.current = null;
-    };
 
     window.addEventListener('mousemove', handleMouseMoveRaw);
     window.addEventListener('mouseup', handleMouseUp);
@@ -1217,7 +1226,7 @@ const ChartContainer: React.FC = () => {
       window.removeEventListener('touchmove', handleTouchMoveRaw);
       window.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [handleMouseMoveRaw, handleTouchMoveRaw, activeYAxes, width, height, padding, startAnimation]);
+  }, [handleMouseMoveRaw, handleTouchMoveRaw, handleTouchEnd, activeXAxesUsed, activeYAxes, width, height, padding, startAnimation]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {


### PR DESCRIPTION
The changes allow users to pinch-zoom on a specific axis (X or Y) to zoom only that axis, while pinching in the main chart area continues to zoom both axes as before. This is achieved by preserving the `panTarget` (the axis or the whole chart) when multiple fingers are detected during the touch start phase. Additionally, the touch end logic was improved to allow for a seamless transition when one finger is lifted during a pinch, transitioning back to a single-finger pan on the same axis or area.

Fixes #88

---
*PR created automatically by Jules for task [18086151724420300072](https://jules.google.com/task/18086151724420300072) started by @michaelkrisper*