### PR TITLE
⚡ Bolt: Optimize dataset column index lookup

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -4,6 +4,7 @@ import { WebGLRenderer } from './WebGLRenderer';
 import { useGraphStore } from '../../store/useGraphStore';
 import { type YAxisConfig, type XAxisConfig, type SeriesConfig, type Dataset } from '../../services/persistence';
 import { getTimeStep, generateTimeTicks, generateSecondaryLabels, formatFullDate, type TimeTick, type SecondaryLabel } from '../../utils/time';
+import { getColumnIndex } from '../../utils/columns';
 
 const BASE_PADDING_DESKTOP = { top: 20, right: 20, bottom: 60, left: 20 };
 const BASE_PADDING_MOBILE = { top: 10, right: 10, bottom: 40, left: 10 };
@@ -409,14 +410,8 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
       const xAxis = xAxes.find(a => a.id === (ds?.xAxisId || 'axis-1'));
       if (!ds || !axis || !xAxis) return null;
 
-      const findColumn = (name: string) => {
-        const idx = ds.columns.indexOf(name);
-        if (idx !== -1) return idx;
-        return ds.columns.findIndex(c => c.endsWith(`: ${name}`) || c === name);
-      };
-
-      const xIdx = findColumn(ds.xAxisColumn);
-      const yIdx = findColumn(s.yColumn);
+      const xIdx = getColumnIndex(ds, ds.xAxisColumn);
+      const yIdx = getColumnIndex(ds, s.yColumn);
 
       if (xIdx === -1 || yIdx === -1) return null;
 
@@ -904,7 +899,7 @@ const ChartContainer: React.FC = () => {
          const xAxis = state.xAxes.find(a => a.id === (ds?.xAxisId || 'axis-1'));
          if (!ds || !xAxis) return;
 
-         const xIdx = ds.columns.indexOf(ds.xAxisColumn);
+         const xIdx = getColumnIndex(ds, ds.xAxisColumn);
          const xCol = ds.data[xIdx];
          
          if (xCol && xCol.bounds) {
@@ -927,7 +922,7 @@ const ChartContainer: React.FC = () => {
       state.series.forEach(s => {
         const ds = datasetsById.get(s.sourceId);
         if (!ds) return;
-        const xIdx = ds.columns.indexOf(ds.xAxisColumn);
+        const xIdx = getColumnIndex(ds, ds.xAxisColumn);
         const col = ds.data[xIdx];
         if (!col || !col.bounds) return;
         const xId = ds.xAxisId || 'axis-1';
@@ -960,7 +955,8 @@ const ChartContainer: React.FC = () => {
         let yMin = Infinity, yMax = -Infinity;
         axisSeries.forEach(s => {
           const ds = datasetsById.get(s.sourceId); if (!ds) return;
-          const yCol = ds.data[ds.columns.indexOf(s.yColumn)]; if (!yCol || !yCol.bounds) return;
+          const yIdx = getColumnIndex(ds, s.yColumn);
+          const yCol = ds.data[yIdx]; if (!yCol || !yCol.bounds) return;
           if (yCol.bounds.min < yMin) yMin = yCol.bounds.min;
           if (yCol.bounds.max > yMax) yMax = yCol.bounds.max;
         });
@@ -1040,14 +1036,8 @@ const ChartContainer: React.FC = () => {
       const xAxis = state.xAxes.find(a => a.id === (ds.xAxisId || 'axis-1'));
       if (!xAxis) return;
       
-      const findColumn = (name: string) => {
-        const idx = ds.columns.indexOf(name);
-        if (idx !== -1) return idx;
-        return ds.columns.findIndex((c: string) => c.endsWith(`: ${name}`) || c === name);
-      };
-
-      const xIdx = findColumn(ds.xAxisColumn);
-      const yIdx = findColumn(s.yColumn);
+      const xIdx = getColumnIndex(ds, ds.xAxisColumn);
+      const yIdx = getColumnIndex(ds, s.yColumn);
       if (xIdx === -1 || yIdx === -1) return;
 
       const colX = ds.data[xIdx];
@@ -1181,7 +1171,7 @@ const ChartContainer: React.FC = () => {
 
       let xMin = Infinity, xMax = -Infinity;
       activeDatasetsUsingAxis.forEach(ds => {
-        const xIdx = ds.columns.indexOf(ds.xAxisColumn);
+        const xIdx = getColumnIndex(ds, ds.xAxisColumn);
         const col = ds.data[xIdx];
         if (col && col.bounds) {
           if (col.bounds.min < xMin) xMin = col.bounds.min;

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState, useMemo } from 'react';
 import { type Dataset, type SeriesConfig, type YAxisConfig, type XAxisConfig } from '../../services/persistence';
+import { getColumnIndex } from '../../utils/columns';
 
 const VERTEX_SHADER_SOURCE = `
       attribute float a_x;
@@ -200,14 +201,8 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, xA
       const yAxis = yAxes.find(a => a.id === s.yAxisId);
       if (!ds || !xAxis || !yAxis) return null;
 
-      const findColumn = (name: string) => {
-        const idx = ds.columns.indexOf(name);
-        if (idx !== -1) return idx;
-        return ds.columns.findIndex(c => c.endsWith(`: ${name}`) || c === name);
-      };
-
-      const xIdx = findColumn(ds.xAxisColumn);
-      const yIdx = findColumn(s.yColumn);
+      const xIdx = getColumnIndex(ds, ds.xAxisColumn);
+      const yIdx = getColumnIndex(ds, s.yColumn);
 
       if (xIdx === -1 || yIdx === -1) {
         return null;

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -1,6 +1,7 @@
 import { type Dataset, type SeriesConfig, type YAxisConfig, type XAxisConfig } from './persistence';
 import { worldToScreen } from '../utils/coords';
 import { lttb } from '../utils/lttb';
+import { getColumnIndex } from '../utils/columns';
 
 const AXIS_WIDTH_BASE = 15; // Ticks, gap, and safe margin
 
@@ -113,14 +114,8 @@ export const exportToSVG = (
     const yAxis = yAxes.find(a => a.id === s.yAxisId);
     if (!ds || !xAxis || !yAxis) return;
 
-    const findColumn = (name: string) => {
-      const idx = ds.columns.indexOf(name);
-      if (idx !== -1) return idx;
-      return ds.columns.findIndex(c => c.endsWith(`: ${name}`) || c === name);
-    };
-
-    const xIdx = findColumn(ds.xAxisColumn);
-    const yIdx = findColumn(s.yColumn);
+    const xIdx = getColumnIndex(ds, ds.xAxisColumn);
+    const yIdx = getColumnIndex(ds, s.yColumn);
     if (xIdx === -1 || yIdx === -1) return;
 
     const xCol = ds.data[xIdx], yCol = ds.data[yIdx], visibleData = [];

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { type Dataset, type SeriesConfig, persistence, type AppState, type YAxisConfig, type XAxisConfig, type ViewSnapshot } from '../services/persistence';
 import { generateDemoDataset, getDemoAppState } from '../services/demoData';
+import { getColumnIndex } from '../utils/columns';
 
 interface GraphState {
   datasets: Dataset[];
@@ -83,7 +84,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         dataset.xAxisId = unusedAxis.id;
       }
 
-      const xColIdx = dataset.columns.indexOf(dataset.xAxisColumn);
+      const xColIdx = getColumnIndex(dataset, dataset.xAxisColumn);
       const col = dataset.data[xColIdx];
       const bounds = col?.bounds || { min: 0, max: 100 };
       const isDate = col?.isFloat64 || false;

--- a/src/utils/columns.ts
+++ b/src/utils/columns.ts
@@ -1,0 +1,31 @@
+import { type Dataset } from '../services/persistence';
+
+const columnCache = new WeakMap<Dataset, Map<string, number>>();
+
+/**
+ * ⚡ Bolt Optimization:
+ * O(1) cached lookup for dataset column indices, replacing O(N) inline find/indexOf
+ * operations with string comparisons (`endsWith`) in hot paths (render/interaction loops).
+ */
+export function getColumnIndex(ds: Dataset, columnName: string): number {
+  let cache = columnCache.get(ds);
+  if (!cache) {
+    cache = new Map<string, number>();
+    columnCache.set(ds, cache);
+  }
+
+  const cachedValue = cache.get(columnName);
+  if (cachedValue !== undefined) {
+    return cachedValue;
+  }
+
+  const idx = ds.columns.indexOf(columnName);
+  if (idx !== -1) {
+    cache.set(columnName, idx);
+    return idx;
+  }
+
+  const suffixIdx = ds.columns.findIndex(c => c.endsWith(`: ${columnName}`) || c === columnName);
+  cache.set(columnName, suffixIdx);
+  return suffixIdx;
+}


### PR DESCRIPTION
💡 **What:** Replaced inline `indexOf` and `findIndex` calls for retrieving column indices with a new `getColumnIndex` utility (`src/utils/columns.ts`). This utility uses a `WeakMap` to cache lookups per dataset.
🎯 **Why:** To eliminate redundant O(N) array traversals and string comparisons (`endsWith`) that were happening repeatedly during high-frequency events like mouse tracking (`ChartContainer.tsx` crosshair/snap), scaling (`handleAutoScaleX/Y`), and rendering (`WebGLRenderer.tsx`).
📊 **Impact:** Reduces computational overhead in render and interaction loops. Lookups are now O(1) after the first scan per column per dataset.
🔬 **Measurement:** Confirmed test suite runs without regressions and verified expected optimization pattern.

---
*PR created automatically by Jules for task [17642818122374403307](https://jules.google.com/task/17642818122374403307) started by @michaelkrisper*