### PR TITLE
Security Hardening: Verify secureJSONParse and Enhance Tests

### DIFF
--- a/src/utils/__tests__/json.test.ts
+++ b/src/utils/__tests__/json.test.ts
@@ -45,6 +45,37 @@ describe('secureJSONParse', () => {
     expect(result).toEqual([{}, { valid: 1 }]);
   });
 
+  it('should filter out dangerous keys in deeply nested structures', () => {
+    // Note: We use computed property names or raw strings because JSON.stringify
+    // skips __proto__ when defined directly in an object literal.
+    const json = JSON.stringify({
+      level1: {
+        ['__proto__']: { polluted: 'level1' },
+        level2: [
+          {
+            constructor: { prototype: { polluted: 'level2' } },
+            valid: true
+          },
+          {
+            prototype: { polluted: 'level2_alt' },
+            nested: {
+              ['__proto__']: { polluted: 'level3' }
+            }
+          }
+        ]
+      }
+    });
+    const result = secureJSONParse(json) as any;
+    expect(result.level1.__proto__).not.toHaveProperty('polluted');
+    expect(result.level1.level2[0].constructor).toBe(Object);
+    expect(result.level1.level2[0].valid).toBe(true);
+    expect(result.level1.level2[1].prototype).toBeUndefined();
+    expect(result.level1.level2[1].nested.__proto__).not.toHaveProperty('polluted');
+
+    // Check global state
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
   it('should throw error for invalid JSON', () => {
     const json = '{"invalid": }';
     expect(() => secureJSONParse(json)).toThrow();


### PR DESCRIPTION
The task was to ensure `secureJSONParse` is used instead of native `JSON.parse` in `src/workers/data-parser.worker.ts` to prevent prototype pollution. 

Upon investigation, it was found that the worker already implemented this security fix. To provide a complete solution, I:
1. Conducted a codebase-wide audit to ensure no other unsanitized `JSON.parse` calls were present in `src/`.
2. Enhanced the test suite for `secureJSONParse` by adding a test case that specifically targets deeply nested structures, ensuring that recursive objects and arrays are correctly sanitized.
3. Refined the test implementation to use computed property names (e.g., `['__proto__']`) to bypass the behavior where `JSON.stringify` omits a literal `__proto__` key.
4. Manually verified the logic with a custom script to guarantee correctness.

---
*PR created automatically by Jules for task [18270652680191990206](https://jules.google.com/task/18270652680191990206) started by @michaelkrisper*