### PR TITLE
fix: correct xMode type assertion in addDataset

### DIFF
--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -90,7 +90,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
       const nextXAxes = state.xAxes.map(a =>
         a.id === dataset.xAxisId
-          ? { ...a, min: bounds.min, max: bounds.max, xMode: isDate ? 'date' : 'numeric' as const }
+          ? { ...a, min: bounds.min, max: bounds.max, xMode: (isDate ? 'date' : 'numeric') as 'date' | 'numeric' }
           : a
       );
 


### PR DESCRIPTION
## Summary
- Fixes TypeScript build error where `xMode` was inferred as `string` instead of `'date' | 'numeric'`
- Root cause: `as const` was binding only to `'numeric'` literal, not the full ternary expression
- Fix: wrap ternary in parentheses before casting to `'date' | 'numeric'`

## Test plan
- [x] `npm run build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)