### PR TITLE
Fix memory leak in PNG export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The application blindly parsed `localStorage` state using `JSON.parse` without error handling. If a malicious actor or extension corrupted the `webgraphy-state` item with invalid JSON, the resulting `SyntaxError` would crash the application on initialization (Client-Side DoS).
 **Learning:** Client-side storage (localStorage, sessionStorage, IndexedDB) must be treated as untrusted input. It can be modified externally or corrupted.
 **Prevention:** Always wrap `JSON.parse` operations on client-side storage within a `try...catch` block. Handle the error gracefully by returning a safe default (e.g., `null`) and logging the event without exposing stack traces to the user interface.
+## 2026-04-11 - [Export PNG Memory Leak]
+**Vulnerability:** In `exportToPNG`, a Blob URL is generated from the generated SVG to render on a canvas but `img.onerror` was not handled. If the SVG fails to load (e.g. malformed markup), the image will not trigger `img.onload`, the Promise won't resolve or reject, and the Object URL will never be revoked, leading to an unhandled promise rejection and a memory leak (Client-side DoS pattern).
+**Learning:** When using object URLs (`URL.createObjectURL`), ensure they are reliably revoked by handling all completion paths (success and error).
+**Prevention:** Always add `.onerror` handlers alongside `.onload` handlers when generating URLs from Blobs and revoke them consistently in all code paths.

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -225,12 +225,13 @@ export const formatDate = (val: number, step: number) => {
 
 export const exportToPNG = async (datasets: Dataset[], series: SeriesConfig[], xAxes: XAxisConfig[], yAxes: YAxisConfig[], axisTitles: { x: string, y: string }, width: number, height: number): Promise<string> => {
   const svgString = exportToSVG(datasets, series, xAxes, yAxes, axisTitles, width, height);
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const canvas = document.createElement('canvas'), dpr = window.devicePixelRatio || 1;
     canvas.width = width * dpr; canvas.height = height * dpr;
     const ctx = canvas.getContext('2d')!; ctx.scale(dpr, dpr);
     const img = new Image(), svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' }), url = URL.createObjectURL(svgBlob);
     img.onload = () => { ctx.fillStyle = 'white'; ctx.fillRect(0, 0, width, height); ctx.drawImage(img, 0, 0, width, height); URL.revokeObjectURL(url); resolve(canvas.toDataURL('image/png')); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('Failed to load SVG into image for PNG export')); };
     img.src = url;
   });
 };


### PR DESCRIPTION
Fixes a memory leak and unhandled promise rejection in `exportToPNG` when exporting to PNG. An `onerror` handler was added to ensure the `ObjectURL` is revoked even if the image fails to load.

---
*PR created automatically by Jules for task [12049236672616630070](https://jules.google.com/task/12049236672616630070) started by @michaelkrisper*