### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits to view names

### DIFF
--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -211,7 +211,8 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
   saveView: (name) => {
     set((state) => {
-      let finalName = name.trim();
+      // SECURITY ENHANCEMENT: Input length limit to prevent DoS via large strings
+      let finalName = name.trim().slice(0, 100);
       if (!finalName) {
         const userViews = state.views.filter(v => v.id !== 'default-view');
         finalName = `View ${userViews.length + 1}`;
@@ -239,8 +240,10 @@ export const useGraphStore = create<GraphState>((set, get) => ({
   },
 
   updateViewName: (id, name) => {
+    // SECURITY ENHANCEMENT: Input length limit to prevent DoS via large strings
+    const finalName = name.trim().slice(0, 100);
     set((state) => ({
-      views: state.views.map(v => v.id === id ? { ...v, name } : v)
+      views: state.views.map(v => v.id === id ? { ...v, name: finalName } : v)
     }));
     if (get().isLoaded) debouncedSaveState();
   },


### PR DESCRIPTION
🛡️ Sentinel: Add input length limits to view names

*   **🚨 Severity:** MEDIUM
*   **💡 Vulnerability:** Missing input validation on user data (View Names).
*   **🎯 Impact:** A user could intentionally or accidentally provide an extremely large string as a view name, potentially causing UI rendering issues, exhausting LocalStorage quota, or causing a local Denial of Service (DoS) by bloating application state.
*   **🔧 Fix:** Implemented a 100-character input length limit (`.slice(0, 100)`) in the `saveView` and `updateViewName` functions within `src/store/useGraphStore.ts`.
*   **✅ Verification:** Run `pnpm lint` and `pnpm test` to verify changes. Creating a view with a name longer than 100 characters will now safely truncate it.

---
*PR created automatically by Jules for task [9468309644808259959](https://jules.google.com/task/9468309644808259959) started by @michaelkrisper*