### PR TITLE
🧪 [testing improvement] Add test for generateDemoDataset chunk limits

### DIFF
--- a/src/services/__tests__/demoData.test.ts
+++ b/src/services/__tests__/demoData.test.ts
@@ -108,6 +108,38 @@ describe('demoData', () => {
       expect(dataset.data[4].refPoint + dataset.data[4].data[0]).toBeCloseTo(2, 2);
 
       vi.restoreAllMocks();
+    }, 10000);
+
+    it('should have valid chunkMin and chunkMax for each column', () => {
+      const dataset = generateDemoDataset();
+      const CHUNK_SIZE = 512;
+      const expectedNumChunks = Math.ceil(dataset.rowCount / CHUNK_SIZE);
+
+      dataset.data.forEach((column) => {
+        expect(column.chunkMin).toBeDefined();
+        expect(column.chunkMax).toBeDefined();
+        expect(column.chunkMin).toBeInstanceOf(Float32Array);
+        expect(column.chunkMax).toBeInstanceOf(Float32Array);
+        expect(column.chunkMin!.length).toBe(expectedNumChunks);
+        expect(column.chunkMax!.length).toBe(expectedNumChunks);
+
+        // Verify bounds for the first and last chunk
+        for (const chunkIndex of [0, expectedNumChunks - 1]) {
+          const start = chunkIndex * CHUNK_SIZE;
+          const end = Math.min(start + CHUNK_SIZE, dataset.rowCount);
+          let expectedMin = Infinity;
+          let expectedMax = -Infinity;
+
+          for (let i = start; i < end; i++) {
+            const val = column.data[i];
+            if (val < expectedMin) expectedMin = val;
+            if (val > expectedMax) expectedMax = val;
+          }
+
+          expect(column.chunkMin![chunkIndex]).toBeCloseTo(expectedMin, 4);
+          expect(column.chunkMax![chunkIndex]).toBeCloseTo(expectedMax, 4);
+        }
+      });
     });
   });
 


### PR DESCRIPTION
🎯 **What:** The previous test suite did not verify the `chunkMin` and `chunkMax` optimizations introduced for linear scanning in `generateDemoDataset`.
📊 **Coverage:** Added test case to ensure dataset chunks contain valid lengths and correct min/max bounds.
✨ **Result:** Improved test reliability by verifying caching boundaries and extending test execution timeouts on tests performing full dataset generation.

---
*PR created automatically by Jules for task [2112166329865425680](https://jules.google.com/task/2112166329865425680) started by @michaelkrisper*