### PR TITLE
🧹 Extract dataset prefixing logic in useDataImport

### DIFF
--- a/src/hooks/useDataImport.ts
+++ b/src/hooks/useDataImport.ts
@@ -3,6 +3,18 @@ import { persistence, type Dataset } from '../services/persistence';
 import { useGraphStore } from '../store/useGraphStore';
 import type { ImportSettings } from '../types/import';
 
+
+const processImportedDataset = (ds: Dataset, currentDatasetsLength: number) => {
+  const letter = String.fromCharCode(65 + currentDatasetsLength);
+  const prefix = `${letter}: `;
+  ds.name = `${letter} - ${ds.name}`;
+  ds.columns = ds.columns.map(c => `${prefix}${c}`);
+  if (ds.xAxisColumn) {
+    ds.xAxisColumn = `${prefix}${ds.xAxisColumn}`;
+  }
+  return ds;
+};
+
 /**
  * Hook to manage data import logic and worker communication.
  */
@@ -39,17 +51,8 @@ export const useDataImport = () => {
       const { type: msgType, dataset, error: msgError } = event.data;
 
       if (msgType === 'success') {
-        const ds = dataset as Dataset;
-        const currentDatasets = useGraphStore.getState().datasets;
-        
-        // Add A-Z prefix
-        const letter = String.fromCharCode(65 + currentDatasets.length);
-        const prefix = `${letter}: `;
-        ds.name = `${letter} - ${ds.name}`;
-        ds.columns = ds.columns.map(c => `${prefix}${c}`);
-        if (ds.xAxisColumn) {
-          ds.xAxisColumn = `${prefix}${ds.xAxisColumn}`;
-        }
+        const currentDatasetsLength = useGraphStore.getState().datasets.length;
+        const ds = processImportedDataset(dataset as Dataset, currentDatasetsLength);
 
         await persistence.saveDataset(ds);
         addDataset(ds);


### PR DESCRIPTION
🎯 What: Extracted the inline dataset prefix logic in `confirmImport` into a pure helper function `processImportedDataset`.
💡 Why: Extracted the logic out to shorten the long `confirmImport` callback and improve code readability.
✅ Verification: Ran `pnpm test` and ensured no existing logic or tests broke.
✨ Result: The `useDataImport` hook and its `confirmImport` function are significantly shorter, and the complex transformation logic is separated out.

---
*PR created automatically by Jules for task [14146294177172159135](https://jules.google.com/task/14146294177172159135) started by @michaelkrisper*