### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure deserialization in localStorage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-05 - [localStorage Parsing Denial of Service]
+**Vulnerability:** The application blindly parsed `localStorage` state using `JSON.parse` without error handling. If a malicious actor or extension corrupted the `webgraphy-state` item with invalid JSON, the resulting `SyntaxError` would crash the application on initialization (Client-Side DoS).
+**Learning:** Client-side storage (localStorage, sessionStorage, IndexedDB) must be treated as untrusted input. It can be modified externally or corrupted.
+**Prevention:** Always wrap `JSON.parse` operations on client-side storage within a `try...catch` block. Handle the error gracefully by returning a safe default (e.g., `null`) and logging the event without exposing stack traces to the user interface.

--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -182,10 +182,19 @@ export const persistence = {
     await db.delete(DATASET_STORE, id);
   },
   saveAppState(state: AppState): void {
-    localStorage.setItem('webgraphy-state', JSON.stringify(state));
+    try {
+      localStorage.setItem('webgraphy-state', JSON.stringify(state));
+    } catch (error) {
+      console.error('Failed to save state to localStorage:', error);
+    }
   },
   loadAppState(): AppState | null {
-    const state = localStorage.getItem('webgraphy-state');
-    return state ? JSON.parse(state) : null;
+    try {
+      const state = localStorage.getItem('webgraphy-state');
+      return state ? JSON.parse(state) : null;
+    } catch (error) {
+      console.error('Failed to load state from localStorage:', error);
+      return null;
+    }
   }
 };


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix insecure deserialization in localStorage

🚨 Severity: MEDIUM
💡 Vulnerability: The application previously used `JSON.parse` on untrusted data from `localStorage` without a `try/catch` block. If the stored data was corrupted or maliciously modified by an extension or user script, the application would encounter a `SyntaxError` and fail to load (Client-Side DoS). Additionally, `localStorage.setItem` could throw `QuotaExceededError` leading to unhandled promise rejections.
🎯 Impact: A corrupted local storage item would prevent the application from loading for that specific user.
🔧 Fix: Wrapped both the read (`loadAppState`) and write (`saveAppState`) functions in `src/services/persistence.ts` with `try/catch` blocks. The loader now returns `null` on failure, and the saver logs the error, ensuring the application degrades gracefully.
✅ Verification: Ran all tests using `pnpm test` and ensured the linter passes using `pnpm lint`. All tests covering `persistence.ts` pass and behave as expected.

---
*PR created automatically by Jules for task [6498508907638433222](https://jules.google.com/task/6498508907638433222) started by @michaelkrisper*