### PR TITLE
Restore smooth animations (lerping) in ChartContainer

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -695,7 +695,7 @@ const ChartContainer: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (isLoaded) {
+    if (isLoaded && !isAnimating.current) {
       // If datasets are already present from persistence, don't auto-scale on load
       if (useGraphStore.getState().datasets.length > 0) wasEmptyRef.current = false;
       xAxes.forEach(axis => { targetXAxes.current[axis.id] = { min: axis.min, max: axis.max }; });


### PR DESCRIPTION
This PR fixes a regression where smooth animations (lerping) would "jump" once and stop instead of completing their movement.

The root cause was a `useEffect` hook in `ChartContainer.tsx` that synchronizes the animation targets (`targetXAxes.current` and `targetYs.current`) with the current store values. Since the animation loop updates the store values on every frame, this hook would trigger and reset the animation's target to the current (intermediate) position, effectively killing the animation.

Added an `!isAnimating.current` guard to the hook to ensure it only synchronizes targets when no animation is active.

Verified with:
1. `pnpm test` (all passed)
2. Manual visual verification via Playwright script (confirmed smooth panning on ArrowRight).
3. Code review (addressed lockfile bloat).

Fixes #123

---
*PR created automatically by Jules for task [4487433723259108843](https://jules.google.com/task/4487433723259108843) started by @michaelkrisper*