### PR TITLE
🧪 Improve test coverage for column caching logic

### DIFF
--- a/src/utils/__tests__/columns.test.ts
+++ b/src/utils/__tests__/columns.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getColumnIndex } from '../columns';
 import { type Dataset } from '../../services/persistence';
 
@@ -73,5 +73,44 @@ describe('getColumnIndex', () => {
     const ds = mockDataset(['A: Time', 'Time']);
     // indexOf will find 'Time' at index 1 first
     expect(getColumnIndex(ds, 'Time')).toBe(1);
+  });
+
+  it('should cache negative lookup results (-1) across property mutations', () => {
+    const ds = mockDataset(['A', 'B', 'C']);
+
+    // First lookup - populates cache with -1
+    expect(getColumnIndex(ds, 'D')).toBe(-1);
+
+    // Mutate the array
+    (ds.columns as string[])[0] = 'D';
+
+    // Second lookup - should hit cache and still return -1
+    expect(getColumnIndex(ds, 'D')).toBe(-1);
+  });
+
+  it('should bypass indexOf and findIndex on cache hits', () => {
+    const ds = mockDataset(['A', 'B', 'C']);
+    const indexOfSpy = vi.spyOn(ds.columns, 'indexOf');
+    const findIndexSpy = vi.spyOn(ds.columns, 'findIndex');
+
+    // First lookup - populates cache, calls indexOf
+    expect(getColumnIndex(ds, 'B')).toBe(1);
+    expect(indexOfSpy).toHaveBeenCalledTimes(1);
+    expect(findIndexSpy).not.toHaveBeenCalled();
+
+    // Second lookup - cache hit, no array methods called
+    expect(getColumnIndex(ds, 'B')).toBe(1);
+    expect(indexOfSpy).toHaveBeenCalledTimes(1);
+    expect(findIndexSpy).not.toHaveBeenCalled();
+
+    // Suffix match lookup
+    expect(getColumnIndex(ds, 'Missing')).toBe(-1);
+    expect(indexOfSpy).toHaveBeenCalledTimes(2);
+    expect(findIndexSpy).toHaveBeenCalledTimes(1);
+
+    // Suffix cache hit
+    expect(getColumnIndex(ds, 'Missing')).toBe(-1);
+    expect(indexOfSpy).toHaveBeenCalledTimes(2);
+    expect(findIndexSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
🎯 **What:** Adds unit tests to cover the caching behavior of `getColumnIndex` in `src/utils/columns.ts`. Specifically addresses testing gaps for caching negative lookups and explicitly verifying performance bypass mechanisms.

📊 **Coverage:**
- Tests that `-1` (column not found) is correctly cached per dataset and survives dataset property mutations without re-scanning.
- Adds Vitest spies on `ds.columns.indexOf` and `ds.columns.findIndex` to confirm that when a cache hit occurs, the underlying O(N) array traversals are completely bypassed.

✨ **Result:** Enhanced test suite reliability ensuring future changes to the bolt optimization in the render loop don't unknowingly introduce performance regressions.

---
*PR created automatically by Jules for task [14909493845847514621](https://jules.google.com/task/14909493845847514621) started by @michaelkrisper*