### PR TITLE
Streamline Data Series configuration UI into a raster

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -3,7 +3,7 @@ import { useGraphStore } from '../../store/useGraphStore';
 import { useDataImport } from '../../hooks/useDataImport';
 import { SeriesConfigUI } from '../Sidebar/SeriesConfig';
 import { persistence } from '../../services/persistence';
-import { FilePlus, Layout, Trash2, ChevronRight, ChevronUp, ChevronDown, HelpCircle, X, Eye, FileImage, Image, RotateCcw, Bookmark, Upload, Clock, Hash } from 'lucide-react';
+import { FilePlus, Layout, Trash2, ChevronRight, ChevronUp, ChevronDown, HelpCircle, X, Eye, FileImage, Image, RotateCcw, Bookmark, Upload, Clock, Hash, ArrowUpDown, MoveHorizontal, Minus, Circle, Palette, Type, Rows } from 'lucide-react';
 import { ImportSettingsDialog } from './ImportSettingsDialog';
 import { DataViewModal } from './DataViewModal';
 
@@ -366,6 +366,21 @@ export const Sidebar: React.FC = () => {
             </div>
             {openSections.series && <div className="series-list" style={{ marginBottom: '1rem' }}>
               {series.length === 0 && <p style={{ fontSize: 'var(--mobile-font-size)', color: '#666', padding: '8px' }}>Click a column above to add a series.</p>}
+              {series.length > 0 && (
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(8, var(--touch-target-size)) 100px 1fr var(--touch-target-size)', gap: '4px', padding: '4px 0', borderBottom: '2px solid var(--border-color)', color: '#64748b', alignItems: 'center', position: 'sticky', top: 0, background: 'var(--sidebar-bg)', zIndex: 1 }}>
+                  <div title="Order" style={{ display: 'flex', justifyContent: 'center' }}><ArrowUpDown size={14} /></div>
+                  <div title="Y-Axis #" style={{ display: 'flex', justifyContent: 'center' }}><Hash size={14} /></div>
+                  <div title="Side (L/R)" style={{ display: 'flex', justifyContent: 'center' }}><MoveHorizontal size={14} /></div>
+                  <div title="Grid" style={{ display: 'flex', justifyContent: 'center' }}><Rows size={14} /></div>
+                  <div title="Line Style" style={{ display: 'flex', justifyContent: 'center' }}><Minus size={14} /></div>
+                  <div title="Line Width" style={{ display: 'flex', justifyContent: 'center', fontSize: '10px', fontWeight: 'bold' }}>W</div>
+                  <div title="Point Style" style={{ display: 'flex', justifyContent: 'center' }}><Circle size={12} /></div>
+                  <div title="Color" style={{ display: 'flex', justifyContent: 'center' }}><Palette size={14} /></div>
+                  <div title="Data Column" style={{ paddingLeft: '4px', fontSize: '10px', fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>COL</div>
+                  <div title="Series Name" style={{ paddingLeft: '4px', fontSize: '10px', fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>NAME</div>
+                  <div />
+                </div>
+              )}
               {[...series].reverse().map((s, i) => {
                 const dataset = datasets.find(d => d.id === s.sourceId);
                 return (

--- a/src/components/Sidebar/SeriesConfig.tsx
+++ b/src/components/Sidebar/SeriesConfig.tsx
@@ -68,7 +68,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
   };
 
   return (
-    <div style={{ borderBottom: '1px solid #e2e8f0', padding: '6px 0', fontSize: 'var(--mobile-font-size)', display: 'flex', gap: '6px', alignItems: 'center', flexWrap: 'wrap' }}>
+    <div style={{ borderBottom: '1px solid #e2e8f0', padding: '4px 0', fontSize: 'var(--mobile-font-size)', display: 'grid', gridTemplateColumns: 'repeat(8, var(--touch-target-size)) 100px 1fr var(--touch-target-size)', gap: '4px', alignItems: 'center' }}>
       {/* Reorder Buttons (UP/DOWN) */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '1px', background: '#f1f5f9', borderRadius: '3px', padding: '1px' }}>
         <button
@@ -99,7 +99,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
       </button>
 
       {/* L/R Side Toggle */}
-      {currentYAxis && (
+      {currentYAxis ? (
         <button
           onClick={() => updateYAxis(currentYAxis.id, { position: currentYAxis.position === 'left' ? 'right' : 'left' })}
           style={{ width: 'var(--touch-target-size)', height: 'var(--touch-target-size)', fontSize: 'var(--mobile-font-size)', padding: '0', cursor: 'pointer', background: '#f1f5f9', border: '1px solid #cbd5e1', borderRadius: '4px', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#475569' }}
@@ -115,10 +115,10 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
             </svg>
           )}
         </button>
-      )}
+      ) : <div style={{ width: 'var(--touch-target-size)' }} />}
 
       {/* Grid Toggle */}
-      {currentYAxis && (
+      {currentYAxis ? (
         <button
           onClick={() => updateYAxis(currentYAxis.id, { showGrid: !currentYAxis.showGrid })}
           style={{ width: 'var(--touch-target-size)', height: 'var(--touch-target-size)', padding: '0', cursor: 'pointer', background: currentYAxis.showGrid ? '#f1f5f9' : '#f8fafc', border: '1px solid #cbd5e1', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, color: '#475569' }}
@@ -126,7 +126,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
          aria-label="Toggle Grid">
           {currentYAxis.showGrid ? <Rows size={16} /> : <Square size={16} />}
         </button>
-      )}
+      ) : <div style={{ width: 'var(--touch-target-size)' }} />}
 
       {/* Line Style Cycle */}
       <button
@@ -148,7 +148,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
           const next = widths[(widths.indexOf(series.lineWidth) + 1) % widths.length];
           handleUpdate({ lineWidth: next });
         }}
-        style={{ padding: '0', cursor: 'pointer', background: '#f8fafc', border: '1px solid #cbd5e1', borderRadius: '2px', display: 'flex', alignItems: 'center', justifyContent: 'center', width: '20px', height: '20px', flexShrink: 0, color: '#475569' }}
+        style={{ padding: '0', cursor: 'pointer', background: '#f8fafc', border: '1px solid #cbd5e1', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center', width: 'var(--touch-target-size)', height: 'var(--touch-target-size)', flexShrink: 0, color: '#475569' }}
         title={`Line Width: ${series.lineWidth}`}
        aria-label="Cycle Line Width">
         {renderLineWidthIcon()}


### PR DESCRIPTION
I have refactored the Data Series configuration UI to use a compact raster (table-like) layout. 

Key changes:
1.  **SeriesConfig.tsx**: Replaced the flexbox-based layout with a CSS Grid layout for the `SeriesConfigUI` component. This ensures all configuration buttons (reorder, axis, grid, line style, color, etc.) are perfectly aligned in a single row.
2.  **SeriesConfig.tsx**: Standardized button widths to `var(--touch-target-size)` and added placeholder elements for conditional buttons (like Axis Side and Grid toggle) to maintain column alignment when a Y-axis is not yet assigned.
3.  **Sidebar.tsx**: Added a sticky header row above the Data Series list that uses the same Grid configuration as the rows. This header provides clear labels and icons for each column of the raster.
4.  **Sidebar.tsx**: Updated `lucide-react` imports to include the necessary icons for the new header.
5.  **Verified** the changes by inspecting the resulting JSX and ensuring that the layout is consistent and space-efficient.

These changes significantly reduce vertical space usage in the sidebar when multiple series are present and provide a much cleaner, "spreadsheet-like" overview of all data series settings.

Fixes #181

---
*PR created automatically by Jules for task [7922469718028218884](https://jules.google.com/task/7922469718028218884) started by @michaelkrisper*