### PR TITLE
🧪 test: add ImportSettingsDialog JSON parsing error path test

### DIFF
--- a/pr_desc.md
+++ b/pr_desc.md
@@ -1,3 +1,3 @@
-🎯 **What:** The `getDemoAppState` test previously used `generateDemoDataset()` which generated a full year of minute-by-minute data (525,600 rows). This was slow and violated unit testing principles by not isolating the function being tested.
-📊 **Coverage:** The test now uses a minimal mock dataset with 10 rows and explicit bounds, verifying that `getDemoAppState` correctly configures the AppState, axes, bounds, and series based on the provided dataset structure.
-✨ **Result:** Improved test execution time and better isolation of unit tests, preventing changes in `generateDemoDataset` from breaking the `getDemoAppState` tests.
+🎯 **What:** Added a missing test for the JSON parsing error path in `ImportSettingsDialog`. When parsing an invalid JSON file to generate a preview table, the component correctly catches the error and degrades gracefully without crashing the UI.
+📊 **Coverage:** The new test verifies that `ImportSettingsDialog` correctly handles unparseable JSON files by ensuring the dialog still renders and the fallback empty column configurations state is provided.
+✨ **Result:** Improved test coverage for `ImportSettingsDialog` ensuring robustness against invalid JSON data parsing.

--- a/src/components/Layout/__tests__/ImportSettingsDialog.test.tsx
+++ b/src/components/Layout/__tests__/ImportSettingsDialog.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ImportSettingsDialog } from '../ImportSettingsDialog';
+
+describe('ImportSettingsDialog', () => {
+  it('handles invalid JSON gracefully', () => {
+    const invalidJson = '{"broken": json';
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    // Mock console.error if needed, though secureJSONParse might throw directly handled by catch block.
+    // ImportSettingsDialog's catch block doesn't log to console based on my investigation, it just returns empty arrays.
+
+    render(
+      <ImportSettingsDialog
+        fileName="test.json"
+        fileContent={invalidJson}
+        fileType="json"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+
+    // Verify it renders the base dialog title
+    expect(screen.getByText('Import Settings: test.json')).toBeDefined();
+
+    // Verify it doesn't crash and renders the fallback empty table headers
+    // When error occurs, previewData.headers is [] and previewData.rows is []
+    // so no column configurations are rendered (no inputs with role column header)
+    const inputs = screen.queryAllByRole('textbox', { name: /Column .* name/i });
+    expect(inputs).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added a missing test for the JSON parsing error path in `ImportSettingsDialog`. When parsing an invalid JSON file to generate a preview table, the component correctly catches the error and degrades gracefully without crashing the UI.
📊 **Coverage:** The new test verifies that `ImportSettingsDialog` correctly handles unparseable JSON files by ensuring the dialog still renders and the fallback empty column configurations state is provided.
✨ **Result:** Improved test coverage for `ImportSettingsDialog` ensuring robustness against invalid JSON data parsing.

---
*PR created automatically by Jules for task [7053001697568937074](https://jules.google.com/task/7053001697568937074) started by @michaelkrisper*