### PR TITLE
Reduce Tooltip Precision and Fix Y-Value Spacing

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -551,7 +551,7 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
         maxWidth: 320
       }}>
         {entries.length > 0 && (
-          <div style={{ display: 'grid', gridTemplateColumns: 'auto minmax(auto, 1fr) auto auto', columnGap: '12px', rowGap: '4px' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'auto minmax(auto, 1fr) auto auto', columnGap: '0px', rowGap: '4px' }}>
             {entries.map((group, groupIdx) => (
               <React.Fragment key={`group-${groupIdx}`}>
                 <div style={{ color: '#64748b', textAlign: 'right', gridColumn: '1 / span 4', fontSize: '8px', borderBottom: '1px solid rgba(0,0,0,0.04)', marginTop: groupIdx > 0 ? '4px' : 0 }}>X: {group.xLabel}</div>
@@ -568,10 +568,10 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
 
                   return (
                     <React.Fragment key={`item-${groupIdx}-${itemIdx}`}>
-                      <div style={{ color: item.color, textAlign: 'right' }}>{item.label}:</div>
+                      <div style={{ color: item.color, textAlign: 'right', paddingRight: '12px' }}>{item.label}:</div>
                       <div style={{ color: '#1e293b', fontWeight: 'bold', textAlign: 'right' }}>{intPart}</div>
                       <div style={{ color: '#1e293b', fontWeight: 'bold', textAlign: 'left' }}>{decPart}</div>
-                      <div></div> {/* empty grid cell for the 4th column */}
+                      <div style={{ width: '12px' }}></div> {/* spacer for right alignment padding */}
                     </React.Fragment>
                   );
                 })}

--- a/src/utils/__tests__/time.test.ts
+++ b/src/utils/__tests__/time.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { formatFullDate } from '../time';
+
+describe('formatFullDate', () => {
+    it('removes fractional seconds if they are zero', () => {
+        const ts = 1673784000; // 2023-01-15 12:00:00
+        expect(formatFullDate(ts)).toBe('15.01.2023, 12:00:00');
+    });
+
+    it('keeps fractional seconds if they are non-zero', () => {
+        const ts = 1673784000.123;
+        expect(formatFullDate(ts)).toBe('15.01.2023, 12:00:00,123');
+    });
+
+    it('trims trailing zeros from fractional seconds', () => {
+        const ts = 1673784000.120;
+        expect(formatFullDate(ts)).toBe('15.01.2023, 12:00:00,12');
+    });
+
+    it('trims all trailing zeros but keeps the first decimal if specified, but here we trim all', () => {
+        const ts = 1673784000.100;
+        expect(formatFullDate(ts)).toBe('15.01.2023, 12:00:00,1');
+    });
+});

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -247,7 +247,7 @@ export function generateSecondaryLabels(min: number, max: number, step: TimeStep
 }
 
 export function formatFullDate(ts: number): string {
-    return new Date(ts * 1000).toLocaleString('de-DE', {
+    const s = new Date(ts * 1000).toLocaleString('de-DE', {
         day: '2-digit',
         month: '2-digit',
         year: 'numeric',
@@ -256,4 +256,6 @@ export function formatFullDate(ts: number): string {
         second: '2-digit',
         fractionalSecondDigits: 3
     });
+    // Remove trailing zeros from fractional seconds, and the comma if all zeros
+    return s.replace(/,(\d*?[1-9])0+$/, ',$1').replace(/,0+$/, '');
 }


### PR DESCRIPTION
This change improves the readability of the hover tooltip by:
1. Reducing X-axis date precision: `formatFullDate` now trims trailing zeros from fractional seconds (e.g., "12:00:00,000" becomes "12:00:00").
2. Fixing Y-value spacing: The "space before the comma" in Y-values was caused by the CSS Grid column gap. I adjusted the layout to use `columnGap: 0` between the integer and decimal columns, while maintaining label separation with padding.
3. Adding unit tests for the date formatting utility.

Fixes #95

---
*PR created automatically by Jules for task [2339719172462426865](https://jules.google.com/task/2339719172462426865) started by @michaelkrisper*