### PR TITLE
Professional Design & Color Palette Update

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -13,9 +13,7 @@ import { HelpModal } from './HelpModal';
 import { LicenseModal } from './LicenseModal';
 
 const COLOR_PALETTE = [
-  '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', 
-  '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
-  '#aec6e7', '#ffbb78', '#98df8a', '#ff9896', '#c5b0d5', '#c49c94'
+  '#2563eb', '#e11d48', '#059669', '#d97706', '#7c3aed', '#db2777', '#0891b2', '#ea580c'
 ];
 
 /**
@@ -202,7 +200,7 @@ export const Sidebar: React.FC = () => {
         }}
       >
         <div className={`sidebar-content ${isCollapsed ? 'hidden' : ''}`}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem', borderBottom: '2px solid #212529', paddingBottom: '0.5rem' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem', borderBottom: '2px solid var(--text-color)', paddingBottom: '0.5rem' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
               <img src="./favicon.svg" alt="logo" style={{ width: '24px', height: '24px', borderRadius: '4px' }} />
               <h2 style={{ margin: 0, border: 'none', padding: 0 }}>WebGraphy</h2>
@@ -210,7 +208,7 @@ export const Sidebar: React.FC = () => {
                 onClick={() => setShowHelp(true)}
                 title="Help & Interactions"
                 aria-label="Help & Interactions"
-                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '0', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#007bff' }}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '0', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#3b82f6' }}
               >
                 <HelpCircle size={18} />
               </button>
@@ -230,7 +228,7 @@ export const Sidebar: React.FC = () => {
               <button
                 disabled={isImporting}
                 onClick={() => fileInputRef.current?.click()}
-                style={{ padding: '4px 8px', cursor: 'pointer', background: '#007bff', color: '#fff', border: 'none', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                style={{ padding: '4px 8px', cursor: 'pointer', background: '#3b82f6', color: '#fff', border: 'none', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
               >
                 {isImporting ? '...' : <Upload size={14} />}
               </button>
@@ -249,7 +247,7 @@ export const Sidebar: React.FC = () => {
             </div>
             {openSections.sources && <div className="sources-list" style={{ marginBottom: '1rem' }}>
               {datasets.map(d => (
-                <div key={d.id} style={{ padding: '8px', border: '1px solid #dee2e6', borderRadius: '4px', background: '#fff', marginBottom: '8px' }}>
+                <div key={d.id} style={{ padding: '8px', border: '1px solid var(--border-color)', borderRadius: '4px', background: '#fff', marginBottom: '8px' }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
                     <div
                       onDoubleClick={() => setViewingDatasetId(d.id)}
@@ -266,7 +264,7 @@ export const Sidebar: React.FC = () => {
                           aria-label={`X Column for ${d.name}`}
                           value={d.xAxisColumn}
                           onChange={(e) => updateDataset(d.id, { xAxisColumn: e.target.value })}
-                          style={{ width: '70px', fontSize: '9px', padding: '1px', height: '18px', minWidth: 0, flexShrink: 1, border: '1px solid #e3f2fd', color: '#1976d2', borderRadius: '2px' }}
+                          style={{ width: '70px', fontSize: '9px', padding: '1px', height: '18px', minWidth: 0, flexShrink: 1, border: '1px solid #cbd5e1', color: '#475569', borderRadius: '2px', background: '#f8fafc' }}
                           title="X Column (Source Wide)"
                         >
                           {d.columns.map(c => <option key={c} value={c}>{c}</option>)}
@@ -277,7 +275,7 @@ export const Sidebar: React.FC = () => {
                             const nextXIdx = (currentXIdx % 9) + 1;
                             updateDataset(d.id, { xAxisId: `axis-${nextXIdx}` });
                           }}
-                          style={{ width: '18px', height: '18px', fontSize: '10px', padding: '0', cursor: 'pointer', background: '#e3f2fd', border: '1px solid #90caf9', borderRadius: '2px', fontWeight: 'bold', flexShrink: 0, color: '#1976d2' }}
+                          style={{ width: '18px', height: '18px', fontSize: '10px', padding: '0', cursor: 'pointer', background: '#f1f5f9', border: '1px solid #cbd5e1', borderRadius: '2px', fontWeight: 'bold', flexShrink: 0, color: '#475569' }}
                           title="Cycle X-Axis (1-9)"
                           aria-label="Cycle X-Axis">
                           {parseInt(d.xAxisId?.split('-')[1]) || 1}
@@ -291,7 +289,7 @@ export const Sidebar: React.FC = () => {
                             const { updateXAxis } = useGraphStore.getState();
                             updateXAxis(axisId, { xMode: e.target.value as 'date' | 'numeric' });
                           }}
-                          style={{ width: '45px', fontSize: '9px', padding: '1px', height: '18px', minWidth: 0, flexShrink: 1, border: '1px solid #e3f2fd', color: '#1976d2', borderRadius: '2px' }}
+                          style={{ width: '45px', fontSize: '9px', padding: '1px', height: '18px', minWidth: 0, flexShrink: 1, border: '1px solid #cbd5e1', color: '#475569', borderRadius: '2px', background: '#f8fafc' }}
                           title="X-Axis Mode (Time / Decimal)"
                         >
                           <option value="date">Time</option>
@@ -300,11 +298,11 @@ export const Sidebar: React.FC = () => {
                       </div>
 
                       <div style={{ fontSize: '0.75rem', color: '#666' }}>{d.rowCount.toLocaleString()} rows</div>
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: '1px', background: '#eef1f4', borderRadius: '3px', padding: '1px' }}>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '1px', background: '#f1f5f9', borderRadius: '3px', padding: '1px' }}>
                         <button
                           onClick={() => moveDataset(d.id, -1)}
                           disabled={datasets.indexOf(d) === 0}
-                          style={{ padding: '0', cursor: 'pointer', background: 'none', border: 'none', color: '#444', height: '11px', display: 'flex', alignItems: 'center', opacity: datasets.indexOf(d) === 0 ? 0.3 : 1 }}
+                          style={{ padding: '0', cursor: 'pointer', background: 'none', border: 'none', color: '#475569', height: '11px', display: 'flex', alignItems: 'center', opacity: datasets.indexOf(d) === 0 ? 0.3 : 1 }}
                           title="Move Up"
                         >
                           <ChevronUp size={12} strokeWidth={3} />
@@ -312,7 +310,7 @@ export const Sidebar: React.FC = () => {
                         <button
                           onClick={() => moveDataset(d.id, 1)}
                           disabled={datasets.indexOf(d) === datasets.length - 1}
-                          style={{ padding: '0', cursor: 'pointer', background: 'none', border: 'none', color: '#444', height: '11px', display: 'flex', alignItems: 'center', opacity: datasets.indexOf(d) === datasets.length - 1 ? 0.3 : 1 }}
+                          style={{ padding: '0', cursor: 'pointer', background: 'none', border: 'none', color: '#475569', height: '11px', display: 'flex', alignItems: 'center', opacity: datasets.indexOf(d) === datasets.length - 1 ? 0.3 : 1 }}
                           title="Move Down"
                         >
                           <ChevronDown size={12} strokeWidth={3} />
@@ -323,7 +321,7 @@ export const Sidebar: React.FC = () => {
                           await persistence.deleteDataset(d.id);
                           removeDataset(d.id);
                         }} 
-                        style={{ padding: '2px', cursor: 'pointer', background: 'none', border: 'none', color: '#dc3545', display: 'flex' }}
+                        style={{ padding: '2px', cursor: 'pointer', background: 'none', border: 'none', color: '#ef4444', display: 'flex' }}
                         title="Remove data source"
                         aria-label="Remove data source"
                       >
@@ -332,7 +330,7 @@ export const Sidebar: React.FC = () => {
                     </div>
                   </div>
                   <details>
-                    <summary style={{ fontSize: '0.8rem', cursor: 'pointer', userSelect: 'none', marginBottom: '8px', color: '#495057', display: 'flex', alignItems: 'center' }}>
+                    <summary style={{ fontSize: '0.8rem', cursor: 'pointer', userSelect: 'none', marginBottom: '8px', color: '#64748b', display: 'flex', alignItems: 'center' }}>
                       <ChevronRight size={14} className="details-chevron" />
                       <span style={{ flex: 1 }}>Columns ({d.columns.length})</span>
                     </summary>
@@ -365,7 +363,7 @@ export const Sidebar: React.FC = () => {
                         <button 
                           key={col} 
                           onClick={() => createSeries(d.id, col)}
-                          style={{ fontSize: '10px', padding: '2px 4px', cursor: 'pointer', background: '#e9ecef', border: '1px solid #ced4da', borderRadius: '3px' }}
+                          style={{ fontSize: '10px', padding: '2px 4px', cursor: 'pointer', background: '#f1f5f9', border: '1px solid #cbd5e1', borderRadius: '3px', color: '#475569' }}
                         >
                           {col}
                         </button>
@@ -415,21 +413,21 @@ export const Sidebar: React.FC = () => {
               </button>
               <button
                 onClick={(e) => { e.stopPropagation(); saveView(''); }}
-                style={{ padding: '4px 8px', cursor: 'pointer', background: '#007bff', color: '#fff', border: 'none', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                style={{ padding: '4px 8px', cursor: 'pointer', background: '#3b82f6', color: '#fff', border: 'none', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
               >
                 <Bookmark size={14} />
               </button>
             </div>
-            {openSections.views && <div style={{ padding: '8px', border: '1px solid #dee2e6', borderRadius: '4px', background: '#fff', marginBottom: '1rem' }}>
+            {openSections.views && <div style={{ padding: '8px', border: '1px solid var(--border-color)', borderRadius: '4px', background: '#fff', marginBottom: '1rem' }}>
               
               {customViews.length === 0 && (
-                <div style={{ fontSize: '12px', color: '#666', textAlign: 'center', padding: '4px' }}>No saved views.</div>
+                <div style={{ fontSize: '12px', color: '#64748b', textAlign: 'center', padding: '4px' }}>No saved views.</div>
               )}
               
               {customViews.length > 0 && (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
                   {customViews.map(v => (
-                    <div key={v.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px', background: '#f8f9fa', borderRadius: '3px', border: '1px solid #e9ecef' }}>
+                    <div key={v.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px', background: '#f8fafc', borderRadius: '3px', border: '1px solid #e2e8f0' }}>
                       {editingViewId === v.id ? (
                         <input
                           autoFocus
@@ -464,7 +462,7 @@ export const Sidebar: React.FC = () => {
                       <div style={{ display: 'flex', gap: '4px' }}>
                         <button 
                           onClick={() => applyView(v.id)}
-                          style={{ padding: '2px', cursor: 'pointer', background: 'none', border: 'none', color: '#4CAF50', display: 'flex' }}
+                          style={{ padding: '2px', cursor: 'pointer', background: 'none', border: 'none', color: '#10b981', display: 'flex' }}
                           title="Apply view bounds"
                           aria-label="Apply view bounds"
                         >
@@ -472,7 +470,7 @@ export const Sidebar: React.FC = () => {
                         </button>
                         <button 
                           onClick={() => deleteView(v.id)}
-                          style={{ padding: '2px', cursor: 'pointer', background: 'none', border: 'none', color: '#dc3545', display: 'flex' }}
+                          style={{ padding: '2px', cursor: 'pointer', background: 'none', border: 'none', color: '#ef4444', display: 'flex' }}
                           title="Delete view"
                           aria-label="Delete view"
                         >
@@ -490,13 +488,13 @@ export const Sidebar: React.FC = () => {
             <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
               <button
                 onClick={handleExportSVG}
-                style={{ flex: 1, padding: '8px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}
+                style={{ flex: 1, padding: '8px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px', background: '#fff', border: '1px solid var(--border-color)', borderRadius: '4px', color: 'var(--text-color)', fontSize: '12px' }}
               >
                 <FileImage size={14} /> Export SVG
               </button>
               <button
                 onClick={handleExportPNG}
-                style={{ flex: 1, padding: '8px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}
+                style={{ flex: 1, padding: '8px', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px', background: '#fff', border: '1px solid var(--border-color)', borderRadius: '4px', color: 'var(--text-color)', fontSize: '12px' }}
               >
                 <Image size={14} /> Export PNG
               </button>
@@ -517,7 +515,7 @@ export const Sidebar: React.FC = () => {
                     };
                   }
                 }}
-                style={{ flex: 1, padding: '8px', cursor: 'pointer', background: '#fff', color: '#007bff', border: '1px solid #007bff', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}
+                style={{ flex: 1, padding: '8px', cursor: 'pointer', background: '#fff', color: '#3b82f6', border: '1px solid #3b82f6', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px', fontSize: '12px' }}
               >
                 <RotateCcw size={14} /> Demo
               </button>
@@ -535,7 +533,7 @@ export const Sidebar: React.FC = () => {
                     };
                   }
                 }}
-                style={{ flex: 1, padding: '8px', cursor: 'pointer', background: '#fff', color: '#dc3545', border: '1px solid #dc3545', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}
+                style={{ flex: 1, padding: '8px', cursor: 'pointer', background: '#fff', color: '#ef4444', border: '1px solid #ef4444', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px', fontSize: '12px' }}
               >
                 <RotateCcw size={14} /> Reset
               </button>
@@ -572,7 +570,7 @@ export const Sidebar: React.FC = () => {
               bottom: 0,
               width: '5px',
               cursor: 'col-resize',
-              background: isResizing ? '#007bff' : 'transparent',
+              background: isResizing ? '#3b82f6' : 'transparent',
               zIndex: 10,
               transition: 'background 0.2s'
             }}

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -67,7 +67,7 @@ const GridLines = React.memo(({ xAxes, yAxes, width, height, padding }: GridLine
         return axis.ticks.result.map((t: any) => {
           const timestamp = typeof t === 'number' ? t : t.timestamp;
           const { x } = worldToScreen(timestamp, 0, vp);
-          return <line key={`gx-${timestamp}`} x1={x} y1={padding.top} x2={x} y2={height - padding.bottom} stroke="#f0f0f0" strokeWidth="1" />;
+          return <line key={`gx-${timestamp}`} x1={x} y1={padding.top} x2={x} y2={height - padding.bottom} stroke="#f1f5f9" strokeWidth="1" />;
         });
       })()}
       {yAxes.map((axis: YAxisConfig) => {
@@ -89,7 +89,7 @@ const GridLines = React.memo(({ xAxes, yAxes, width, height, padding }: GridLine
         const mainXConf = useGraphStore.getState().xAxes[0];
         return result.map(t => {
           const { y } = worldToScreen(mainXConf.min, t, { xMin: mainXConf.min, xMax: mainXConf.max, yMin: axis.min, yMax: axis.max, width, height, padding });
-          return <line key={`gy-${axis.id}-${t}`} x1={padding.left} y1={y} x2={width - padding.right} y2={y} stroke="#f0f0f0" strokeWidth="1" />;
+          return <line key={`gy-${axis.id}-${t}`} x1={padding.left} y1={y} x2={width - padding.right} y2={y} stroke="#f1f5f9" strokeWidth="1" />;
         });
       })}
     </svg>
@@ -111,7 +111,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
       <svg width="100%" height="100%" style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 6 }}>
         <defs>
           <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
-            <path d="M 0 0 L 10 5 L 0 10 z" fill="#333" />
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569" />
           </marker>
         </defs>
         
@@ -119,7 +119,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
         <path 
           d={`M${padding.left},${height - padding.bottom} V${padding.top} H${width - padding.right} V${height - padding.bottom}`} 
           fill="none" 
-          stroke="#333" 
+          stroke="#475569"
           strokeWidth="2" 
         />
         
@@ -138,7 +138,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
                 y1={y}
                 x2={width - padding.right + 8}
                 y2={y}
-                stroke="#333"
+                stroke="#475569"
                 strokeWidth="1"
                 markerEnd="url(#arrow)"
               />
@@ -147,7 +147,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
               {axis.ticks.result.map((t: any) => {
                 const { x } = worldToScreen(typeof t === 'number' ? t : t.timestamp, 0, vp);
                 if (x < padding.left || x > width - padding.right) return null;
-                return <line key={`xt-${axis.id}-${typeof t === 'number' ? t : t.timestamp}`} x1={x} y1={y} x2={x} y2={y + 6} stroke="#333" strokeWidth="1" />;
+                return <line key={`xt-${axis.id}-${typeof t === 'number' ? t : t.timestamp}`} x1={x} y1={y} x2={x} y2={y + 6} stroke="#475569" strokeWidth="1" />;
               })}
 
               {/* 0 line if visible */}
@@ -157,7 +157,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
                   y1={height - padding.bottom}
                   x2={worldToScreen(0, 0, vp).x}
                   y2={padding.top - 8}
-                  stroke="#666"
+                  stroke="#94a3b8"
                   strokeWidth="1"
                   strokeDasharray="4 4"
                   markerEnd="url(#arrow)"
@@ -178,7 +178,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
                 y1={worldToScreen(mainXConf.min, 0, axisVp).y}
                 x2={width - padding.right + 8} 
                 y2={worldToScreen(mainXConf.min, 0, axisVp).y}
-                stroke="#666" 
+                stroke="#94a3b8"
                 strokeWidth="1" 
                 strokeDasharray="4 4"
                 markerEnd="url(#arrow)" 
@@ -221,7 +221,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
                 y1={height - padding.bottom} 
                 x2={axisLineX} 
                 y2={padding.top - 8} 
-                stroke="#333" 
+                stroke="#475569"
                 strokeWidth="1" 
                 markerEnd="url(#arrow)"
               />
@@ -230,7 +230,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
                 const { y } = worldToScreen(mainXConf.min, t, { xMin: mainXConf.min, xMax: mainXConf.max, yMin: axis.min, yMax: axis.max, width, height, padding });
                 const x1 = isLeft ? axisLineX - 5 : axisLineX;
                 const x2 = isLeft ? axisLineX : axisLineX + 5;
-                return <line key={`yt-${axis.id}-${t}`} x1={x1} y1={y} x2={x2} y2={y} stroke="#333" strokeWidth="1" />;
+                return <line key={`yt-${axis.id}-${t}`} x1={x1} y1={y} x2={x2} y2={y} stroke="#475569" strokeWidth="1" />;
               })}
             </g>
           );
@@ -331,9 +331,9 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
               {result.map(t => {
                 const { y } = worldToScreen(mainXConf.min, t, { xMin: mainXConf.min, xMax: mainXConf.max, yMin: axis.min, yMax: axis.max, width, height, padding });
                 const label = Math.abs(t) < 1e-12 ? '0' : t.toFixed(precision);
-                return <div key={`yl-${axis.id}-${t}`} style={{ position: 'absolute', left: labelX, top: y, transform: 'translateY(-50%)', fontSize: '9px', color: '#333', width: axisMetrics.label, textAlign: isLeft ? 'right' : 'left' }}>{label}</div>;
+                return <div key={`yl-${axis.id}-${t}`} style={{ position: 'absolute', left: labelX, top: y, transform: 'translateY(-50%)', fontSize: '9px', color: '#475569', width: axisMetrics.label, textAlign: isLeft ? 'right' : 'left' }}>{label}</div>;
               })}
-              <div style={{ position: 'absolute', top: padding.top + chartHeight / 2, left: titleX, transform: `translate(-50%, -50%) rotate(${isLeft ? -90 : 90}deg)`, fontSize: '12px', fontWeight: 'bold', color: axisSeries[0]?.lineColor || '#333', padding: '2px 4px', borderRadius: '2px', whiteSpace: 'nowrap', textAlign: 'center', maxWidth: chartHeight, overflow: 'hidden', textOverflow: 'ellipsis' }}>{title}</div>
+              <div style={{ position: 'absolute', top: padding.top + chartHeight / 2, left: titleX, transform: `translate(-50%, -50%) rotate(${isLeft ? -90 : 90}deg)`, fontSize: '12px', fontWeight: 'bold', color: axisSeries[0]?.lineColor || '#475569', padding: '2px 4px', borderRadius: '2px', whiteSpace: 'nowrap', textAlign: 'center', maxWidth: chartHeight, overflow: 'hidden', textOverflow: 'ellipsis' }}>{title}</div>
             </React.Fragment>
           );
         })}
@@ -506,7 +506,7 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
         group = { xLabel: xLab, items: [] };
         entries.push(group);
       }
-      group.items.push({ label: displayLabel, value: yVal, color: s.lineColor || '#333' });
+      group.items.push({ label: displayLabel, value: yVal, color: s.lineColor || '#475569' });
     });
 
     // Screen position of the snapped point
@@ -527,7 +527,7 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
   return (
     <>
       <svg width="100%" height="100%" style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 15 }}>
-        <line x1={snapScreenX} y1={padding.top} x2={snapScreenX} y2={height - padding.bottom} stroke="#aaa" strokeWidth="1" strokeDasharray="3 3" />
+        <line x1={snapScreenX} y1={padding.top} x2={snapScreenX} y2={height - padding.bottom} stroke="#cbd5e1" strokeWidth="1" strokeDasharray="3 3" />
       </svg>
       <div style={{
         position: 'absolute',
@@ -535,26 +535,26 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
         right: isTooltipOnRight ? 'auto' : (width - snapScreenX) + 12,
         top: isTooltipBelow ? pos.y + 15 : 'auto',
         bottom: isTooltipBelow ? 'auto' : (height - pos.y) + 15,
-        backgroundColor: 'rgba(255,255,255,0.92)',
-        color: '#333',
-        padding: '6px 10px',
-        borderRadius: '5px',
+        backgroundColor: 'rgba(255, 255, 255, 0.95)',
+        color: '#1e293b',
+        padding: '8px 12px',
+        borderRadius: '8px',
         fontSize: '10px',
         fontFamily: 'monospace',
         pointerEvents: 'none',
         zIndex: 100,
-        boxShadow: '0 2px 10px rgba(0,0,0,0.12)',
+        boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
         backdropFilter: 'blur(4px)',
-        border: '1px solid rgba(0,0,0,0.08)',
+        border: '1px solid #e2e8f0',
         whiteSpace: 'pre',
         lineHeight: '1.2',
         maxWidth: 320
       }}>
         {entries.length > 0 && (
-          <div style={{ display: 'grid', gridTemplateColumns: 'auto minmax(auto, 1fr) auto auto', columnGap: '4px', rowGap: '4px' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'auto minmax(auto, 1fr) auto auto', columnGap: '12px', rowGap: '4px' }}>
             {entries.map((group, groupIdx) => (
               <React.Fragment key={`group-${groupIdx}`}>
-                <div style={{ color: '#666', textAlign: 'right', gridColumn: '1 / span 4', fontSize: '8px', borderBottom: '1px solid rgba(0,0,0,0.04)', marginTop: groupIdx > 0 ? '4px' : 0 }}>X: {group.xLabel}</div>
+                <div style={{ color: '#64748b', textAlign: 'right', gridColumn: '1 / span 4', fontSize: '8px', borderBottom: '1px solid rgba(0,0,0,0.04)', marginTop: groupIdx > 0 ? '4px' : 0 }}>X: {group.xLabel}</div>
                 {group.items.map((item, itemIdx) => {
                   // Strip Float32 garbage using toPrecision(7) as Float32 supports ~7 significant digits
                   const cleanValue = parseFloat(item.value.toPrecision(7));
@@ -569,8 +569,8 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
                   return (
                     <React.Fragment key={`item-${groupIdx}-${itemIdx}`}>
                       <div style={{ color: item.color, textAlign: 'right' }}>{item.label}:</div>
-                      <div style={{ color: '#333', fontWeight: 'bold', textAlign: 'right' }}>{intPart}</div>
-                      <div style={{ color: '#333', fontWeight: 'bold', textAlign: 'left' }}>{decPart}</div>
+                      <div style={{ color: '#1e293b', fontWeight: 'bold', textAlign: 'right' }}>{intPart}</div>
+                      <div style={{ color: '#1e293b', fontWeight: 'bold', textAlign: 'left' }}>{decPart}</div>
                       <div></div> {/* empty grid cell for the 4th column */}
                     </React.Fragment>
                   );
@@ -1270,7 +1270,7 @@ const ChartContainer: React.FC = () => {
       const datasetsForThisAxis = datasets.filter(d => (d.xAxisId || 'axis-1') === axis.id && series.some(s => s.sourceId === d.id));
       const seriesForThisAxis = series.filter(s => datasetsForThisAxis.some(d => d.id === s.sourceId));
       const title = Array.from(new Set(datasetsForThisAxis.map(d => d.xAxisColumn))).join(' / ');
-      const color = seriesForThisAxis[0]?.lineColor || '#333';
+      const color = seriesForThisAxis[0]?.lineColor || '#475569';
 
       if (range <= 0 || chartWidth <= 0) return { id: axis.id, ticks: { result: [], step: 1, precision: 0, isXDate: false as const }, title, color };
 

--- a/src/components/Sidebar/SeriesConfig.tsx
+++ b/src/components/Sidebar/SeriesConfig.tsx
@@ -60,13 +60,13 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
   };
 
   return (
-    <div style={{ borderBottom: '1px solid #dee2e6', padding: '4px 0', fontSize: '11px', display: 'flex', gap: '4px', alignItems: 'center' }}>
+    <div style={{ borderBottom: '1px solid #e2e8f0', padding: '4px 0', fontSize: '11px', display: 'flex', gap: '4px', alignItems: 'center' }}>
       {/* Reorder Buttons (UP/DOWN) */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '1px', background: '#eef1f4', borderRadius: '3px', padding: '1px' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1px', background: '#f1f5f9', borderRadius: '3px', padding: '1px' }}>
         <button
           onClick={(e) => { e.stopPropagation(); onMove?.(1); }}
           disabled={isFirst}
-          style={{ padding: '0', cursor: isFirst ? 'default' : 'pointer', background: 'none', border: 'none', color: isFirst ? '#ccc' : '#444', height: '11px', display: 'flex', alignItems: 'center', opacity: isFirst ? 0.3 : 1 }}
+          style={{ padding: '0', cursor: isFirst ? 'default' : 'pointer', background: 'none', border: 'none', color: isFirst ? '#cbd5e1' : '#475569', height: '11px', display: 'flex', alignItems: 'center', opacity: isFirst ? 0.3 : 1 }}
           title="Move Up (Layer Forward)"
          aria-label="Move Up">
           <ChevronUp size={12} strokeWidth={3} />
@@ -74,7 +74,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
         <button
           onClick={(e) => { e.stopPropagation(); onMove?.(-1); }}
           disabled={isLast}
-          style={{ padding: '0', cursor: isLast ? 'default' : 'pointer', background: 'none', border: 'none', color: isLast ? '#ccc' : '#444', height: '11px', display: 'flex', alignItems: 'center', opacity: isLast ? 0.3 : 1 }}
+          style={{ padding: '0', cursor: isLast ? 'default' : 'pointer', background: 'none', border: 'none', color: isLast ? '#cbd5e1' : '#475569', height: '11px', display: 'flex', alignItems: 'center', opacity: isLast ? 0.3 : 1 }}
           title="Move Down (Layer Backward)"
          aria-label="Move Down">
           <ChevronDown size={12} strokeWidth={3} />
@@ -84,7 +84,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
       {/* Y Axis Cycle Button (1-9) */}
       <button
         onClick={cycleYAxis}
-        style={{ width: '18px', height: '18px', fontSize: '10px', padding: '0', cursor: 'pointer', background: '#f8f9fa', border: '1px solid #ced4da', borderRadius: '2px', fontWeight: 'bold', flexShrink: 0 }}
+        style={{ width: '18px', height: '18px', fontSize: '10px', padding: '0', cursor: 'pointer', background: '#f8fafc', border: '1px solid #cbd5e1', borderRadius: '2px', fontWeight: 'bold', flexShrink: 0, color: '#475569' }}
         title="Cycle Y-Axis (1-9)"
        aria-label="Cycle Y-Axis">
         {currentYAxisIndex}
@@ -94,7 +94,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
       {currentYAxis && (
         <button
           onClick={() => updateYAxis(currentYAxis.id, { position: currentYAxis.position === 'left' ? 'right' : 'left' })}
-          style={{ width: '18px', height: '18px', fontSize: '9px', padding: '0', cursor: 'pointer', background: '#e9ecef', border: '1px solid #ced4da', borderRadius: '2px', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          style={{ width: '18px', height: '18px', fontSize: '9px', padding: '0', cursor: 'pointer', background: '#f1f5f9', border: '1px solid #cbd5e1', borderRadius: '2px', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#475569' }}
           title={currentYAxis.position === 'left' ? "Left Axis" : "Right Axis"}
          aria-label="Toggle Left/Right Axis">
           {currentYAxis.position === 'left' ? (
@@ -113,7 +113,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
       {currentYAxis && (
         <button
           onClick={() => updateYAxis(currentYAxis.id, { showGrid: !currentYAxis.showGrid })}
-          style={{ width: '18px', height: '18px', padding: '0', cursor: 'pointer', background: currentYAxis.showGrid ? '#e9ecef' : '#f8f9fa', border: '1px solid #ced4da', borderRadius: '2px', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}
+          style={{ width: '18px', height: '18px', padding: '0', cursor: 'pointer', background: currentYAxis.showGrid ? '#f1f5f9' : '#f8fafc', border: '1px solid #cbd5e1', borderRadius: '2px', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, color: '#475569' }}
           title="Toggle Grid"
          aria-label="Toggle Grid">
           {currentYAxis.showGrid ? <Rows size={10} /> : <Square size={10} />}
@@ -127,7 +127,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
           const next = styles[(styles.indexOf(series.lineStyle) + 1) % styles.length];
           handleUpdate({ lineStyle: next });
         }}
-        style={{ padding: '0', cursor: 'pointer', background: '#f8f9fa', border: '1px solid #ced4da', borderRadius: '2px', display: 'flex', alignItems: 'center', justifyContent: 'center', width: '20px', height: '20px', flexShrink: 0 }}
+        style={{ padding: '0', cursor: 'pointer', background: '#f8fafc', border: '1px solid #cbd5e1', borderRadius: '2px', display: 'flex', alignItems: 'center', justifyContent: 'center', width: '20px', height: '20px', flexShrink: 0, color: '#475569' }}
         title={`Line Style: ${series.lineStyle}`}
        aria-label="Cycle Line Style">
         {renderLineStyleIcon()}
@@ -140,7 +140,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
           const next = styles[(styles.indexOf(series.pointStyle) + 1) % styles.length];
           handleUpdate({ pointStyle: next });
         }}
-        style={{ padding: '0', cursor: 'pointer', background: 'none', border: '1px solid #ced4da', borderRadius: '2px', display: 'flex', alignItems: 'center', justifyContent: 'center', width: '18px', height: '18px', flexShrink: 0 }}
+        style={{ padding: '0', cursor: 'pointer', background: 'none', border: '1px solid #cbd5e1', borderRadius: '2px', display: 'flex', alignItems: 'center', justifyContent: 'center', width: '18px', height: '18px', flexShrink: 0, color: '#475569' }}
         title="Point Style"
        aria-label="Cycle Point Style">
         {renderPointStyleIcon()}
@@ -167,7 +167,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
           aria-label={`Y Column for ${series.name || series.yColumn}`}
           value={series.yColumn}
           onChange={(e) => handleUpdate({ yColumn: e.target.value })}
-          style={{ width: '70px', fontSize: '8px', padding: '1px', height: '18px', minWidth: 0, flexShrink: 1, borderRadius: '2px', border: '1px solid #ced4da' }}
+          style={{ width: '70px', fontSize: '8px', padding: '1px', height: '18px', minWidth: 0, flexShrink: 1, borderRadius: '2px', border: '1px solid #cbd5e1', color: '#475569', background: '#f8fafc' }}
           title="Y Column"
         >
           {dataset?.columns.map(c => <option key={c} value={c}>{c}</option>)}
@@ -203,7 +203,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
       </div>
 
       {/* Delete Button */}
-      <button onClick={() => removeSeries(series.id)} style={{ padding: '2px', cursor: 'pointer', color: '#dc3545', border: 'none', background: 'none', flexShrink: 0 }} title="Delete" aria-label="Delete Series">
+      <button onClick={() => removeSeries(series.id)} style={{ padding: '2px', cursor: 'pointer', color: '#ef4444', border: 'none', background: 'none', flexShrink: 0 }} title="Delete" aria-label="Delete Series">
         <Trash2 size={12} />
       </button>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,9 @@
 :root {
   --sidebar-width: 300px;
   --bg-color: #ffffff;
-  --sidebar-bg: #f8f9fa;
-  --border-color: #dee2e6;
-  --text-color: #212529;
+  --sidebar-bg: #f8fafc;
+  --border-color: #e2e8f0;
+  --text-color: #1e293b;
 }
 
 * {

--- a/src/services/demoData.ts
+++ b/src/services/demoData.ts
@@ -85,7 +85,7 @@ export const getDemoAppState = (dataset: Dataset): AppState => {
     min: 0,
     max: 100,
     position: i % 2 === 0 ? 'left' : 'right',
-    color: '#333',
+    color: '#475569',
     showGrid: i === 0
   }));
 
@@ -97,9 +97,9 @@ export const getDemoAppState = (dataset: Dataset): AppState => {
       yColumn: dataset.columns[1],
       yAxisId: 'axis-1',
       pointStyle: 'none',
-      pointColor: '#1f77b4',
+      pointColor: '#2563eb',
       lineStyle: 'solid',
-      lineColor: '#1f77b4'
+      lineColor: '#2563eb'
     },
     {
       id: crypto.randomUUID(),
@@ -108,9 +108,9 @@ export const getDemoAppState = (dataset: Dataset): AppState => {
       yColumn: dataset.columns[2],
       yAxisId: 'axis-2',
       pointStyle: 'none',
-      pointColor: '#ff7f0e',
+      pointColor: '#e11d48',
       lineStyle: 'solid',
-      lineColor: '#ff7f0e'
+      lineColor: '#e11d48'
     }
   ];
 

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -55,7 +55,7 @@ const createInitialYAxes = (): YAxisConfig[] => {
     min: 0,
     max: 100,
     position: i % 2 === 0 ? 'left' : 'right',
-    color: '#333',
+    color: '#475569',
     showGrid: i === 0
   }));
 };


### PR DESCRIPTION
This change updates the application's visual identity to be "extremely professional." It replaces generic grays and Bootstrap-style blues with a cohesive design system based on a Slate palette. 

Key improvements:
- **Global Theme:** Introduced `--sidebar-bg`, `--border-color`, and `--text-color` using Slate-50, Slate-200, and Slate-800.
- **Series Palette:** Swapped the 16-color D3 palette for a curated 8-color professional set (Blue, Rose, Emerald, Amber, Violet, Pink, Cyan, Orange).
- **Chart Visuals:** Grid lines are now a subtle `#f1f5f9`, axis spines/ticks use `#475569`, and the 0-line is `#94a3b8`.
- **Tooltip Enhancement:** Added `8px` border radius, improved shadows, and increased column gap to `12px` for better readability.
- **UI Consistency:** Updated borders, backgrounds, and icons in the Sidebar and SeriesConfig to use the new Slate-based theme.

Fixes #91

---
*PR created automatically by Jules for task [10461106468225624113](https://jules.google.com/task/10461106468225624113) started by @michaelkrisper*