### PR TITLE
🧪 Add edge case test for empty dataset in DataViewModal

### DIFF
--- a/src/components/Layout/DataViewModal.tsx
+++ b/src/components/Layout/DataViewModal.tsx
@@ -42,7 +42,7 @@ export const DataViewModal: React.FC<DataViewModalProps> = ({ dataset, onClose }
           <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
             <thead>
               <tr style={{ backgroundColor: '#f8f9fa', borderBottom: '2px solid #dee2e6' }}>
-                {dataset.columns.map((col, i) => (
+                {(dataset.columns || []).map((col, i) => (
                   <th key={i} style={{ border: '1px solid #dee2e6', padding: '12px', textAlign: 'left', whiteSpace: 'nowrap' }}>
                     {col}
                   </th>
@@ -52,7 +52,7 @@ export const DataViewModal: React.FC<DataViewModalProps> = ({ dataset, onClose }
             <tbody>
               {rows.map(rowIndex => (
                 <tr key={rowIndex} style={{ borderBottom: '1px solid #eee' }}>
-                  {dataset.data.map((colData, colIndex) => {
+                  {(dataset.data || []).map((colData, colIndex) => {
                     const rawValue = colData.data[rowIndex];
                     const absoluteValue = rawValue + colData.refPoint;
 

--- a/src/components/Layout/__tests__/DataViewModal.test.tsx
+++ b/src/components/Layout/__tests__/DataViewModal.test.tsx
@@ -28,4 +28,49 @@ describe('DataViewModal', () => {
     expect(screen.getByText('Time')).toBeInTheDocument();
     expect(screen.getByText('Value')).toBeInTheDocument();
   });
+
+  it('renders safely with a completely empty dataset (zero columns and data arrays)', () => {
+    const mockDataset = {
+      id: 'ds-3',
+      name: 'No Columns Dataset',
+      columns: [],
+      data: [],
+      rowCount: 0,
+      xAxisColumn: '',
+      xAxisId: 'x-3'
+    };
+
+    const onClose = vi.fn();
+
+    render(<DataViewModal dataset={mockDataset as any} onClose={onClose} />);
+
+    expect(screen.getByText('Data Source: No Columns Dataset')).toBeInTheDocument();
+    expect(screen.getByText('Showing first 0 of 0 rows.')).toBeInTheDocument();
+  });
+
+  it('renders with some data', () => {
+    const mockDataset = {
+      id: 'ds-2',
+      name: 'Dataset With Data',
+      columns: ['Time', 'Value'],
+      data: [
+        { isFloat64: true, refPoint: 1672531200000, bounds: { min: 1672531200000, max: 1672531200000 }, data: new Float32Array([0]) },
+        { isFloat64: false, refPoint: 0, bounds: { min: 42.5, max: 42.5 }, data: new Float32Array([42.5]) }
+      ],
+      rowCount: 1,
+      xAxisColumn: 'Time',
+      xAxisId: 'x-2'
+    };
+
+    const onClose = vi.fn();
+
+    // use `as any` as the `dataset` type might be more strict
+    render(<DataViewModal dataset={mockDataset as any} onClose={onClose} />);
+
+    expect(screen.getByText('Data Source: Dataset With Data')).toBeInTheDocument();
+    expect(screen.getByText('Showing first 1 of 1 rows.')).toBeInTheDocument();
+
+    // Value test
+    expect(screen.getByText('42.5')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
🎯 What: Added tests to handle completely empty datasets and datasets with actual values, while defensively handling rendering of missing/undefined columns and data in the modal component.
📊 Coverage: Completely empty datasets and datasets with sample values are now fully tested.
✨ Result: The modal correctly and safely displays 'Showing first 0 of 0 rows.' when empty without crashing, increasing test coverage and reliability.

---
*PR created automatically by Jules for task [15230090100767361856](https://jules.google.com/task/15230090100767361856) started by @michaelkrisper*