### PR TITLE
🧹 Remove unused AxisPosition type

### DIFF
--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -26,7 +26,7 @@ export interface Dataset {
   xAxisId: string;
 }
 
-export type AxisPosition = 'left' | 'right';
+
 
 export interface XAxisConfig {
   id: string;
@@ -42,7 +42,7 @@ export interface YAxisConfig {
   name: string;
   min: number;
   max: number;
-  position: AxisPosition;
+  position: 'left' | 'right';
   color: string;
   showGrid: boolean;
 }


### PR DESCRIPTION
🎯 **What:** Removed the `AxisPosition` type definition from `src/services/persistence.ts` and inlined its values ('left' | 'right') directly into the `YAxisConfig` interface.

💡 **Why:** The `AxisPosition` type was only used once locally and added unnecessary indirection to the file, making the interface simpler. This removes dead/single-use code, adhering to cleaner and more maintainable type definitions.

✅ **Verification:** Verified `persistence.ts` correctness. Executed type checker via `pnpm build` and ran `vitest` unit tests `pnpm test src/services/__tests__/persistence.test.ts`, confirming that the isolated change does not cause regressions within its component module.

✨ **Result:** Reduced file complexity and unneeded type definitions without altering runtime logic or validation criteria.

---
*PR created automatically by Jules for task [15396903727242936386](https://jules.google.com/task/15396903727242936386) started by @michaelkrisper*