### PR TITLE
⚡ Bolt: O(1) Map lookups for crosshair and WebGL render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,6 @@
 ## 2026-04-11 - [Optimize y-axis offsets from O(N^2) to O(1)]
 **Learning:** Computing cumulative sizes of sibling elements inline during mapping (like stacked y-axes offsets) involves iterating over previous elements inside the loop, creating an O(N^2) complexity. This happens on every render and export. Pre-calculating the sum using a simple object map eliminates this bottleneck entirely and is much faster.
 **Action:** When rendering stacked or sequential items based on dimensions of earlier items, compute a cumulative sum map (`Record<id, number>`) in a `useMemo` first, transforming nested iteration into O(1) lookups.
+## 2026-04-12 - [Avoid O(N) array loops in React render loops]
+**Learning:** Found O(N) `.find()` and array iteration bottlenecks inside React component `useMemo` hooks (`ChartContainer.tsx` and `WebGLRenderer.tsx`) running on high-frequency events.
+**Action:** Replaced inline array lookups with O(1) `Map` objects computed outside the inner loops to maintain stable performance during user interactions.

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -527,7 +527,7 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
     const finalXConf = bestSeriesXConf as XAxisConfig;
 
     // Collect all Y values from all series at this X, grouped by X-label and X-axis name
-    const entries: { xLabel: string, xAxisName: string, items: { label: string, value: number, color: string, xVal: number, isXDate: boolean }[] }[] = [];
+    const entriesMap = new Map<string, { xLabel: string, xAxisName: string, items: { label: string, value: number, color: string, xVal: number, isXDate: boolean }[] }>();
     seriesMetadata.forEach(({ series: s, ds, axis, xAxis, xCol, yCol }) => {
       const xData = xCol.data, yData = yCol.data;
       const refX = xCol.refPoint, refY = yCol.refPoint;
@@ -545,13 +545,16 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
         ? formatFullDate(xVal)
         : parseFloat(xVal.toPrecision(7)).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 10 });
 
-      let group = entries.find(g => g.xLabel === xLab && g.xAxisName === xAxis.name);
+      const xAxisName = xAxis.name || `X-Axis ${ds.xAxisId}`;
+      const groupKey = `${xLab}|${xAxisName}`;
+      let group = entriesMap.get(groupKey);
       if (!group) {
-        group = { xLabel: xLab, xAxisName: xAxis.name || `X-Axis ${ds.xAxisId}`, items: [] };
-        entries.push(group);
+        group = { xLabel: xLab, xAxisName, items: [] };
+        entriesMap.set(groupKey, group);
       }
       group.items.push({ label: displayLabel, value: yVal, color: s.lineColor || '#333', xVal, isXDate: xAxis.xMode === 'date' });
     });
+    const entries = Array.from(entriesMap.values());
 
     // Screen position of the snapped point
     const snapScreenX = worldToScreen(finalBestXWorld, 0, { xMin: finalXConf.min, xMax: finalXConf.max, yMin: 0, yMax: 100, width, height, padding }).x;

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -195,10 +195,19 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, xA
 
   // ⚡ Bolt Optimization: Pre-calculate series metadata to avoid O(N) array/string operations inside the render loop
   const seriesMetadata = useMemo(() => {
+    const datasetsById = new Map<string, Dataset>();
+    datasets.forEach(d => datasetsById.set(d.id, d));
+
+    const xAxesById = new Map<string, XAxisConfig>();
+    xAxes.forEach(a => xAxesById.set(a.id, a));
+
+    const yAxesById = new Map<string, YAxisConfig>();
+    yAxes.forEach(a => yAxesById.set(a.id, a));
+
     return series.map(s => {
-      const ds = datasets.find(d => d.id === s.sourceId);
-      const xAxis = xAxes.find(a => a.id === (ds?.xAxisId || 'axis-1'));
-      const yAxis = yAxes.find(a => a.id === s.yAxisId);
+      const ds = datasetsById.get(s.sourceId);
+      const xAxis = xAxesById.get(ds?.xAxisId || 'axis-1');
+      const yAxis = yAxesById.get(s.yAxisId);
       if (!ds || !xAxis || !yAxis) return null;
 
       const xIdx = getColumnIndex(ds, ds.xAxisColumn);


### PR DESCRIPTION
💡 **What:** Replaced `Array.prototype.find()` operations inside hot loops (`snap` in `ChartContainer.tsx` and `seriesMetadata` in `WebGLRenderer.tsx`) with pre-calculated Javascript `Map` objects.

🎯 **Why:** The previous code performed nested O(N) array searches on every mouse movement (for the crosshair) and on every render (for WebGL config). By converting these to O(1) map lookups, we significantly reduce time complexity from O(S * D) to O(S + D), mitigating frame drops and interaction latency when plotting multiple series and axes.

📊 **Impact:** Reduces crosshair interaction calculation time and render loop config preparation time, ensuring O(1) lookups regardless of the number of axes or series.

🔬 **Measurement:** Verify by plotting numerous series and moving the mouse across the chart. The crosshair updates and rendering should remain smooth without JS execution spikes. All unit tests (`pnpm test`) pass successfully.

---
*PR created automatically by Jules for task [10148733148061136838](https://jules.google.com/task/10148733148061136838) started by @michaelkrisper*