### PR TITLE
fix: resolve all lint errors (no-explicit-any, set-state-in-effect, react-compiler)

### DIFF
--- a/benchmark.cjs
+++ b/benchmark.cjs
@@ -67,7 +67,6 @@ const optimizedTime = performance.now() - start;
 console.log(`Original: ${(originalTime / 10).toFixed(2)} ms`);
 console.log(`Optimized: ${(optimizedTime / 10).toFixed(2)} ms`);
 console.log(`Improvement: ${((originalTime - optimizedTime) / originalTime * 100).toFixed(2)}%`);
-const { performance } = require('perf_hooks');
 
 function testAllocation(iterations, numPoints) {
   const start = performance.now();

--- a/benchmark.ts
+++ b/benchmark.ts
@@ -5,7 +5,7 @@ const numSeries = 10000;
 
 interface Dataset {
     id: string;
-    data: any;
+    data: Record<string, unknown>;
 }
 
 interface Series {

--- a/src/components/Layout/ImportSettingsDialog.tsx
+++ b/src/components/Layout/ImportSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { X, Check } from 'lucide-react';
 import type { ImportSettings, ColumnConfig, ColumnType } from '../../types/import';
 
@@ -10,6 +10,19 @@ interface ImportSettingsDialogProps {
   onCancel: () => void;
 }
 
+function detectDelimiter(fileContent: string, fileType: 'csv' | 'json'): string {
+  if (fileType !== 'csv') return ',';
+  const firstLine = fileContent.split('\n')[0];
+  const candidates = [',', ';', '\t', '|'];
+  let best = ',';
+  let maxCount = -1;
+  for (const d of candidates) {
+    const count = firstLine.split(d).length;
+    if (count > maxCount) { maxCount = count; best = d; }
+  }
+  return best;
+}
+
 export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
   fileName,
   fileContent,
@@ -17,101 +30,78 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
   onConfirm,
   onCancel
 }) => {
-  const [delimiter, setDelimiter] = useState<string>(',');
+  const [delimiter, setDelimiter] = useState<string>(() => detectDelimiter(fileContent, fileType));
   const [decimalPoint, setDecimalPoint] = useState<string>('.');
   const [startRow, setStartRow] = useState<number>(1);
-  const [columnConfigs, setColumnConfigs] = useState<ColumnConfig[]>([]);
-  const [xAxisColumn, setXAxisColumn] = useState<string>('');
-
-  // Auto-detect delimiter on mount
-  useEffect(() => {
-    if (fileType === 'csv') {
-      const firstLine = fileContent.split('\n')[0];
-      const delimiters = [',', ';', '\t', '|'];
-      let best = ',';
-      let maxCount = -1;
-      for (const d of delimiters) {
-        const count = firstLine.split(d).length;
-        if (count > maxCount) {
-          maxCount = count;
-          best = d;
-        }
-      }
-      setDelimiter(best);
-    }
-  }, [fileContent, fileType]);
+  // Stores per-column user overrides, keyed by column name
+  const [columnOverrides, setColumnOverrides] = useState<Record<string, Partial<ColumnConfig>>>({});
+  // null = auto-select best X axis column
+  const [xAxisColumnOverride, setXAxisColumnOverride] = useState<string | null>(null);
 
   const previewData = useMemo(() => {
     if (fileType === 'json') {
       try {
-        const parsed = JSON.parse(fileContent);
+        const parsed = JSON.parse(fileContent) as unknown;
         const rows = Array.isArray(parsed) ? parsed : [parsed];
-        const headers = Object.keys(rows[0] || {});
-        return { headers, rows: rows.slice(0, 10) };
-      } catch (e) {
-        return { headers: [], rows: [] };
+        const headers = Object.keys((rows[0] as Record<string, unknown>) || {});
+        return { headers, rows: (rows as Record<string, string>[]).slice(0, 10) };
+      } catch {
+        return { headers: [], rows: [] as Record<string, string>[] };
       }
     }
 
     const lines = fileContent.split(/\r?\n/).filter(l => l.trim());
-    if (lines.length === 0) return { headers: [], rows: [] };
+    if (lines.length === 0) return { headers: [], rows: [] as string[][] };
 
     const headers = lines[0].split(delimiter).map(h => h.trim().replace(/^"|"$/g, ''));
     const rows = lines.slice(1, 11).map(line =>
       line.split(delimiter).map(v => v.trim().replace(/^"|"$/g, ''))
     );
-
     return { headers, rows };
   }, [fileContent, fileType, delimiter]);
 
-  // Initialize column configs when previewData headers change
-  useEffect(() => {
-    if (previewData.headers.length > 0) {
-      // Preserve existing manual changes if possible
-      const newConfigs: ColumnConfig[] = previewData.headers.map((name, index) => {
-        const existing = columnConfigs[index];
-        if (existing && existing.name === name) return existing;
+  // Derived column configs: auto-detected type + user overrides (keyed by column name)
+  const columnConfigs = useMemo<ColumnConfig[]>(() => {
+    return previewData.headers.map((name, index) => {
+      const override = columnOverrides[name];
+      if (override) return { index, name, type: 'numeric' as ColumnType, ...override };
 
-        // Try to guess type from first few rows
-        let type: ColumnType = 'numeric';
-        let dateFormat: string | undefined = undefined;
+      let type: ColumnType = 'numeric';
+      let dateFormat: string | undefined;
 
-        const firstVal = fileType === 'json'
-          ? previewData.rows.find(row => (row as any)[name])?.[name as any]
-          : previewData.rows.find(row => row[index])?.[index];
-        if (firstVal) {
-          const normalized = firstVal.replace(decimalPoint, '.');
-          const asNum = Number(normalized);
-          if (isNaN(asNum) || (normalized.split('.').length > 2)) {
-            // Check if it looks like a date
-            if (firstVal.includes('-') || firstVal.includes('.') || firstVal.includes('/')) {
-              type = 'date';
-              // Simple heuristic for common formats
-              if (firstVal.match(/^\d{4}-\d{2}-\d{2}$/)) dateFormat = 'YYYY-MM-DD';
-              else if (firstVal.match(/^\d{2}\.\d{2}\.\d{4}$/)) dateFormat = 'DD.MM.YYYY';
-              else if (firstVal.match(/^\d{2}\/\d{2}\/\d{4}$/)) dateFormat = 'DD/MM/YYYY';
-            } else {
-              type = 'categorical';
-            }
+      const firstVal = fileType === 'json'
+        ? (previewData.rows as Record<string, string>[]).find(row => row[name])?.[name]
+        : (previewData.rows as string[][])[0]?.[index];
+
+      if (firstVal) {
+        const normalized = firstVal.replace(decimalPoint, '.');
+        if (isNaN(Number(normalized)) || normalized.split('.').length > 2) {
+          if (firstVal.includes('-') || firstVal.includes('.') || firstVal.includes('/')) {
+            type = 'date';
+            if (firstVal.match(/^\d{4}-\d{2}-\d{2}$/)) dateFormat = 'YYYY-MM-DD';
+            else if (firstVal.match(/^\d{2}\.\d{2}\.\d{4}$/)) dateFormat = 'DD.MM.YYYY';
+            else if (firstVal.match(/^\d{2}\/\d{2}\/\d{4}$/)) dateFormat = 'DD/MM/YYYY';
+          } else {
+            type = 'categorical';
           }
         }
-
-        return { index, name, type, dateFormat };
-      });
-      setColumnConfigs(newConfigs);
-
-      // Auto-set default X-axis if not already set or no longer valid
-      const nonIgnored = newConfigs.filter(c => c.type !== 'ignore');
-      if (nonIgnored.length > 0 && (!xAxisColumn || !nonIgnored.find(c => c.name === xAxisColumn))) {
-        // Prefer 'date' columns
-        const dateCol = nonIgnored.find(c => c.type === 'date');
-        setXAxisColumn(dateCol?.name || nonIgnored[0].name);
       }
+      return { index, name, type, dateFormat };
+    });
+  }, [previewData, columnOverrides, decimalPoint, fileType]);
+
+  // Derived X axis column: user override if still valid, otherwise auto-select date col or first col
+  const xAxisColumn = useMemo(() => {
+    const nonIgnored = columnConfigs.filter(c => c.type !== 'ignore');
+    if (xAxisColumnOverride && nonIgnored.find(c => c.name === xAxisColumnOverride)) {
+      return xAxisColumnOverride;
     }
-  }, [previewData.headers]); // Only re-run if headers (structure) change
+    return nonIgnored.find(c => c.type === 'date')?.name || nonIgnored[0]?.name || '';
+  }, [columnConfigs, xAxisColumnOverride]);
 
   const handleUpdateColumn = (index: number, updates: Partial<ColumnConfig>) => {
-    setColumnConfigs(prev => prev.map(c => c.index === index ? { ...c, ...updates } : c));
+    const name = columnConfigs[index].name;
+    setColumnOverrides(prev => ({ ...prev, [name]: { ...prev[name], ...updates } }));
   };
 
   return (
@@ -171,7 +161,7 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
             <label style={{ display: 'block', fontSize: '12px', fontWeight: 'bold', marginBottom: '4px' }}>X-Axis Column</label>
             <select
               value={xAxisColumn}
-              onChange={e => setXAxisColumn(e.target.value)}
+              onChange={e => setXAxisColumnOverride(e.target.value)}
               style={{ width: '100%', padding: '4px', borderRadius: '4px', border: '1px solid #ced4da' }}
             >
               {columnConfigs.filter(c => c.type !== 'ignore').map(c => (
@@ -229,7 +219,9 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
                       color: config.type === 'ignore' ? '#adb5bd' : '#212529',
                       backgroundColor: config.type === 'ignore' ? '#f8f9fa' : 'transparent'
                     }}>
-                      {fileType === 'json' ? (row as any)[previewData.headers[colIndex]] : row[colIndex]}
+                      {fileType === 'json'
+                        ? (row as Record<string, string>)[previewData.headers[colIndex]]
+                        : (row as string[])[colIndex]}
                     </td>
                   ))}
                 </tr>

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -70,7 +70,7 @@ const GridLines = React.memo(({ xAxes, yAxes, width, height, padding }: GridLine
         const conf = state.xAxes.find(a => a.id === axis.id);
         if (!conf) return null;
         const vp = { xMin: conf.min, xMax: conf.max, yMin: 0, yMax: 100, width, height, padding };
-        return axis.ticks.result.map((t: any) => {
+        return axis.ticks.result.map((t: number | TimeTick) => {
           const timestamp = typeof t === 'number' ? t : t.timestamp;
           const { x } = worldToScreen(timestamp, 0, vp);
           if (x < padding.left || x > width - padding.right) return null;
@@ -138,7 +138,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
               />
 
               {/* Ticks */}
-              {axis.ticks.result.map((t: any) => {
+              {axis.ticks.result.map((t: number | TimeTick) => {
                 const { x } = worldToScreen(typeof t === 'number' ? t : t.timestamp, 0, vp);
                 if (x < padding.left || x > width - padding.right) return null;
                 return <line key={`xt-${axis.id}-${typeof t === 'number' ? t : t.timestamp}`} x1={x} y1={y} x2={x} y2={y + 6} stroke="#475569" strokeWidth="1" />;
@@ -231,7 +231,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
           
           return (
             <React.Fragment key={`x-labels-${axis.id}`}>
-              {axis.ticks.secondaryLabels && axis.ticks.secondaryLabels.map((sl: any, idx: number) => {
+              {axis.ticks.secondaryLabels && axis.ticks.secondaryLabels.map((sl: SecondaryLabel, idx: number) => {
                 const nextSl = axis.ticks.secondaryLabels![idx + 1];
                 const { x: currentX } = worldToScreen(sl.timestamp, 0, vp);
                 const { x: nextX } = nextSl ? worldToScreen(nextSl.timestamp, 0, vp) : { x: width - padding.right + 200 };
@@ -266,7 +266,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
                 }
                 return null;
               })}
-              {axis.ticks.result.map((t: any) => {
+              {axis.ticks.result.map((t: number | TimeTick) => {
                 const timestamp = typeof t === 'number' ? t : t.timestamp;
                 const { x } = worldToScreen(timestamp, 0, vp);
                 if (x < padding.left || x > width - padding.right) return null;
@@ -440,7 +440,7 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
       seriesByAxis[sr.yAxisId].push(sr.name || sr.yColumn);
     });
     const axisTitleMap: Record<string, string> = {};
-    yAxes.forEach((axis: any) => {
+    yAxes.forEach((axis: YAxisConfig) => {
       if (seriesByAxis[axis.id]) {
         axisTitleMap[axis.id] = seriesByAxis[axis.id].join('/');
       }
@@ -489,7 +489,7 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
     const snapScreenX = worldToScreen(finalBestXWorld, 0, { xMin: finalXConf.min, xMax: finalXConf.max, yMin: 0, yMax: 100, width, height, padding }).x;
 
     return { snapScreenX, entries };
-  }, [pos, seriesMetadata, yAxes, xAxes, width, height, padding]);
+  }, [pos, seriesMetadata, yAxes, xAxes, width, height, padding, datasets, series]);
 
   if (!pos) return null;
   if (!snap) return null; // Only show when near a point
@@ -585,7 +585,7 @@ const ChartContainer: React.FC = () => {
   const isAnimating = useRef(false);
   const isPanningRef = useRef(false);
 
-  const lockedXSteps = useRef<Record<string, any>>({});
+  const lockedXSteps = useRef<Record<string, { step?: number; timeStep?: ReturnType<typeof getTimeStep> }>>({});
   const lockedYSteps = useRef<Record<string, number>>({});
 
   const startAnimation = useCallback(() => {
@@ -1339,7 +1339,7 @@ const ChartContainer: React.FC = () => {
       if (!isXDate) {
         let actualStep: number;
         if (isInteracting && lockedXSteps.current[axis.id]?.step) {
-          actualStep = lockedXSteps.current[axis.id].step;
+          actualStep = lockedXSteps.current[axis.id].step!;
         } else {
           const maxTicks = Math.max(2, Math.floor(chartWidth / 60));
           const step = range / maxTicks;
@@ -1362,7 +1362,7 @@ const ChartContainer: React.FC = () => {
       } else {
         let timeStep;
         if (isInteracting && lockedXSteps.current[axis.id]?.timeStep) {
-          timeStep = lockedXSteps.current[axis.id].timeStep;
+          timeStep = lockedXSteps.current[axis.id].timeStep!;
         } else {
           timeStep = getTimeStep(range, Math.max(2, Math.floor(chartWidth / 80)));
           lockedXSteps.current[axis.id] = { timeStep };

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -2,6 +2,22 @@ import React, { useRef, useEffect, useState, useMemo } from 'react';
 import { type Dataset, type SeriesConfig, type YAxisConfig, type XAxisConfig } from '../../services/persistence';
 import { downsampleMinMax } from '../../utils/downsampling';
 
+interface WebGLLocations {
+  posLoc: number;
+  otherLoc: number;
+  tLoc: number;
+  distStartLoc: number;
+  xRelLoc: WebGLUniformLocation | null;
+  yRelLoc: WebGLUniformLocation | null;
+  padLoc: WebGLUniformLocation | null;
+  resLoc: WebGLUniformLocation | null;
+  colorLoc: WebGLUniformLocation | null;
+  styleLoc: WebGLUniformLocation | null;
+  lineStyleLoc: WebGLUniformLocation | null;
+  dprLoc: WebGLUniformLocation | null;
+  sizeLoc: WebGLUniformLocation | null;
+}
+
 interface Props {
   datasets: Dataset[];
   series: SeriesConfig[];
@@ -20,7 +36,7 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, xA
   const glRef = useRef<WebGLRenderingContext | null>(null);
   const [glReady, setGlReady] = useState(false);
   const [program, setProgram] = useState<WebGLProgram | null>(null);
-  const [locations, setLocations] = useState<any>({});
+  const [locations, setLocations] = useState<WebGLLocations | null>(null);
   const buffersRef = useRef<Map<string, WebGLBuffer>>(new Map());
   const segParamsRef = useRef<Map<string, string>>(new Map());
 

--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useDataImport } from '../useDataImport';
 import { useGraphStore } from '../../store/useGraphStore';
 import { persistence } from '../../services/persistence';
+import type { ImportSettings } from '../../types/import';
 
 // Mock the graph store
 vi.mock('../../store/useGraphStore', () => ({
@@ -30,38 +31,43 @@ if (typeof URL.createObjectURL === 'undefined') {
   URL.createObjectURL = vi.fn(() => 'blob:test-url');
 }
 
-// Global variable to keep track of the mock worker instance
-let mockWorkerInstance: any = null;
+interface MockWorkerInstance {
+  postMessage: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
+  onmessage?: (event: MessageEvent) => void;
+}
+
+type MockWorkerConstructor = ReturnType<typeof vi.fn> & { mock: { instances: MockWorkerInstance[] } };
 
 describe('useDataImport hook', () => {
   let originalWorker: typeof Worker;
   const mockAddDataset = vi.fn();
+  let MockWorkerCtor: MockWorkerConstructor;
+
+  const getMockWorker = () => MockWorkerCtor.mock.instances[MockWorkerCtor.mock.instances.length - 1] as MockWorkerInstance;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
     // Setup store mock
-    (useGraphStore as any).mockImplementation(() => ({
+    vi.mocked(useGraphStore).mockImplementation(() => ({
       addDataset: mockAddDataset,
     }));
-    (useGraphStore.getState as any).mockReturnValue({
+    vi.mocked(useGraphStore.getState).mockReturnValue({
       datasets: [],
-    });
+    } as ReturnType<typeof useGraphStore.getState>);
 
     // Mock Worker
     originalWorker = global.Worker;
-    const MockWorker = vi.fn().mockImplementation(function(this: any) {
+    MockWorkerCtor = vi.fn().mockImplementation(function(this: MockWorkerInstance) {
       this.postMessage = vi.fn();
       this.terminate = vi.fn();
-      mockWorkerInstance = this;
-      return this;
-    });
-    global.Worker = MockWorker as any;
+    }) as MockWorkerConstructor;
+    global.Worker = MockWorkerCtor as unknown as typeof Worker;
   });
 
   afterEach(() => {
     global.Worker = originalWorker;
-    mockWorkerInstance = null;
   });
 
   it('should initialize correctly', () => {
@@ -79,14 +85,14 @@ describe('useDataImport hook', () => {
 
     const originalFileReader = global.FileReader;
     class MockFileReader {
-      onload: any;
-      readAsText(blob: Blob) {
+      onload: ((event: { target: { result: string } }) => void) | null = null;
+      readAsText() {
         setTimeout(() => {
-          this.onload({ target: { result: 'preview data json' } });
+          this.onload?.({ target: { result: 'preview data json' } });
         }, 10);
       }
     }
-    global.FileReader = MockFileReader as any;
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
 
     act(() => {
       result.current.importFile(file);
@@ -108,28 +114,24 @@ describe('useDataImport hook', () => {
   it('should set pending file on initiateImport', async () => {
     const { result } = renderHook(() => useDataImport());
 
-    // Create a mock file
     const fileContent = 'A,B\n1,2';
     const file = new File([fileContent], 'test.csv', { type: 'text/csv' });
 
-    // Override readAsText directly since FileReader in JSDOM handles slices fine
-    // but just to make it fast and synchronous in act
     const originalFileReader = global.FileReader;
     class MockFileReader {
-      onload: any;
-      readAsText(blob: Blob) {
+      onload: ((event: { target: { result: string } }) => void) | null = null;
+      readAsText() {
         setTimeout(() => {
-          this.onload({ target: { result: 'preview data' } });
+          this.onload?.({ target: { result: 'preview data' } });
         }, 10);
       }
     }
-    global.FileReader = MockFileReader as any;
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
 
     act(() => {
       result.current.importFile(file);
     });
 
-    // Wait for the mock reader to finish
     await act(async () => {
       await new Promise(r => setTimeout(r, 20));
     });
@@ -145,18 +147,16 @@ describe('useDataImport hook', () => {
   it('should cancel import correctly', () => {
     const { result } = renderHook(() => useDataImport());
 
-    // Directly inject a pending file state using act by forcing a re-render or mocking initial state isn't easy here,
-    // so let's call the actual hook method but mock the file reader synchronous
     const file = new File([''], 'test.csv', { type: 'text/csv' });
 
     const originalFileReader = global.FileReader;
     class MockFileReader {
-      onload: any;
+      onload: ((event: { target: { result: string } }) => void) | null = null;
       readAsText() {
-        this.onload({ target: { result: 'data' } });
+        this.onload?.({ target: { result: 'data' } });
       }
     }
-    global.FileReader = MockFileReader as any;
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
 
     act(() => {
       result.current.importFile(file);
@@ -174,9 +174,10 @@ describe('useDataImport hook', () => {
 
   it('should do nothing on confirmImport if no pending file', async () => {
       const { result } = renderHook(() => useDataImport());
+      const emptySettings: ImportSettings = { delimiter: ',', decimalPoint: '.', startRow: 1, columnConfigs: [], xAxisColumn: '' };
 
       act(() => {
-          result.current.confirmImport({} as any);
+          result.current.confirmImport(emptySettings);
       });
 
       expect(result.current.isImporting).toBe(false);
@@ -185,16 +186,15 @@ describe('useDataImport hook', () => {
   it('should process import with worker successfully', async () => {
     const { result } = renderHook(() => useDataImport());
 
-    // Setup pending file
     const file = new File([''], 'test.csv', { type: 'text/csv' });
     const originalFileReader = global.FileReader;
     class MockFileReader {
-      onload: any;
+      onload: ((event: { target: { result: string } }) => void) | null = null;
       readAsText() {
-        this.onload({ target: { result: 'data' } });
+        this.onload?.({ target: { result: 'data' } });
       }
     }
-    global.FileReader = MockFileReader as any;
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
 
     act(() => {
       result.current.importFile(file);
@@ -202,22 +202,16 @@ describe('useDataImport hook', () => {
 
     expect(result.current.pendingFile).not.toBeNull();
 
-    // Call confirmImport
-    const settings = { delimiter: ',', decimalPoint: '.', startRow: 1, columnConfigs: [] };
+    const settings: ImportSettings = { delimiter: ',', decimalPoint: '.', startRow: 1, columnConfigs: [] };
 
     act(() => {
-      result.current.confirmImport(settings as any);
+      result.current.confirmImport(settings);
     });
 
     expect(result.current.isImporting).toBe(true);
     expect(global.Worker).toHaveBeenCalled();
-    expect(mockWorkerInstance.postMessage).toHaveBeenCalledWith({
-      file,
-      type: 'csv',
-      settings
-    });
+    expect(getMockWorker().postMessage).toHaveBeenCalledWith({ file, type: 'csv', settings });
 
-    // Simulate worker success message
     const mockDataset = {
       id: 'ds-1',
       name: 'test.csv',
@@ -229,11 +223,8 @@ describe('useDataImport hook', () => {
     };
 
     await act(async () => {
-      await mockWorkerInstance.onmessage({
-        data: {
-          type: 'success',
-          dataset: mockDataset
-        }
+      await getMockWorker().onmessage?.({
+        data: { type: 'success', dataset: mockDataset }
       } as MessageEvent);
     });
 
@@ -243,7 +234,7 @@ describe('useDataImport hook', () => {
     expect(mockAddDataset.mock.calls[0][0].columns[0]).toBe('A: Col1');
     expect(result.current.isImporting).toBe(false);
     expect(result.current.pendingFile).toBeNull();
-    expect(mockWorkerInstance.terminate).toHaveBeenCalled();
+    expect(getMockWorker().terminate).toHaveBeenCalled();
 
     global.FileReader = originalFileReader;
   });
@@ -254,47 +245,42 @@ describe('useDataImport hook', () => {
     const file = new File([''], 'test.json', { type: 'application/json' });
     const originalFileReader = global.FileReader;
     class MockFileReader {
-      onload: any;
+      onload: ((event: { target: { result: string } }) => void) | null = null;
       readAsText() {
-        this.onload({ target: { result: 'data' } });
+        this.onload?.({ target: { result: 'data' } });
       }
     }
-    global.FileReader = MockFileReader as any;
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
 
     act(() => {
       result.current.importFile(file);
     });
 
-    const settings = { delimiter: ',', decimalPoint: '.', startRow: 1, columnConfigs: [] };
+    const settings: ImportSettings = { delimiter: ',', decimalPoint: '.', startRow: 1, columnConfigs: [] };
 
     act(() => {
-      result.current.confirmImport(settings as any);
+      result.current.confirmImport(settings);
     });
 
     expect(result.current.isImporting).toBe(true);
     expect(result.current.error).toBeNull();
 
-    // Simulate worker error message
     const errorMessage = 'Failed to parse JSON';
 
     await act(async () => {
-      await mockWorkerInstance.onmessage({
-        data: {
-          type: 'error',
-          error: errorMessage
-        }
+      await getMockWorker().onmessage?.({
+        data: { type: 'error', error: errorMessage }
       } as MessageEvent);
     });
 
     expect(result.current.isImporting).toBe(false);
     expect(result.current.error).toBe(errorMessage);
-    expect(mockWorkerInstance.terminate).toHaveBeenCalled();
+    expect(getMockWorker().terminate).toHaveBeenCalled();
     expect(persistence.saveDataset).not.toHaveBeenCalled();
     expect(mockAddDataset).not.toHaveBeenCalled();
 
     global.FileReader = originalFileReader;
   });
-});
 
   it('should handle non-csv files correctly', async () => {
     const { result } = renderHook(() => useDataImport());
@@ -304,14 +290,14 @@ describe('useDataImport hook', () => {
 
     const originalFileReader = global.FileReader;
     class MockFileReader {
-      onload: any;
-      readAsText(blob: Blob) {
+      onload: ((event: { target: { result: string } }) => void) | null = null;
+      readAsText() {
         setTimeout(() => {
-          this.onload({ target: { result: 'preview data txt' } });
+          this.onload?.({ target: { result: 'preview data txt' } });
         }, 10);
       }
     }
-    global.FileReader = MockFileReader as any;
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
 
     act(() => {
       result.current.importFile(file);
@@ -328,3 +314,4 @@ describe('useDataImport hook', () => {
 
     global.FileReader = originalFileReader;
   });
+});

--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -158,9 +158,22 @@ describe('exportToSVG', () => {
     });
 });
 
+interface MockCtx {
+    scale: ReturnType<typeof vi.fn>;
+    fillRect: ReturnType<typeof vi.fn>;
+    drawImage: ReturnType<typeof vi.fn>;
+    fillStyle: string;
+}
+interface MockCanvas {
+    getContext: ReturnType<typeof vi.fn>;
+    width: number;
+    height: number;
+    toDataURL: ReturnType<typeof vi.fn>;
+}
+
 describe('exportToPNG', () => {
-    let mockCanvas: any;
-    let mockCtx: any;
+    let mockCanvas: MockCanvas;
+    let mockCtx: MockCtx;
 
     beforeEach(() => {
         mockCtx = {
@@ -195,7 +208,7 @@ describe('exportToPNG', () => {
             createObjectURL: vi.fn(() => 'blob:mock'),
             revokeObjectURL: vi.fn()
         });
-        class MockBlob { constructor(public content: any[], public options: any) {} }
+        class MockBlob { constructor(public content: unknown[], public options: Record<string, string>) {} }
         vi.stubGlobal('Blob', MockBlob);
     });
 
@@ -235,7 +248,7 @@ describe('downloadFile', () => {
     };
     vi.stubGlobal('document', documentMock);
     vi.stubGlobal('URL', { createObjectURL: vi.fn(() => 'blob:mock-url'), revokeObjectURL: vi.fn() });
-    class MockBlob { constructor(public content: any[], public options: any) {} }
+    class MockBlob { constructor(public content: unknown[], public options: Record<string, string>) {} }
     vi.stubGlobal('Blob', MockBlob);
   });
 
@@ -248,9 +261,9 @@ describe('downloadFile', () => {
     const content = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
     downloadFile(content, 'test.png', 'image/png');
 
-    const doc = document as any;
-    expect(doc.createElement).toHaveBeenCalledWith('a');
-    const a = doc.createElement('a');
+    const mockedCreate = document.createElement as unknown as ReturnType<typeof vi.fn>;
+    expect(mockedCreate).toHaveBeenCalledWith('a');
+    const a = mockedCreate('a') as { href: string; download: string; click: () => void };
     expect(a.href).toBe(content);
     expect(a.download).toBe('test.png');
     expect(mockClick).toHaveBeenCalled();
@@ -260,10 +273,10 @@ describe('downloadFile', () => {
   it('should handle normal strings using Blob correctly', () => {
     downloadFile('Hello, world!', 'test.txt', 'text/plain');
 
-    const doc = document as any;
-    expect(doc.createElement).toHaveBeenCalledWith('a');
+    const mockedCreate = document.createElement as unknown as ReturnType<typeof vi.fn>;
+    expect(mockedCreate).toHaveBeenCalledWith('a');
     expect(URL.createObjectURL).toHaveBeenCalled();
-    const a = doc.createElement('a');
+    const a = mockedCreate('a') as { href: string; download: string; click: () => void };
     expect(a.href).toBe('blob:mock-url');
     expect(a.download).toBe('test.txt');
     expect(mockClick).toHaveBeenCalled();

--- a/src/services/__tests__/persistence.test.ts
+++ b/src/services/__tests__/persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Dataset, AppState } from '../persistence';
+import type { Dataset } from '../persistence';
 
 vi.mock('idb', () => ({
   openDB: vi.fn(),
@@ -7,7 +7,7 @@ vi.mock('idb', () => ({
 
 describe('persistence', () => {
   let persistence: typeof import('../persistence').persistence;
-  let openDBMock: any;
+  let openDBMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -31,7 +31,7 @@ describe('persistence', () => {
             getAll: vi.fn().mockResolvedValue([])
         };
 
-        openDBMock.mockImplementationOnce((name: string, version: number, options: any) => {
+        openDBMock.mockImplementationOnce((name: string, version: number, options: { upgrade: (db: unknown) => void }) => {
             options.upgrade(mockDb);
             return Promise.resolve(mockDb);
         });
@@ -52,7 +52,7 @@ describe('persistence', () => {
             getAll: vi.fn().mockResolvedValue([])
         };
 
-        openDBMock.mockImplementationOnce((name: string, version: number, options: any) => {
+        openDBMock.mockImplementationOnce((name: string, version: number, options: { upgrade: (db: unknown) => void }) => {
             options.upgrade(mockDb);
             return Promise.resolve(mockDb);
         });

--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -98,7 +98,7 @@ async function getDB() {
 function fixDatasetTypes(dataset: Dataset): Dataset {
   if (!dataset.data || !Array.isArray(dataset.data)) return dataset;
 
-  const restoreUint32Array = (arr: any) => {
+  const restoreUint32Array = (arr: unknown) => {
     if (arr instanceof Uint32Array) return arr;
     if (typeof arr === 'object' && arr !== null) {
       return new Uint32Array(Object.values(arr) as number[]);
@@ -106,7 +106,7 @@ function fixDatasetTypes(dataset: Dataset): Dataset {
     return new Uint32Array(0);
   };
 
-  const restoreFloat32Array = (arr: any) => {
+  const restoreFloat32Array = (arr: unknown) => {
     if (arr instanceof Float32Array) return arr;
     if (typeof arr === 'object' && arr !== null) {
       return new Float32Array(Object.values(arr) as number[]);
@@ -114,7 +114,7 @@ function fixDatasetTypes(dataset: Dataset): Dataset {
     return new Float32Array(0);
   };
 
-  dataset.data = dataset.data.map((col: any) => {
+  dataset.data = dataset.data.map((col: DataColumn) => {
     // Migration: ensure bounds exist
     if (!col.bounds) {
       col.bounds = { min: 0, max: 0 };

--- a/src/workers/__tests__/parser.test.ts
+++ b/src/workers/__tests__/parser.test.ts
@@ -3,7 +3,12 @@ import { describe, it, expect } from 'vitest';
 // Re-implement or import the parser logic
 // Since it's in a worker, we'll extract the core functions for testing
 
-function parseValue(val: string, config: any, decimalPoint: string, categoricalMap: Map<string, number>): number {
+interface ParseConfig {
+  type?: 'date' | 'categorical' | 'numeric' | 'ignore';
+  dateFormat?: string;
+}
+
+function parseValue(val: string, config: ParseConfig | null, decimalPoint: string, categoricalMap: Map<string, number>): number {
   if (val === undefined || val === null || val === '') return NaN;
 
   if (config?.type === 'date') {
@@ -50,7 +55,7 @@ function parseDate(val: string, format?: string): number {
 
     const d = new Date(year, month, day, hour, min, sec);
     return d.getTime() / 1000;
-  } catch (e) {
+  } catch {
     const d = new Date(val);
     return d.getTime() / 1000;
   }

--- a/src/workers/data-parser.worker.ts
+++ b/src/workers/data-parser.worker.ts
@@ -1,5 +1,25 @@
 // Data Parser Web Worker (v0.4.0 - Advanced Import Settings & Arbitrary Date Formats)
 
+interface ColumnConfigEntry {
+  index: number;
+  name?: string;
+  type?: 'numeric' | 'date' | 'categorical' | 'ignore';
+  dateFormat?: string;
+}
+
+interface ParseSettings {
+  delimiter?: string;
+  decimalPoint?: string;
+  startRow?: number;
+  columnConfigs?: ColumnConfigEntry[];
+  xAxisColumn?: string;
+}
+
+interface ParseConfig {
+  type?: string;
+  dateFormat?: string;
+}
+
 self.onmessage = async (event) => {
   const { file, type, settings } = event.data;
 
@@ -42,7 +62,7 @@ self.onmessage = async (event) => {
     });
 
     // ⚡ Bolt Optimization: Pre-calculate non-ignored configs to avoid O(N) array filtering operations inside .find() in the inner loop
-    const nonIgnoredConfigs = settings?.columnConfigs ? settings.columnConfigs.filter((cc: any) => cc.type !== 'ignore') : [];
+    const nonIgnoredConfigs = settings?.columnConfigs ? settings.columnConfigs.filter((cc: { type: string }) => cc.type !== 'ignore') : [];
 
     const dataset = {
       id: crypto.randomUUID(),
@@ -51,7 +71,7 @@ self.onmessage = async (event) => {
       rowCount: rowCount,
       xAxisColumn: settings?.xAxisColumn,
       data: columns.map((colName, colIdx) => {
-        const config = settings?.columnConfigs?.find((c: any) => c.name === colName || (c.name === nonIgnoredConfigs[colIdx]?.name));
+        const config = settings?.columnConfigs?.find((c: { name: string; type: string }) => c.name === colName || (c.name === nonIgnoredConfigs[colIdx]?.name));
         const isPotentialX = config?.type === 'date' || colIdx === 0 || colName.toLowerCase().includes('time') || colName.toLowerCase().includes('date');
 
         const { minTree, maxTree } = buildMinMaxTrees(relativeData[colIdx].data);
@@ -74,9 +94,9 @@ self.onmessage = async (event) => {
       col.maxTree.forEach(level => transferList.push(level.buffer as ArrayBuffer));
     });
 
-    (self as any).postMessage({ type: 'success', dataset }, transferList);
-  } catch (error: any) {
-    self.postMessage({ type: 'error', error: error.message });
+    (self as unknown as Worker).postMessage({ type: 'success', dataset }, transferList);
+  } catch (error: unknown) {
+    self.postMessage({ type: 'error', error: error instanceof Error ? error.message : String(error) });
   }
 };
 
@@ -142,7 +162,7 @@ function buildMinMaxTrees(data: Float32Array): { minTree: Uint32Array[], maxTree
   return { minTree, maxTree };
 }
 
-function parseCSV(text: string, settings?: any) {
+function parseCSV(text: string, settings?: ParseSettings) {
   const { delimiter = ',', decimalPoint = '.', startRow = 1, columnConfigs = [] } = settings || {};
 
   // Strip BOM if present
@@ -157,7 +177,7 @@ function parseCSV(text: string, settings?: any) {
   // ⚡ Bolt Optimization: Pre-calculate column configurations to avoid O(N) .find() lookup inside inner loop
   const configsByIndex = new Array(headers.length);
   for (let j = 0; j < headers.length; j++) {
-    configsByIndex[j] = columnConfigs.find((c: any) => c.index === j);
+    configsByIndex[j] = columnConfigs.find((c: ColumnConfigEntry) => c.index === j);
   }
 
   for (let i = startRow; i < lines.length; i++) {
@@ -178,12 +198,12 @@ function parseCSV(text: string, settings?: any) {
   }
 
   const finalHeaders = headers.filter((_, i) => {
-    const config = columnConfigs.find((c: any) => c.index === i);
+    const config = columnConfigs.find((c: ColumnConfigEntry) => c.index === i);
     return config?.type !== 'ignore';
   }).map((h) => {
      // Re-find the original index to look up the correct config
      const originalIdx = headers.indexOf(h);
-     const config = columnConfigs.find((c: any) => c.index === originalIdx);
+     const config = columnConfigs.find((c: ColumnConfigEntry) => c.index === originalIdx);
      return config?.name || h;
   });
 
@@ -191,7 +211,7 @@ function parseCSV(text: string, settings?: any) {
 }
 
 
-function parseJSON(text: string, settings?: any) {
+function parseJSON(text: string, settings?: ParseSettings) {
   const { decimalPoint = '.', columnConfigs = [] } = settings || {};
   const raw = JSON.parse(text);
   if (!Array.isArray(raw) || raw.length === 0) throw new Error('Invalid JSON format');
@@ -205,7 +225,7 @@ function parseJSON(text: string, settings?: any) {
   // ⚡ Bolt Optimization: Pre-calculate column configurations to avoid O(N) .find() lookup inside inner loop
   const configsByIndex = new Array(allHeaders.length);
   for (let j = 0; j < allHeaders.length; j++) {
-    configsByIndex[j] = columnConfigs.find((c: any) => c.index === j);
+    configsByIndex[j] = columnConfigs.find((c: ColumnConfigEntry) => c.index === j);
   }
 
   for (let i = 0; i < rowCount; i++) {
@@ -224,18 +244,18 @@ function parseJSON(text: string, settings?: any) {
   }
 
   const finalHeaders = allHeaders.filter((_, i) => {
-    const config = columnConfigs.find((c: any) => c.index === i);
+    const config = columnConfigs.find((c: ColumnConfigEntry) => c.index === i);
     return config?.type !== 'ignore';
   }).map((h) => {
      const originalIdx = allHeaders.indexOf(h);
-     const config = columnConfigs.find((c: any) => c.index === originalIdx);
+     const config = columnConfigs.find((c: ColumnConfigEntry) => c.index === originalIdx);
      return config?.name || h;
   });
 
   return { columns: finalHeaders, rowCount: data.length, data: data };
 }
 
-function parseValue(val: string, config: any, decimalPoint: string, categoricalMap: Map<string, number>): number {
+function parseValue(val: string, config: ParseConfig | null | undefined, decimalPoint: string, categoricalMap: Map<string, number>): number {
   if (val === undefined || val === null || val === '') return NaN;
 
   if (config?.type === 'date') {
@@ -283,7 +303,7 @@ function parseDate(val: string, format?: string): number {
 
     const d = new Date(year, month, day, hour, min, sec);
     return d.getTime() / 1000;
-  } catch (e) {
+  } catch {
     const d = new Date(val);
     return d.getTime() / 1000;
   }


### PR DESCRIPTION
## Summary
- Eliminates all 72 lint errors — build and lint now fully clean (0 errors, 5 intentional exhaustive-deps warnings)
- Replaces `any` types with proper interfaces across all production and test files
- Refactors `ImportSettingsDialog` to derive state via `useMemo` instead of `setState` in effects (fixes `react-hooks/set-state-in-effect`)
- Adds `WebGLLocations` interface distinguishing attribute (`number`) vs uniform (`WebGLUniformLocation`) locations
- Fixes `react-compiler` error in `ChartContainer` by adding missing `datasets`/`series` to `useMemo` deps
- Adds `ParseSettings` / `ColumnConfigEntry` interfaces to data-parser worker
- Replaces `no-this-alias` pattern in test with `mock.instances` approach

## Test plan
- [x] `npm run build` passes with no type errors
- [x] `npm run lint` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)