### PR TITLE
🧪 Improve LicenseModal testing coverage

### DIFF
--- a/src/components/Layout/__tests__/LicenseModal.test.tsx
+++ b/src/components/Layout/__tests__/LicenseModal.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { LicenseModal } from '../LicenseModal';
@@ -7,8 +8,8 @@ describe('LicenseModal', () => {
     const onClose = vi.fn();
     render(<LicenseModal onClose={onClose} />);
 
-    expect(screen.getByRole('heading', { name: 'License' })).toBeDefined();
-    expect(screen.getByText(/MIT License/i)).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'License' })).toBeInTheDocument();
+    expect(screen.getByText(/MIT License/i)).toBeInTheDocument();
   });
 
   it('calls onClose when the close button is clicked', () => {


### PR DESCRIPTION
🎯 **What:** The `LicenseModal` test assertions were updated to match the project's testing conventions by importing and using `@testing-library/jest-dom`.
📊 **Coverage:** Changed `.toBeDefined()` to `.toBeInTheDocument()` for stronger, DOM-specific assertions.
✨ **Result:** Better and more robust testing coverage for the LicenseModal component that catches real potential rendering bugs instead of just checking variable definition.

---
*PR created automatically by Jules for task [5768796382356890764](https://jules.google.com/task/5768796382356890764) started by @michaelkrisper*