### PR TITLE
⚡ perf(ChartContainer): optimize ResizeObserver callback

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -659,7 +659,13 @@ const ChartContainer: React.FC = () => {
 
   useEffect(() => {
     if (!containerRef.current) return;
-    const observer = new ResizeObserver((entries) => { for (const entry of entries) { setWidth(entry.contentRect.width); setHeight(entry.contentRect.height); } });
+    const observer = new ResizeObserver((entries) => {
+      if (entries.length > 0) {
+        const entry = entries[entries.length - 1];
+        setWidth(entry.contentRect.width);
+        setHeight(entry.contentRect.height);
+      }
+    });
     observer.observe(containerRef.current); return () => observer.disconnect();
   }, []);
 


### PR DESCRIPTION
💡 **What:** Replaced the `for` loop in the `ResizeObserver` callback within `ChartContainer.tsx` with direct access to the latest resize entry.
🎯 **Why:** To prevent redundant React state setter calls (`setWidth`, `setHeight`) from firing multiple times if multiple resize entries are batched.
📊 **Measured Improvement:** This is a micro-optimization. The exact millisecond difference is negligible to accurately trace in a generic benchmark; however, eliminating the O(N) traversal in favor of an O(1) access ensures exactly one batched React state update happens instead of multiple overwrite cycles during intensive container resize operations.

---
*PR created automatically by Jules for task [6132860541268696484](https://jules.google.com/task/6132860541268696484) started by @michaelkrisper*