### PR TITLE
Add data series smoothing feature

### DIFF
--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -1,6 +1,9 @@
 import React, { useRef, useEffect, useState, useMemo } from 'react';
 import { type Dataset, type SeriesConfig, type YAxisConfig, type XAxisConfig } from '../../services/persistence';
 import { getColumnIndex } from '../../utils/columns';
+import { smoothArray } from '../../utils/data-processing';
+
+const smoothedCache = new WeakMap<Float32Array, Float32Array>();
 
 const VERTEX_SHADER_SOURCE = `
       attribute float a_x;
@@ -271,6 +274,16 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, xA
       if (!colX || !colY) return;
 
       const xData = colX.data;
+      let yData = colY.data;
+
+      if (s.smooth) {
+        let smoothed = smoothedCache.get(colY.data);
+        if (!smoothed) {
+          smoothed = smoothArray(colY.data, 5);
+          smoothedCache.set(colY.data, smoothed);
+        }
+        yData = smoothed;
+      }
       const xRef = colX.refPoint;
       let startIdx = 0;
       let endIdx = xData.length - 1;
@@ -298,7 +311,6 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, xA
       }
 
       const numPoints = endIdx - startIdx + 1;
-      const yData = colY.data;
 
       const drawStep = (isInteracting && numPoints > 50000) ? Math.max(1, Math.floor(numPoints / 20000)) : 1;
 
@@ -314,7 +326,7 @@ export const WebGLRenderer: React.FC<Props> = React.memo(({ datasets, series, xA
         buffersRef.current.set(xBufferKey, xBuffer);
       }
 
-      const yBufferKey = `buf-y-${ds.id}-${yIdx}`;
+      const yBufferKey = `buf-y-${ds.id}-${yIdx}${s.smooth ? '-smooth' : ''}`;
       let yBuffer = buffersRef.current.get(yBufferKey);
       if (!yBuffer) {
         yBuffer = gl.createBuffer()!;

--- a/src/components/Sidebar/SeriesConfig.tsx
+++ b/src/components/Sidebar/SeriesConfig.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useGraphStore } from '../../store/useGraphStore';
 import { type SeriesConfig, type Dataset } from '../../services/persistence';
 import { THEMES, type ThemeName } from '../../themes';
-import { Trash2, Circle, Square, X, Rows, Ban, ChevronUp, ChevronDown, Eye, EyeOff } from 'lucide-react';
+import { Trash2, Circle, Square, X, Rows, Ban, ChevronUp, ChevronDown, Eye, EyeOff, Spline } from 'lucide-react';
 
 interface Props {
   series: SeriesConfig;
@@ -77,7 +77,7 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
   };
 
   return (
-    <div style={{ borderBottom: `1px solid ${rowBorder}`, padding: '4px 0', fontSize: 'var(--mobile-font-size)', display: 'grid', gridTemplateColumns: 'var(--touch-target-size) var(--touch-target-size) repeat(7, var(--touch-target-size)) 100px 1fr var(--touch-target-size)', gap: '0', alignItems: 'center', opacity: series.hidden ? 0.5 : 1 }}>
+    <div style={{ borderBottom: `1px solid ${rowBorder}`, padding: '4px 0', fontSize: 'var(--mobile-font-size)', display: 'grid', gridTemplateColumns: 'var(--touch-target-size) var(--touch-target-size) repeat(8, var(--touch-target-size)) 100px 1fr var(--touch-target-size)', gap: '0', alignItems: 'center', opacity: series.hidden ? 0.5 : 1 }}>
 
       {/* Visibility Toggle */}
       <button
@@ -185,6 +185,15 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
         title="Point Style"
        aria-label="Cycle Point Style">
         {renderPointStyleIcon()}
+      </button>
+
+      {/* Smoothing Toggle */}
+      <button
+        onClick={() => handleUpdate({ smooth: !series.smooth })}
+        style={{ padding: '0', cursor: 'pointer', background: series.smooth ? bg2 : bg, border: `1px solid ${border}`, borderRadius: '0', display: 'flex', alignItems: 'center', justifyContent: 'center', width: 'var(--touch-target-size)', height: 'var(--touch-target-size)', flexShrink: 0, color: series.smooth ? '#3b82f6' : color }}
+        title={series.smooth ? "Disable Smoothing" : "Enable Smoothing"}
+        aria-label="Toggle Smoothing">
+        <Spline size={16} />
       </button>
 
       {/* Color Picker */}

--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -72,6 +72,7 @@ export interface SeriesConfig {
   lineColor: string;
   lineWidth: number;
   hidden?: boolean;
+  smooth?: boolean;
 }
 
 export interface AppState {
@@ -84,7 +85,7 @@ export interface AppState {
 
 export const XAxisConfigSchema = z.object({ id: z.string(), name: z.string(), min: z.number(), max: z.number(), showGrid: z.boolean(), xMode: z.enum(['date', 'numeric']) });
 export const YAxisConfigSchema = z.object({ id: z.string(), name: z.string(), min: z.number(), max: z.number(), position: z.enum(['left', 'right']), color: z.string(), showGrid: z.boolean() });
-export const SeriesConfigSchema = z.object({ id: z.string(), sourceId: z.string(), name: z.string(), yColumn: z.string(), yAxisId: z.string(), pointStyle: z.enum(['circle', 'square', 'cross', 'none']), pointColor: z.string(), lineStyle: z.enum(['solid', 'dashed', 'dotted', 'none']), lineColor: z.string(), lineWidth: z.number(), hidden: z.boolean().optional() });
+export const SeriesConfigSchema = z.object({ id: z.string(), sourceId: z.string(), name: z.string(), yColumn: z.string(), yAxisId: z.string(), pointStyle: z.enum(['circle', 'square', 'cross', 'none']), pointColor: z.string(), lineStyle: z.enum(['solid', 'dashed', 'dotted', 'none']), lineColor: z.string(), lineWidth: z.number(), hidden: z.boolean().optional(), smooth: z.boolean().optional() });
 export const ViewAxisSnapshotSchema = z.object({ id: z.string(), min: z.number(), max: z.number() });
 export const ViewSnapshotSchema = z.object({ id: z.string(), name: z.string(), xAxes: z.array(ViewAxisSnapshotSchema), yAxes: z.array(ViewAxisSnapshotSchema) });
 export const AppStateSchema = z.object({ xAxes: z.array(XAxisConfigSchema), yAxes: z.array(YAxisConfigSchema), series: z.array(SeriesConfigSchema), axisTitles: z.object({ x: z.string(), y: z.string() }), views: z.array(ViewSnapshotSchema).optional() });

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -349,7 +349,8 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         savedState.series = savedState.series.map(s => ({
           ...s,
           lineWidth: s.lineWidth ?? 1.5,
-          hidden: s.hidden ?? false
+          hidden: s.hidden ?? false,
+          smooth: s.smooth ?? false
         }));
       }
       set({ ...savedState, datasets: allDatasets, isLoaded: true });

--- a/src/utils/__tests__/smoothing.test.ts
+++ b/src/utils/__tests__/smoothing.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { smoothArray } from '../data-processing';
+
+describe('smoothArray', () => {
+  it('should smooth a simple array', () => {
+    const data = new Float32Array([10, 20, 10, 20, 10]);
+    // window 5:
+    // i=0: [10, 20, 10] -> 40/3 = 13.33
+    // i=1: [10, 20, 10, 20] -> 60/4 = 15
+    // i=2: [10, 20, 10, 20, 10] -> 70/5 = 14
+    // i=3: [20, 10, 20, 10] -> 60/4 = 15
+    // i=4: [10, 20, 10] -> 40/3 = 13.33
+    const smoothed = smoothArray(data, 5);
+    expect(smoothed[0]).toBeCloseTo(13.33, 1);
+    expect(smoothed[2]).toBe(14);
+    expect(smoothed[4]).toBeCloseTo(13.33, 1);
+  });
+
+  it('should handle NaN values', () => {
+    const data = new Float32Array([10, NaN, 10, 20, 10]);
+    // i=1: [10, NaN, 10, 20] -> 40/3 = 13.33
+    const smoothed = smoothArray(data, 5);
+    expect(Number.isNaN(smoothed[1])).toBe(false);
+    expect(smoothed[1]).toBeCloseTo(13.33, 1);
+  });
+
+  it('should preserve single values if window is empty of non-NaNs', () => {
+    const data = new Float32Array([NaN, NaN, NaN]);
+    const smoothed = smoothArray(data, 3);
+    expect(Number.isNaN(smoothed[1])).toBe(true);
+  });
+});

--- a/src/utils/data-processing.ts
+++ b/src/utils/data-processing.ts
@@ -63,3 +63,35 @@ export function processRawColumn(sourceData: Float64Array | number[]): Processed
     chunkMax
   };
 }
+
+/**
+ * Smoothes an array of data using a simple moving average.
+ * Handles NaN values by ignoring them in the average calculation.
+ */
+export function smoothArray(data: Float32Array, windowSize: number = 5): Float32Array {
+  const result = new Float32Array(data.length);
+  const halfWindow = Math.floor(windowSize / 2);
+
+  for (let i = 0; i < data.length; i++) {
+    let sum = 0;
+    let count = 0;
+
+    for (let j = i - halfWindow; j <= i + halfWindow; j++) {
+      if (j >= 0 && j < data.length) {
+        const val = data[j];
+        if (!Number.isNaN(val)) {
+          sum += val;
+          count++;
+        }
+      }
+    }
+
+    if (count > 0) {
+      result[i] = sum / count;
+    } else {
+      result[i] = data[i];
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
This change adds a "Smooth" toggle to each data series in the sidebar. When enabled, the series line is rendered using a Simple Moving Average (SMA) filter, which reduces noise while ensuring no overshoots or artificial spikes are created.

Key technical details:
- **Smoothing Algorithm**: Uses a moving average (window size 5) in `src/utils/data-processing.ts`.
- **Performance**: Smoothed data is cached in a `WeakMap<Float32Array, Float32Array>` within `WebGLRenderer.tsx` to avoid re-calculating on every frame.
- **UI**: Added a `Spline` icon toggle in the `SeriesConfig` sidebar component.
- **Persistence**: Updated the Zod schema and store initialization to support the new property.

Fixes #240

---
*PR created automatically by Jules for task [14432582780261789401](https://jules.google.com/task/14432582780261789401) started by @michaelkrisper*