### PR TITLE
🧹 Refactor duplicated Modal layouts into a reusable component

### DIFF
--- a/src/components/Layout/DataViewModal.tsx
+++ b/src/components/Layout/DataViewModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { X } from 'lucide-react';
 import { type Dataset } from '../../services/persistence';
 import { formatFullDate } from '../../utils/time';
+import { Modal } from './Modal';
 
 interface DataViewModalProps {
   dataset: Dataset;
@@ -17,70 +17,14 @@ export const DataViewModal: React.FC<DataViewModalProps> = ({ dataset, onClose }
   const rows = Array.from({ length: maxRows }, (_, i) => i);
 
   return (
-    <div style={{
-      position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
-      backgroundColor: 'rgba(0, 0, 0, 0.5)', display: 'flex',
-      alignItems: 'center', justifyContent: 'center', zIndex: 9999, backdropFilter: 'blur(2px)'
-    }}>
-      <div style={{
-        backgroundColor: '#fff', padding: '16px', borderRadius: '8px',
-        maxWidth: '1000px', width: '95%', maxHeight: '90vh', overflowY: 'auto',
-        boxShadow: '0 4px 20px rgba(0,0,0,0.15)', display: 'flex', flexDirection: 'column'
-      }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
-          <h2 style={{ margin: 0, fontSize: '1.2rem' }}>Data Source: {dataset.name}</h2>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '8px', minWidth: '44px', minHeight: '44px', display: 'flex', alignItems: 'center', justifyContent: 'center' }} aria-label="Close dialog">
-            <X size={24} />
-          </button>
-        </div>
-
-        <div style={{ marginBottom: '12px', fontSize: '1rem', color: '#666' }}>
-          Showing first {maxRows} of {dataset.rowCount.toLocaleString()} rows.
-        </div>
-
-        <div style={{ overflowX: 'auto', border: '1px solid #dee2e6', borderRadius: '4px' }}>
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
-            <thead>
-              <tr style={{ backgroundColor: '#f8f9fa', borderBottom: '2px solid #dee2e6' }}>
-                {(dataset.columns || []).map((col, i) => (
-                  <th key={i} style={{ border: '1px solid #dee2e6', padding: '12px', textAlign: 'left', whiteSpace: 'nowrap' }}>
-                    {col}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map(rowIndex => (
-                <tr key={rowIndex} style={{ borderBottom: '1px solid #eee' }}>
-                  {(dataset.data || []).map((colData, colIndex) => {
-                    const rawValue = colData.data[rowIndex];
-                    const absoluteValue = rawValue + colData.refPoint;
-
-                    let displayValue: string;
-                    if (colData.isFloat64 && !isNaN(absoluteValue)) {
-                      displayValue = formatFullDate(absoluteValue);
-                    } else if (isNaN(absoluteValue)) {
-                      displayValue = 'NaN';
-                    } else {
-                      // Format numbers with up to 4 decimal places
-                      displayValue = Number.isInteger(absoluteValue)
-                        ? absoluteValue.toString()
-                        : absoluteValue.toFixed(4).replace(/\.?0+$/, '');
-                    }
-
-                    return (
-                      <td key={colIndex} style={{ border: '1px solid #dee2e6', padding: '12px' }}>
-                        {displayValue}
-                      </td>
-                    );
-                  })}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '20px' }}>
+    <Modal
+      onClose={onClose}
+      title={`Data Source: ${dataset.name}`}
+      maxWidth="1000px"
+      width="95%"
+      padding="16px"
+      footer={
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
           <button
             onClick={onClose}
             style={{ padding: '12px 32px', borderRadius: '4px', border: '1px solid #ced4da', background: '#fff', cursor: 'pointer', fontWeight: 'bold', minHeight: '44px', fontSize: '1rem' }}
@@ -88,7 +32,53 @@ export const DataViewModal: React.FC<DataViewModalProps> = ({ dataset, onClose }
             Close
           </button>
         </div>
+      }
+    >
+      <div style={{ marginBottom: '12px', fontSize: '1rem', color: '#666' }}>
+        Showing first {maxRows} of {dataset.rowCount.toLocaleString()} rows.
       </div>
-    </div>
+
+      <div style={{ overflowX: 'auto', border: '1px solid #dee2e6', borderRadius: '4px' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
+          <thead>
+            <tr style={{ backgroundColor: '#f8f9fa', borderBottom: '2px solid #dee2e6' }}>
+              {(dataset.columns || []).map((col, i) => (
+                <th key={i} style={{ border: '1px solid #dee2e6', padding: '12px', textAlign: 'left', whiteSpace: 'nowrap' }}>
+                  {col}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(rowIndex => (
+              <tr key={rowIndex} style={{ borderBottom: '1px solid #eee' }}>
+                {(dataset.data || []).map((colData, colIndex) => {
+                  const rawValue = colData.data[rowIndex];
+                  const absoluteValue = rawValue + colData.refPoint;
+
+                  let displayValue: string;
+                  if (colData.isFloat64 && !isNaN(absoluteValue)) {
+                    displayValue = formatFullDate(absoluteValue);
+                  } else if (isNaN(absoluteValue)) {
+                    displayValue = 'NaN';
+                  } else {
+                    // Format numbers with up to 4 decimal places
+                    displayValue = Number.isInteger(absoluteValue)
+                      ? absoluteValue.toString()
+                      : absoluteValue.toFixed(4).replace(/\.?0+$/, '');
+                  }
+
+                  return (
+                    <td key={colIndex} style={{ border: '1px solid #dee2e6', padding: '12px' }}>
+                      {displayValue}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Modal>
   );
 };

--- a/src/components/Layout/HelpModal.tsx
+++ b/src/components/Layout/HelpModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X } from 'lucide-react';
+import { Modal } from './Modal';
 
 interface HelpModalProps {
   onClose: () => void;
@@ -17,85 +17,46 @@ const Section: React.FC<{ title: string; children: React.ReactNode; first?: bool
 
 export const HelpModal: React.FC<HelpModalProps> = ({ onClose }) => {
   return (
-    <div style={{
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      backgroundColor: 'rgba(0, 0, 0, 0.5)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      zIndex: 9999,
-      backdropFilter: 'blur(2px)'
-    }}>
-      <div style={{
-        backgroundColor: '#fff',
-        padding: '30px',
-        borderRadius: '8px',
-        maxWidth: '720px',
-        width: '90%',
-        position: 'relative',
-        boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
-        maxHeight: '90vh',
-        overflowY: 'auto'
-      }}>
-        <button
-          onClick={onClose}
-          aria-label="Close Help"
-          style={{
-            position: 'absolute',
-            top: '16px',
-            right: '16px',
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            padding: '4px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}
-        >
-          <X size={20} />
-        </button>
+    <Modal
+      onClose={onClose}
+      title="Help & Interactions"
+      maxWidth="720px"
+      padding="30px"
+      ariaLabel="Close Help"
+    >
+      <Section title="Plot Area" first>
+        <li><strong>Mouse Wheel:</strong> Zoom in and out</li>
+        <li><strong>Click & Drag:</strong> Pan the chart</li>
+        <li><strong>Shift + Interaction:</strong> Synchronize all active X-axes (Zoom/Pan/Keys)</li>
+        <li><strong>CTRL + Drag:</strong> Draw a zoom selection box</li>
+        <li><strong>CTRL + C:</strong> Copy current tooltip data to clipboard</li>
+        <li><strong>Hover:</strong> Show tooltips for the nearest data points</li>
+        <li><strong>Double Click:</strong> Auto-scale to fit all data</li>
+      </Section>
 
-        <h2 style={{ marginTop: 0, marginBottom: '24px', color: '#333' }}>Help & Interactions</h2>
+      <Section title="Axes (X & Y)">
+        <li><strong>Mouse Wheel:</strong> Zoom only this specific axis</li>
+        <li><strong>Drag:</strong> Pan this specific axis</li>
+        <li><strong>Double Click:</strong> Auto-scale this specific axis</li>
+        <li><strong>CTRL + Dbl Click (Y):</strong> Auto-scale to top or bottom half of data</li>
+        <li><strong>Click on title:</strong> Rename the axis</li>
+      </Section>
 
-        <Section title="Plot Area" first>
-          <li><strong>Mouse Wheel:</strong> Zoom in and out</li>
-          <li><strong>Click & Drag:</strong> Pan the chart</li>
-          <li><strong>Shift + Interaction:</strong> Synchronize all active X-axes (Zoom/Pan/Keys)</li>
-          <li><strong>CTRL + Drag:</strong> Draw a zoom selection box</li>
-          <li><strong>CTRL + C:</strong> Copy current tooltip data to clipboard</li>
-          <li><strong>Hover:</strong> Show tooltips for the nearest data points</li>
-          <li><strong>Double Click:</strong> Auto-scale to fit all data</li>
-        </Section>
+      <Section title="Keyboard">
+        <li><strong>← →:</strong> Pan the X axis</li>
+        <li><strong>↑ ↓:</strong> Pan the Y axis (hovered axis, or all)</li>
+        <li><strong>+ / =:</strong> Zoom in on the X axis</li>
+        <li><strong>- / _:</strong> Zoom out on the X axis</li>
+        <li><strong>Shift + ← →:</strong> Pan all active X-axes together</li>
+        <li><strong>CTRL + + / -:</strong> Zoom the Y axis (while hovering an axis)</li>
+      </Section>
 
-        <Section title="Axes (X & Y)">
-          <li><strong>Mouse Wheel:</strong> Zoom only this specific axis</li>
-          <li><strong>Drag:</strong> Pan this specific axis</li>
-          <li><strong>Double Click:</strong> Auto-scale this specific axis</li>
-          <li><strong>CTRL + Dbl Click (Y):</strong> Auto-scale to top or bottom half of data</li>
-          <li><strong>Click on title:</strong> Rename the axis</li>
-        </Section>
-
-        <Section title="Keyboard">
-          <li><strong>← →:</strong> Pan the X axis</li>
-          <li><strong>↑ ↓:</strong> Pan the Y axis (hovered axis, or all)</li>
-          <li><strong>+ / =:</strong> Zoom in on the X axis</li>
-          <li><strong>- / _:</strong> Zoom out on the X axis</li>
-          <li><strong>Shift + ← →:</strong> Pan all active X-axes together</li>
-          <li><strong>CTRL + + / -:</strong> Zoom the Y axis (while hovering an axis)</li>
-        </Section>
-
-        <Section title="Sidebar">
-          <li><strong>Data Sources:</strong> Import large CSV or JSON files — parsed with LTTB downsampling for high performance</li>
-          <li><strong>Data Series:</strong> Map columns to X/Y axes and style lines/points</li>
-          <li><strong>Multiple Y-Axes:</strong> Each series can have an independent Y-axis with its own scale, position, and color</li>
-          <li><strong>Export:</strong> Save the current chart view as SVG or PNG</li>
-        </Section>
-      </div>
-    </div>
+      <Section title="Sidebar">
+        <li><strong>Data Sources:</strong> Import large CSV or JSON files — parsed with LTTB downsampling for high performance</li>
+        <li><strong>Data Series:</strong> Map columns to X/Y axes and style lines/points</li>
+        <li><strong>Multiple Y-Axes:</strong> Each series can have an independent Y-axis with its own scale, position, and color</li>
+        <li><strong>Export:</strong> Save the current chart view as SVG or PNG</li>
+      </Section>
+    </Modal>
   );
 };

--- a/src/components/Layout/ImportSettingsDialog.tsx
+++ b/src/components/Layout/ImportSettingsDialog.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useMemo } from 'react';
-import { X, Check } from 'lucide-react';
+import { Check } from 'lucide-react';
 import { secureJSONParse } from '../../utils/json';
 import type { ImportSettings, ColumnConfig, ColumnType } from '../../types/import';
+import { Modal } from './Modal';
 
 interface ImportSettingsDialogProps {
   fileName: string;
@@ -112,139 +113,14 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
   };
 
   return (
-    <div style={{
-      position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
-      backgroundColor: 'rgba(0, 0, 0, 0.5)', display: 'flex',
-      alignItems: 'center', justifyContent: 'center', zIndex: 9999, backdropFilter: 'blur(2px)'
-    }}>
-      <div style={{
-        backgroundColor: '#fff', padding: '16px', borderRadius: '8px',
-        maxWidth: '1000px', width: '95%', maxHeight: '90vh', overflowY: 'auto',
-        boxShadow: '0 4px 20px rgba(0,0,0,0.15)', display: 'flex', flexDirection: 'column'
-      }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
-          <h2 style={{ margin: 0, fontSize: '1.2rem' }}>Import Settings: {fileName}</h2>
-          <button onClick={onCancel} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '8px', minWidth: '44px', minHeight: '44px', display: 'flex', alignItems: 'center', justifyContent: 'center' }} aria-label="Close dialog"><X size={24} /></button>
-        </div>
-
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '12px', marginBottom: '20px', padding: '12px', backgroundColor: '#f8f9fa', borderRadius: '4px' }}>
-          {fileType === 'csv' && (
-            <div>
-              <label htmlFor="import-delimiter" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>Delimiter</label>
-              <select
-                id="import-delimiter"
-                value={delimiter}
-                onChange={e => setDelimiter(e.target.value)}
-                style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
-              >
-                <option value=",">Comma (,)</option>
-                <option value=";">Semicolon (;)</option>
-                <option value="\t">Tab</option>
-                <option value="|">Pipe (|)</option>
-              </select>
-            </div>
-          )}
-          <div>
-            <label htmlFor="import-decimal" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>Decimal Point</label>
-            <select
-              id="import-decimal"
-              value={decimalPoint}
-              onChange={e => setDecimalPoint(e.target.value)}
-              style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
-            >
-              <option value=".">Dot (.)</option>
-              <option value=",">Comma (,)</option>
-            </select>
-          </div>
-          <div>
-            <label htmlFor="import-start-row" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>Start Row</label>
-            <input
-              id="import-start-row"
-              type="number"
-              min="1"
-              value={startRow}
-              onChange={e => setStartRow(parseInt(e.target.value) || 1)}
-              style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
-            />
-          </div>
-          <div>
-            <label htmlFor="import-x-axis" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>X-Axis Column</label>
-            <select
-              id="import-x-axis"
-              value={xAxisColumn}
-              onChange={e => setXAxisColumnOverride(e.target.value)}
-              style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
-            >
-              {columnConfigs.filter(c => c.type !== 'ignore').map(c => (
-                <option key={c.index} value={c.name}>{c.name}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-
-        <div style={{ marginBottom: '20px', overflowX: 'auto' }}>
-          <h3 style={{ fontSize: '1rem', marginBottom: '10px' }}>Column Configuration & Preview</h3>
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
-            <thead>
-              <tr style={{ backgroundColor: '#e9ecef' }}>
-                {columnConfigs.map((config, i) => (
-                  <th key={i} style={{ border: '1px solid #dee2e6', padding: '12px', textAlign: 'left', minWidth: '180px' }}>
-                    <input
-                      type="text"
-                      maxLength={100}
-                      value={config.name}
-                      aria-label={`Column ${i + 1} name`}
-                      onChange={e => handleUpdateColumn(i, { name: e.target.value })}
-                      style={{ width: '100%', marginBottom: '8px', fontWeight: 'bold', border: '1px solid #dee2e6', background: '#fff', padding: '4px', fontSize: '14px', borderRadius: '4px' }}
-                    />
-                    <select
-                      value={config.type}
-                      aria-label={`Column ${i + 1} data type`}
-                      onChange={e => handleUpdateColumn(i, { type: e.target.value as ColumnType })}
-                      style={{ width: '100%', fontSize: '14px', marginBottom: '8px', height: '36px', borderRadius: '4px' }}
-                    >
-                      <option value="numeric">Numeric</option>
-                      <option value="date">Date/Time</option>
-                      <option value="categorical">Categorical</option>
-                      <option value="ignore">Ignore</option>
-                    </select>
-                    {config.type === 'date' && (
-                      <input
-                        type="text"
-                        placeholder="Format (e.g. YYYY-MM-DD)"
-                        maxLength={50}
-                        aria-label={`Column ${i + 1} date format`}
-                        value={config.dateFormat || ''}
-                        onChange={e => handleUpdateColumn(i, { dateFormat: e.target.value })}
-                        style={{ width: '100%', fontSize: '14px', padding: '6px', border: '1px solid #dee2e6', borderRadius: '4px' }}
-                      />
-                    )}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {previewData.rows.map((row, rowIndex) => (
-                <tr key={rowIndex}>
-                  {columnConfigs.map((config, colIndex) => (
-                    <td key={colIndex} style={{
-                      border: '1px solid #dee2e6',
-                      padding: '12px',
-                      color: config.type === 'ignore' ? '#adb5bd' : '#212529',
-                      backgroundColor: config.type === 'ignore' ? '#f8f9fa' : 'transparent'
-                    }}>
-                      {fileType === 'json'
-                        ? (row as Record<string, string>)[previewData.headers[colIndex]]
-                        : (row as string[])[colIndex]}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', marginTop: 'auto', flexWrap: 'wrap' }}>
+    <Modal
+      onClose={onCancel}
+      title={`Import Settings: ${fileName}`}
+      maxWidth="1000px"
+      width="95%"
+      padding="16px"
+      footer={
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', flexWrap: 'wrap' }}>
           <button
             onClick={onCancel}
             style={{ padding: '12px 24px', borderRadius: '4px', border: '1px solid #ced4da', background: '#fff', cursor: 'pointer', minHeight: '44px', fontSize: '1rem', flex: '1 1 auto' }}
@@ -258,7 +134,124 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
             <Check size={20} /> Import Data
           </button>
         </div>
+      }
+    >
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '12px', marginBottom: '20px', padding: '12px', backgroundColor: '#f8f9fa', borderRadius: '4px' }}>
+        {fileType === 'csv' && (
+          <div>
+            <label htmlFor="import-delimiter" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>Delimiter</label>
+            <select
+              id="import-delimiter"
+              value={delimiter}
+              onChange={e => setDelimiter(e.target.value)}
+              style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
+            >
+              <option value=",">Comma (,)</option>
+              <option value=";">Semicolon (;)</option>
+              <option value="\t">Tab</option>
+              <option value="|">Pipe (|)</option>
+            </select>
+          </div>
+        )}
+        <div>
+          <label htmlFor="import-decimal" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>Decimal Point</label>
+          <select
+            id="import-decimal"
+            value={decimalPoint}
+            onChange={e => setDecimalPoint(e.target.value)}
+            style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
+          >
+            <option value=".">Dot (.)</option>
+            <option value=",">Comma (,)</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="import-start-row" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>Start Row</label>
+          <input
+            id="import-start-row"
+            type="number"
+            min="1"
+            value={startRow}
+            onChange={e => setStartRow(parseInt(e.target.value) || 1)}
+            style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
+          />
+        </div>
+        <div>
+          <label htmlFor="import-x-axis" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>X-Axis Column</label>
+          <select
+            id="import-x-axis"
+            value={xAxisColumn}
+            onChange={e => setXAxisColumnOverride(e.target.value)}
+            style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
+          >
+            {columnConfigs.filter(c => c.type !== 'ignore').map(c => (
+              <option key={c.index} value={c.name}>{c.name}</option>
+            ))}
+          </select>
+        </div>
       </div>
-    </div>
+
+      <div style={{ marginBottom: '20px', overflowX: 'auto' }}>
+        <h3 style={{ fontSize: '1rem', marginBottom: '10px' }}>Column Configuration & Preview</h3>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
+          <thead>
+            <tr style={{ backgroundColor: '#e9ecef' }}>
+              {columnConfigs.map((config, i) => (
+                <th key={i} style={{ border: '1px solid #dee2e6', padding: '12px', textAlign: 'left', minWidth: '180px' }}>
+                  <input
+                    type="text"
+                    maxLength={100}
+                    value={config.name}
+                    aria-label={`Column ${i + 1} name`}
+                    onChange={e => handleUpdateColumn(i, { name: e.target.value })}
+                    style={{ width: '100%', marginBottom: '8px', fontWeight: 'bold', border: '1px solid #dee2e6', background: '#fff', padding: '4px', fontSize: '14px', borderRadius: '4px' }}
+                  />
+                  <select
+                    value={config.type}
+                    aria-label={`Column ${i + 1} data type`}
+                    onChange={e => handleUpdateColumn(i, { type: e.target.value as ColumnType })}
+                    style={{ width: '100%', fontSize: '14px', marginBottom: '8px', height: '36px', borderRadius: '4px' }}
+                  >
+                    <option value="numeric">Numeric</option>
+                    <option value="date">Date/Time</option>
+                    <option value="categorical">Categorical</option>
+                    <option value="ignore">Ignore</option>
+                  </select>
+                  {config.type === 'date' && (
+                    <input
+                      type="text"
+                      placeholder="Format (e.g. YYYY-MM-DD)"
+                      maxLength={50}
+                      aria-label={`Column ${i + 1} date format`}
+                      value={config.dateFormat || ''}
+                      onChange={e => handleUpdateColumn(i, { dateFormat: e.target.value })}
+                      style={{ width: '100%', fontSize: '14px', padding: '6px', border: '1px solid #dee2e6', borderRadius: '4px' }}
+                    />
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {previewData.rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {columnConfigs.map((config, colIndex) => (
+                  <td key={colIndex} style={{
+                    border: '1px solid #dee2e6',
+                    padding: '12px',
+                    color: config.type === 'ignore' ? '#adb5bd' : '#212529',
+                    backgroundColor: config.type === 'ignore' ? '#f8f9fa' : 'transparent'
+                  }}>
+                    {fileType === 'json'
+                      ? (row as Record<string, string>)[previewData.headers[colIndex]]
+                      : (row as string[])[colIndex]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Modal>
   );
 };

--- a/src/components/Layout/ImprintModal.tsx
+++ b/src/components/Layout/ImprintModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X } from 'lucide-react';
+import { Modal } from './Modal';
 
 interface ImprintModalProps {
   onClose: () => void;
@@ -7,63 +7,23 @@ interface ImprintModalProps {
 
 export const ImprintModal: React.FC<ImprintModalProps> = ({ onClose }) => {
   return (
-    <div style={{
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      backgroundColor: 'rgba(0, 0, 0, 0.5)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      zIndex: 9999,
-      backdropFilter: 'blur(2px)'
-    }}>
-      <div style={{
-        backgroundColor: '#fff',
-        padding: '24px',
-        borderRadius: '8px',
-        maxWidth: '500px',
-        width: '90%',
-        position: 'relative',
-        boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
-        maxHeight: '90vh',
-        overflowY: 'auto'
-      }}>
-        <button 
-          onClick={onClose}
-          aria-label="Close Imprint"
-          style={{
-            position: 'absolute',
-            top: '16px',
-            right: '16px',
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            padding: '4px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}
-        >
-          <X size={20} />
-        </button>
+    <Modal
+      onClose={onClose}
+      title="Imprint"
+      maxWidth="500px"
+      ariaLabel="Close Imprint"
+    >
+      <p style={{ lineHeight: '1.6', color: '#444' }}>
+        <strong>Michael Krisper</strong><br />
+        GitHub Repository: <br />
+        <a href="https://github.com/michaelkrisper/webgraphy" target="_blank" rel="noopener noreferrer" style={{ color: '#007bff' }}>
+          https://github.com/michaelkrisper/webgraphy
+        </a>
+      </p>
 
-        <h2 style={{ marginTop: 0, marginBottom: '20px', color: '#333' }}>Imprint</h2>
-        
-        <p style={{ lineHeight: '1.6', color: '#444' }}>
-          <strong>Michael Krisper</strong><br />
-          GitHub Repository: <br />
-          <a href="https://github.com/michaelkrisper/webgraphy" target="_blank" rel="noopener noreferrer" style={{ color: '#007bff' }}>
-            https://github.com/michaelkrisper/webgraphy
-          </a>
-        </p>
-
-        <p style={{ fontSize: '0.85em', color: '#666', marginTop: '30px', lineHeight: '1.5' }}>
-          This open-source project provides high-performance data visualization in the browser.
-        </p>
-      </div>
-    </div>
+      <p style={{ fontSize: '0.85em', color: '#666', marginTop: '30px', lineHeight: '1.5' }}>
+        This open-source project provides high-performance data visualization in the browser.
+      </p>
+    </Modal>
   );
 };

--- a/src/components/Layout/LicenseModal.tsx
+++ b/src/components/Layout/LicenseModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X } from 'lucide-react';
+import { Modal } from './Modal';
 
 interface LicenseModalProps {
   onClose: () => void;
@@ -7,52 +7,13 @@ interface LicenseModalProps {
 
 export const LicenseModal: React.FC<LicenseModalProps> = ({ onClose }) => {
   return (
-    <div style={{
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      backgroundColor: 'rgba(0, 0, 0, 0.5)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      zIndex: 9999,
-      backdropFilter: 'blur(2px)'
-    }}>
-      <div style={{
-        backgroundColor: '#fff',
-        padding: '24px',
-        borderRadius: '8px',
-        maxWidth: '600px',
-        width: '90%',
-        position: 'relative',
-        boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
-        maxHeight: '90vh',
-        overflowY: 'auto'
-      }}>
-        <button 
-          onClick={onClose}
-          aria-label="Close License"
-          style={{
-            position: 'absolute',
-            top: '16px',
-            right: '16px',
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            padding: '4px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}
-        >
-          <X size={20} />
-        </button>
-
-        <h2 style={{ marginTop: 0, marginBottom: '20px', color: '#333' }}>License</h2>
-        
-        <div style={{ fontSize: '0.9rem', lineHeight: '1.6', color: '#444', whiteSpace: 'pre-wrap', fontFamily: 'monospace', background: '#f8f9fa', padding: '15px', borderRadius: '4px', border: '1px solid #dee2e6' }}>
+    <Modal
+      onClose={onClose}
+      title="License"
+      maxWidth="600px"
+      ariaLabel="Close License"
+    >
+      <div style={{ fontSize: '0.9rem', lineHeight: '1.6', color: '#444', whiteSpace: 'pre-wrap', fontFamily: 'monospace', background: '#f8f9fa', padding: '15px', borderRadius: '4px', border: '1px solid #dee2e6' }}>
 {`MIT License
 
 Copyright (c) 2026 Michael Krisper
@@ -74,12 +35,11 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.`}
-        </div>
-
-        <p style={{ fontSize: '0.85em', color: '#666', marginTop: '20px', lineHeight: '1.5' }}>
-          This software is free to use, modify, and distribute, provided that the original copyright notice and this permission notice are included in all copies or substantial portions of the Software.
-        </p>
       </div>
-    </div>
+
+      <p style={{ fontSize: '0.85em', color: '#666', marginTop: '20px', lineHeight: '1.5' }}>
+        This software is free to use, modify, and distribute, provided that the original copyright notice and this permission notice are included in all copies or substantial portions of the Software.
+      </p>
+    </Modal>
   );
 };

--- a/src/components/Layout/Modal.tsx
+++ b/src/components/Layout/Modal.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { X } from 'lucide-react';
+
+interface ModalProps {
+  onClose: () => void;
+  title: string | React.ReactNode;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  maxWidth?: string;
+  width?: string;
+  padding?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * A reusable Modal component that provides a consistent backdrop and layout.
+ */
+export const Modal: React.FC<ModalProps> = ({
+  onClose,
+  title,
+  children,
+  footer,
+  maxWidth = '600px',
+  width = '90%',
+  padding = '24px',
+  ariaLabel
+}) => {
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 9999,
+      backdropFilter: 'blur(2px)'
+    }}>
+      <div style={{
+        backgroundColor: '#fff',
+        padding,
+        borderRadius: '8px',
+        maxWidth,
+        width,
+        position: 'relative',
+        boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
+        maxHeight: '90vh',
+        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column'
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px', flexShrink: 0 }}>
+          {typeof title === 'string' ? (
+            <h2 style={{ margin: 0, fontSize: '1.2rem', color: '#333' }}>{title}</h2>
+          ) : (
+            title
+          )}
+          <button
+            onClick={onClose}
+            aria-label={ariaLabel || "Close dialog"}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '8px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minWidth: 'var(--touch-target-size)',
+              minHeight: 'var(--touch-target-size)',
+              color: '#333'
+            }}
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        <div style={{ flex: 1 }}>
+          {children}
+        </div>
+
+        {footer && (
+          <div style={{ marginTop: '20px', flexShrink: 0 }}>
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
This change addresses the duplication of modal layouts in the codebase. A new reusable `Modal` component was created in `src/components/Layout/Modal.tsx`, which handles the common backdrop, container styling, and header (title and close button). All existing modals (`HelpModal`, `ImprintModal`, `LicenseModal`, `DataViewModal`, and `ImportSettingsDialog`) were refactored to use this component, significantly reducing redundant layout code while preserving existing functionality and styles.

---
*PR created automatically by Jules for task [18194091765010026042](https://jules.google.com/task/18194091765010026042) started by @michaelkrisper*