### PR TITLE
🧹 Remove unused 'lerp' export in animation.ts

### DIFF
--- a/src/utils/animation.ts
+++ b/src/utils/animation.ts
@@ -1,6 +1,6 @@
 import { useGraphStore } from '../store/useGraphStore';
 
-export const lerp = (start: number, end: number, factor: number) => start + (end - start) * factor;
+const lerp = (start: number, end: number, factor: number) => start + (end - start) * factor;
 
 export const applyKeyboardZoom = (
   state: ReturnType<typeof useGraphStore.getState>,


### PR DESCRIPTION
🎯 **What:** Removed the `export` keyword from the `lerp` function in `src/utils/animation.ts`.
💡 **Why:** This function is a simple internal utility used only within `animation.ts`. Removing the `export` keyword clarifies its scope and cleans up the module's public API, making the codebase easier to understand and maintain.
✅ **Verification:** Verified that there are no imports of `lerp` from `src/utils/animation.ts` in the codebase. Ran the test suite to ensure the internal usage of `lerp` within `animation.ts` is still working correctly.
✨ **Result:** A cleaner module export interface and proper encapsulation of the internal `lerp` utility.

---
*PR created automatically by Jules for task [11872737197555238269](https://jules.google.com/task/11872737197555238269) started by @michaelkrisper*