### PR TITLE
Automatically assign unused X-axis to new datasets

### DIFF
--- a/src/store/__tests__/useGraphStore.test.ts
+++ b/src/store/__tests__/useGraphStore.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useGraphStore } from '../useGraphStore';
+import { Dataset } from '../../services/persistence';
+
+// Mock persistence to avoid IndexedDB and LocalStorage issues during tests
+vi.mock('../../services/persistence', () => ({
+  persistence: {
+    saveDataset: vi.fn(),
+    loadDataset: vi.fn(),
+    getAllDatasets: vi.fn().mockResolvedValue([]),
+    deleteDataset: vi.fn(),
+    saveAppState: vi.fn(),
+    loadAppState: vi.fn().mockReturnValue(null),
+  },
+}));
+
+describe('useGraphStore', () => {
+  beforeEach(() => {
+    // Reset store state before each test
+    const store = useGraphStore.getState();
+    useGraphStore.setState({
+      datasets: [],
+      series: [],
+      xAxes: store.xAxes.map((a, i) => ({ ...a, min: 0, max: 100, showGrid: i === 0 })),
+      yAxes: store.yAxes.map((a, i) => ({ ...a, min: 0, max: 100, showGrid: i === 0 })),
+      views: [],
+      isLoaded: true, // Set to true to avoid loading demo data
+    });
+  });
+
+  it('should assign unique X-axis IDs to new datasets automatically', () => {
+    const ds1: Dataset = {
+      id: 'ds-1',
+      name: 'Dataset 1',
+      columns: ['Time', 'Value'],
+      data: [
+        { isFloat64: true, refPoint: 0, bounds: { min: 10, max: 20 }, data: new Float32Array([10, 20]), minTree: [], maxTree: [] },
+        { isFloat64: false, refPoint: 0, bounds: { min: 0, max: 5 }, data: new Float32Array([0, 5]), minTree: [], maxTree: [] },
+      ],
+      rowCount: 2,
+      xAxisColumn: 'Time',
+      xAxisId: '',
+    };
+
+    const ds2: Dataset = {
+      id: 'ds-2',
+      name: 'Dataset 2',
+      columns: ['Time', 'Value'],
+      data: [
+        { isFloat64: true, refPoint: 0, bounds: { min: 100, max: 200 }, data: new Float32Array([100, 200]), minTree: [], maxTree: [] },
+        { isFloat64: false, refPoint: 0, bounds: { min: 0, max: 50 }, data: new Float32Array([0, 50]), minTree: [], maxTree: [] },
+      ],
+      rowCount: 2,
+      xAxisColumn: 'Time',
+      xAxisId: '',
+    };
+
+    useGraphStore.getState().addDataset(ds1);
+    useGraphStore.getState().addDataset(ds2);
+
+    const state = useGraphStore.getState();
+    expect(state.datasets[0].xAxisId).toBe('axis-1');
+    expect(state.datasets[1].xAxisId).toBe('axis-2');
+
+    // Verify bounds and xMode were updated correctly
+    const xAxis1 = state.xAxes.find(a => a.id === 'axis-1');
+    const xAxis2 = state.xAxes.find(a => a.id === 'axis-2');
+
+    expect(xAxis1?.min).toBe(10);
+    expect(xAxis1?.max).toBe(20);
+    expect(xAxis1?.xMode).toBe('date');
+
+    expect(xAxis2?.min).toBe(100);
+    expect(xAxis2?.max).toBe(200);
+    expect(xAxis2?.xMode).toBe('date');
+  });
+
+  it('should fallback to axis-1 if all 9 axes are used', () => {
+    const store = useGraphStore.getState();
+    const datasets: Dataset[] = Array.from({ length: 9 }, (_, i) => ({
+      id: `ds-${i + 1}`,
+      name: `Dataset ${i + 1}`,
+      columns: ['Time'],
+      data: [{ isFloat64: false, refPoint: 0, bounds: { min: 0, max: 100 }, data: new Float32Array([0, 100]), minTree: [], maxTree: [] }],
+      rowCount: 2,
+      xAxisColumn: 'Time',
+      xAxisId: '',
+    }));
+
+    datasets.forEach(ds => store.addDataset(ds));
+
+    const ds10: Dataset = {
+      id: 'ds-10',
+      name: 'Dataset 10',
+      columns: ['Time'],
+      data: [{ isFloat64: false, refPoint: 0, bounds: { min: 0, max: 100 }, data: new Float32Array([0, 100]), minTree: [], maxTree: [] }],
+      rowCount: 2,
+      xAxisColumn: 'Time',
+      xAxisId: '',
+    };
+    store.addDataset(ds10);
+
+    const state = useGraphStore.getState();
+    expect(state.datasets[9].xAxisId).toBe('axis-1');
+  });
+});

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -71,26 +71,31 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
   addDataset: (dataset) => {
     set((state) => {
-      const newDatasets = [...state.datasets, dataset];
-      const isFirst = state.datasets.length === 0;
-
       if (!dataset.xAxisColumn) {
         const potentialX = dataset.columns.find(c => c.toLowerCase().includes('time') || c.toLowerCase().includes('date')) || dataset.columns[0];
         dataset.xAxisColumn = potentialX;
       }
+
+      // Automatically assign first unused X-axis
       if (!dataset.xAxisId) {
-        dataset.xAxisId = 'axis-1';
+        const usedXAxisIds = new Set(state.datasets.map(d => d.xAxisId));
+        const unusedAxis = state.xAxes.find(a => !usedXAxisIds.has(a.id)) || state.xAxes[0];
+        dataset.xAxisId = unusedAxis.id;
       }
 
-      let nextXAxes = state.xAxes;
-      if (isFirst) {
-        const xColIdx = dataset.columns.indexOf(dataset.xAxisColumn);
-        const bounds = dataset.data[xColIdx]?.bounds || { min: 0, max: 100 };
-        nextXAxes = state.xAxes.map((a, i) => i === 0 ? { ...a, min: bounds.min, max: bounds.max } : a);
-      }
+      const xColIdx = dataset.columns.indexOf(dataset.xAxisColumn);
+      const col = dataset.data[xColIdx];
+      const bounds = col?.bounds || { min: 0, max: 100 };
+      const isDate = col?.isFloat64 || false;
+
+      const nextXAxes = state.xAxes.map(a =>
+        a.id === dataset.xAxisId
+          ? { ...a, min: bounds.min, max: bounds.max, xMode: isDate ? 'date' : 'numeric' as const }
+          : a
+      );
 
       return {
-        datasets: newDatasets,
+        datasets: [...state.datasets, dataset],
         xAxes: nextXAxes
       };
     });


### PR DESCRIPTION
This change improves the user experience by automatically assigning newly imported datasets to an unused X-axis. 

Key changes:
- In `useGraphStore.ts`, the `addDataset` action now identifies unused X-axis IDs (from the 9 available axes) and assigns the first available one to the new dataset.
- The assigned X-axis is automatically configured with the correct `min`/`max` bounds and `xMode` (Time/Decimal) derived from the dataset's X-column.
- If all 9 axes are in use, it falls back to 'axis-1'.
- Added a comprehensive test suite in `src/store/__tests__/useGraphStore.test.ts` covering these scenarios.
- Verified the change visually by importing a new dataset and observing it being assigned to Axis 2 (as the demo data uses Axis 1).

Fixes #96

---
*PR created automatically by Jules for task [7189128627834393703](https://jules.google.com/task/7189128627834393703) started by @michaelkrisper*