### PR TITLE
⚡ Memoize dataset and axis lookup maps in ChartContainer

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -334,11 +334,11 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
   }, [containerRef, padding, width, height, isPanning]);
 
   const seriesMetadata = useMemo(() => {
-    const datasetsById = new Map<string, Dataset>(); datasets.forEach(d => datasetsById.set(d.id, d));
-    const yAxesById = new Map<string, YAxisConfig>(); yAxes.forEach(a => yAxesById.set(a.id, a));
-    const xAxesById = new Map<string, XAxisConfig>(); xAxes.forEach(a => xAxesById.set(a.id, a));
+    const datasetsByIdLocal = new Map<string, Dataset>(); datasets.forEach(d => datasetsByIdLocal.set(d.id, d));
+    const yAxesByIdLocal = new Map<string, YAxisConfig>(); yAxes.forEach(a => yAxesByIdLocal.set(a.id, a));
+    const xAxesByIdLocal = new Map<string, XAxisConfig>(); xAxes.forEach(a => xAxesByIdLocal.set(a.id, a));
     return series.filter(s => !s.hidden).map(s => {
-      const ds = datasetsById.get(s.sourceId); const axis = yAxesById.get(s.yAxisId); const xAxis = xAxesById.get(ds?.xAxisId || 'axis-1');
+      const ds = datasetsByIdLocal.get(s.sourceId); const axis = yAxesByIdLocal.get(s.yAxisId); const xAxis = xAxesByIdLocal.get(ds?.xAxisId || 'axis-1');
       if (!ds || !axis || !xAxis) return null;
       const xIdx = getColumnIndex(ds, ds.xAxisColumn); const yIdx = getColumnIndex(ds, s.yColumn);
       if (xIdx === -1 || yIdx === -1) return null;
@@ -493,6 +493,24 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
 const ChartContainer: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { series, xAxes, yAxes, isLoaded, lastAppliedViewId, datasets, highlightedSeriesId } = useGraphStore();
+
+  const datasetsById = useMemo(() => {
+    const map = new Map<string, Dataset>();
+    datasets.forEach(d => map.set(d.id, d));
+    return map;
+  }, [datasets]);
+
+  const xAxesById = useMemo(() => {
+    const map = new Map<string, XAxisConfig>();
+    xAxes.forEach(a => map.set(a.id, a));
+    return map;
+  }, [xAxes]);
+
+  const yAxesById = useMemo(() => {
+    const map = new Map<string, YAxisConfig>();
+    yAxes.forEach(a => map.set(a.id, a));
+    return map;
+  }, [yAxes]);
   
   const [panTarget, setPanTarget] = useState<PanTarget | null>(null);
   const [isCtrlPressed, setIsCtrlPressed] = useState(false);
@@ -631,9 +649,8 @@ const ChartContainer: React.FC = () => {
     if (state.series.length === 0 && state.datasets.length === 0) { wasEmptyRef.current = true; return; }
     if (wasEmptyRef.current && (state.xAxes[0].min !== 0 || state.xAxes[0].max !== 100)) wasEmptyRef.current = false;
     let shouldReset = wasEmptyRef.current;
-    const datasetsById = new Map<string, Dataset>(); state.datasets.forEach(d => datasetsById.set(d.id, d));
     if (!shouldReset && state.datasets.length > 0) {
-       let anyDataVisible = false; const xAxesById = new Map<string, (typeof state.xAxes)[0]>(); state.xAxes.forEach(a => xAxesById.set(a.id, a));
+       let anyDataVisible = false;
        state.series.forEach(s => {
          const ds = datasetsById.get(s.sourceId), xAxis = xAxesById.get(ds?.xAxisId || 'axis-1'); if (!ds || !xAxis) return;
          const xIdx = getColumnIndex(ds, ds.xAxisColumn), xCol = ds.data[xIdx];
@@ -655,7 +672,7 @@ const ChartContainer: React.FC = () => {
       });
       startAnimation();
     }
-  }, [isLoaded, startAnimation, series, yAxes, activeYAxes, datasets]);
+  }, [isLoaded, startAnimation, series, yAxes, activeYAxes, datasetsById, xAxesById]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -690,8 +707,7 @@ const ChartContainer: React.FC = () => {
 
   const handleAutoScaleY = useCallback((axisId: string, mouseY?: number) => {
     const state = useGraphStore.getState(); const axisSeries = state.series.filter(s => s.yAxisId === axisId); if (axisSeries.length === 0) return;
-    let yMin = Infinity, yMax = -Infinity; const datasetsById = new Map<string, Dataset>(); state.datasets.forEach(d => datasetsById.set(d.id, d));
-    const xAxesById = new Map<string, (typeof state.xAxes)[0]>(); state.xAxes.forEach(a => xAxesById.set(a.id, a));
+    let yMin = Infinity, yMax = -Infinity;
     axisSeries.forEach(s => {
       const ds = datasetsById.get(s.sourceId), xAxis = xAxesById.get(ds?.xAxisId || 'axis-1'); if (!ds || !xAxis) return;
       const xIdx = getColumnIndex(ds, ds.xAxisColumn), yIdx = getColumnIndex(ds, s.yColumn); if (xIdx === -1 || yIdx === -1) return;
@@ -717,7 +733,7 @@ const ChartContainer: React.FC = () => {
       else { nMin = yMin - p; nMax = yMax + p; }
       targetYs.current[axisId] = { min: nMin, max: nMax }; startAnimation();
     }
-  }, [padding.top, chartHeight, startAnimation]);
+  }, [padding.top, chartHeight, startAnimation, datasetsById, xAxesById]);
 
   const prevSeriesRef = useRef(series);
   useEffect(() => {


### PR DESCRIPTION
💡 **What:** This optimization memoizes the lookup maps for datasets and axes (`datasetsById`, `xAxesById`, `yAxesById`) in the `ChartContainer` component.

🎯 **Why:** Previously, these maps were being reconstructed in every execution of the auto-scaling `useEffect` and the `handleAutoScaleY` callback. By using `useMemo`, we establish O(1) lookups for these frequently accessed entities while only incurring the O(N) map creation cost when the underlying collections actually change.

📊 **Measured Improvement:** While a specific millisecond benchmark was impractical in this environment due to the lack of pre-installed performance testing tools, the change moves map construction from every render-related effect execution to only when data changes. This reduces garbage collection pressure and CPU cycles during frequent interactions like zooming and panning.

---
*PR created automatically by Jules for task [10987160842259561582](https://jules.google.com/task/10987160842259561582) started by @michaelkrisper*