### PR TITLE
Themed SVG and PNG Exports

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -125,7 +125,8 @@ export const Sidebar: React.FC = () => {
       yAxes,
       axisTitles,
       plotContainer.clientWidth,
-      plotContainer.clientHeight
+      plotContainer.clientHeight,
+      t
     );
     downloadFile(svgContent, 'webgraphy-export.svg', 'image/svg+xml');
   };
@@ -141,7 +142,8 @@ export const Sidebar: React.FC = () => {
       yAxes,
       axisTitles,
       plotContainer.clientWidth,
-      plotContainer.clientHeight
+      plotContainer.clientHeight,
+      t
     );
     downloadFile(pngData, 'webgraphy-export.png', 'image/png');
   };

--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { downloadFile, formatDate, exportToSVG, exportToPNG } from '../export';
 import type { Dataset, SeriesConfig, YAxisConfig, XAxisConfig } from '../persistence';
+import { THEMES } from '../../themes';
 
 describe('exportToSVG', () => {
     const mockDatasets: Dataset[] = [
@@ -34,7 +35,7 @@ describe('exportToSVG', () => {
     ];
 
     it('should generate valid SVG string', () => {
-        const svg = exportToSVG(mockDatasets, mockSeries, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svg = exportToSVG(mockDatasets, mockSeries, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svg).toContain('<svg width="800" height="600"');
         expect(svg).toContain('Time');
         expect(svg).toContain('Series 1');
@@ -46,7 +47,7 @@ describe('exportToSVG', () => {
             { id: 's2', sourceId: 'ds1', name: 'Series 2', yColumn: 'OtherValue', yAxisId: 'y3', pointStyle: 'circle', pointColor: '#00ff00', lineStyle: 'solid', lineColor: '#00ff00' },
             { id: 's3', sourceId: 'ds1', name: 'Series 3', yColumn: 'OtherValue', yAxisId: 'y2', pointStyle: 'circle', pointColor: '#0000ff', lineStyle: 'solid', lineColor: '#0000ff' }
         ];
-        const svg = exportToSVG(mockDatasets, multiLeftSeries, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svg = exportToSVG(mockDatasets, multiLeftSeries, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svg).toContain('Series 1');
         expect(svg).toContain('Series 2');
         expect(svg).toContain('Series 3');
@@ -56,13 +57,13 @@ describe('exportToSVG', () => {
         const seriesMissingDS: SeriesConfig[] = [
             { id: 's1', sourceId: 'missing', name: 'Series 1', yColumn: 'Value', yAxisId: 'y1', pointStyle: 'circle', pointColor: '#ff0000', lineStyle: 'solid', lineColor: '#ff0000' }
         ];
-        const svgMissingDS = exportToSVG(mockDatasets, seriesMissingDS, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svgMissingDS = exportToSVG(mockDatasets, seriesMissingDS, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgMissingDS).not.toContain('<path d="M');
 
         const seriesMissingAxis: SeriesConfig[] = [
             { id: 's1', sourceId: 'ds1', name: 'Series 1', yColumn: 'Value', yAxisId: 'missing', pointStyle: 'circle', pointColor: '#ff0000', lineStyle: 'solid', lineColor: '#ff0000' }
         ];
-        const svgMissingAxis = exportToSVG(mockDatasets, seriesMissingAxis, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svgMissingAxis = exportToSVG(mockDatasets, seriesMissingAxis, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgMissingAxis).not.toContain('<path d="M');
     });
 
@@ -71,13 +72,13 @@ describe('exportToSVG', () => {
              ...mockDatasets[0],
              xAxisColumn: 'MissingX'
          }];
-         const svgMissingCol = exportToSVG(datasetsMissingCol, mockSeries, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+         const svgMissingCol = exportToSVG(datasetsMissingCol, mockSeries, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgMissingCol).not.toContain('<path d="M');
 
         const seriesMissingYCol: SeriesConfig[] = [
             { id: 's1', sourceId: 'ds1', name: 'Series 1', yColumn: 'MissingY', yAxisId: 'y1', pointStyle: 'circle', pointColor: '#ff0000', lineStyle: 'solid', lineColor: '#ff0000' }
         ];
-        const svgMissingYCol = exportToSVG(mockDatasets, seriesMissingYCol, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svgMissingYCol = exportToSVG(mockDatasets, seriesMissingYCol, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgMissingYCol).not.toContain('<path d="M');
     });
 
@@ -96,7 +97,7 @@ describe('exportToSVG', () => {
                 ]
             }
         ];
-        const svg = exportToSVG(datasetsWithPrefix, mockSeries, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svg = exportToSVG(datasetsWithPrefix, mockSeries, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svg).toContain('<path d="M');
     });
 
@@ -105,13 +106,13 @@ describe('exportToSVG', () => {
         const seriesSquare: SeriesConfig[] = [
             { id: 's1', sourceId: 'ds1', name: 'Series 1', yColumn: 'Value', yAxisId: 'y1', pointStyle: 'square', pointColor: '#ff0000', lineStyle: 'solid', lineColor: '#ff0000' }
         ];
-        const svgSquare = exportToSVG(mockDatasets, seriesSquare, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svgSquare = exportToSVG(mockDatasets, seriesSquare, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgSquare).toContain('<rect x="');
 
         const seriesCross: SeriesConfig[] = [
             { id: 's1', sourceId: 'ds1', name: 'Series 1', yColumn: 'Value', yAxisId: 'y1', pointStyle: 'cross', pointColor: '#ff0000', lineStyle: 'solid', lineColor: '#ff0000' }
         ];
-        const svgCross = exportToSVG(mockDatasets, seriesCross, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svgCross = exportToSVG(mockDatasets, seriesCross, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgCross).toContain('<path d="M');
     });
 
@@ -119,13 +120,13 @@ describe('exportToSVG', () => {
          const seriesDashed: SeriesConfig[] = [
             { id: 's1', sourceId: 'ds1', name: 'Series 1', yColumn: 'Value', yAxisId: 'y1', pointStyle: 'none', pointColor: '#ff0000', lineStyle: 'dashed', lineColor: '#ff0000' }
         ];
-        const svgDashed = exportToSVG(mockDatasets, seriesDashed, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svgDashed = exportToSVG(mockDatasets, seriesDashed, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgDashed).toContain('stroke-dasharray="8,6"');
 
         const seriesDotted: SeriesConfig[] = [
             { id: 's1', sourceId: 'ds1', name: 'Series 1', yColumn: 'Value', yAxisId: 'y1', pointStyle: 'none', pointColor: '#ff0000', lineStyle: 'dotted', lineColor: '#ff0000' }
         ];
-        const svgDotted = exportToSVG(mockDatasets, seriesDotted, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svgDotted = exportToSVG(mockDatasets, seriesDotted, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgDotted).toContain('stroke-dasharray="2,4"');
     });
 
@@ -133,7 +134,7 @@ describe('exportToSVG', () => {
         const mockXAxesDate: XAxisConfig[] = [
             { id: 'axis-1', name: 'X Axis 1', min: 1672531200, max: 1672617600, showGrid: true, xMode: 'date' }
         ];
-        const svgDate = exportToSVG(mockDatasets, mockSeries, mockXAxesDate, mockYAxes, { x: 'Time', y: 'Y Axis' }, 800, 600);
+        const svgDate = exportToSVG(mockDatasets, mockSeries, mockXAxesDate, mockYAxes, { x: 'Time', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgDate).toContain('Time');
     });
 
@@ -153,7 +154,7 @@ describe('exportToSVG', () => {
         const seriesLarge: SeriesConfig[] = [
             { id: 's1', sourceId: 'dsLarge', name: 'Series 1', yColumn: 'Value', yAxisId: 'y1', pointStyle: 'circle', pointColor: '#ff0000', lineStyle: 'solid', lineColor: '#ff0000' }
         ];
-        const svgLarge = exportToSVG([largeDataset], seriesLarge, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600);
+        const svgLarge = exportToSVG([largeDataset], seriesLarge, mockXAxes, mockYAxes, { x: 'X Axis', y: 'Y Axis' }, 800, 600, THEMES.light);
         expect(svgLarge).toContain('<svg width="800" height="600"');
     });
 });
@@ -223,7 +224,7 @@ describe('exportToPNG', () => {
          const mockXAxes: XAxisConfig[] = [];
          const mockYAxes: YAxisConfig[] = [];
 
-         const result = await exportToPNG(mockDatasets, mockSeries, mockXAxes, mockYAxes, { x: 'X', y: 'Y' }, 800, 600);
+         const result = await exportToPNG(mockDatasets, mockSeries, mockXAxes, mockYAxes, { x: 'X', y: 'Y' }, 800, 600, THEMES.light);
          expect(result).toBe('data:image/png;base64,mock');
          expect(mockCanvas.getContext).toHaveBeenCalledWith('2d');
          expect(mockCtx.drawImage).toHaveBeenCalled();
@@ -329,19 +330,19 @@ describe('exportToSVG edge cases', () => {
 
         // < 1.5
         const axes1: YAxisConfig[] = [{ id: 'y1', name: 'Y1', min: 0, max: 1.2, position: 'left', color: '', showGrid: true }];
-        expect(exportToSVG(datasets, series, xAxes, axes1, { x: 'X', y: 'Y' }, 800, 600)).toContain('svg');
+        expect(exportToSVG(datasets, series, xAxes, axes1, { x: 'X', y: 'Y' }, 800, 600, THEMES.light)).toContain('svg');
 
         // < 3
         const axes2: YAxisConfig[] = [{ id: 'y1', name: 'Y1', min: 0, max: 2.5, position: 'left', color: '', showGrid: true }];
-        expect(exportToSVG(datasets, series, xAxes, axes2, { x: 'X', y: 'Y' }, 800, 600)).toContain('svg');
+        expect(exportToSVG(datasets, series, xAxes, axes2, { x: 'X', y: 'Y' }, 800, 600, THEMES.light)).toContain('svg');
 
         // < 7
         const axes3: YAxisConfig[] = [{ id: 'y1', name: 'Y1', min: 0, max: 6.5, position: 'left', color: '', showGrid: true }];
-        expect(exportToSVG(datasets, series, xAxes, axes3, { x: 'X', y: 'Y' }, 800, 600)).toContain('svg');
+        expect(exportToSVG(datasets, series, xAxes, axes3, { x: 'X', y: 'Y' }, 800, 600, THEMES.light)).toContain('svg');
 
         // >= 7
         const axes4: YAxisConfig[] = [{ id: 'y1', name: 'Y1', min: 0, max: 8.5, position: 'left', color: '', showGrid: true }];
-        expect(exportToSVG(datasets, series, xAxes, axes4, { x: 'X', y: 'Y' }, 800, 600)).toContain('svg');
+        expect(exportToSVG(datasets, series, xAxes, axes4, { x: 'X', y: 'Y' }, 800, 600, THEMES.light)).toContain('svg');
     });
 
     it('should handle negative width and height gracefully', () => {
@@ -349,7 +350,7 @@ describe('exportToSVG edge cases', () => {
         const series: SeriesConfig[] = [];
         const xAxes: XAxisConfig[] = [];
         const yAxes: YAxisConfig[] = [];
-        const svg = exportToSVG(datasets, series, xAxes, yAxes, { x: 'X', y: 'Y' }, -100, -100);
+        const svg = exportToSVG(datasets, series, xAxes, yAxes, { x: 'X', y: 'Y' }, -100, -100, THEMES.light);
         expect(svg).toContain('<svg width="-100" height="-100"');
     });
 
@@ -358,7 +359,7 @@ describe('exportToSVG edge cases', () => {
         const series: SeriesConfig[] = [];
         const xAxes: XAxisConfig[] = [];
         const yAxes: YAxisConfig[] = [];
-        const svg = exportToSVG(datasets, series, xAxes, yAxes, { x: 'X', y: 'Y' }, 0, 0);
+        const svg = exportToSVG(datasets, series, xAxes, yAxes, { x: 'X', y: 'Y' }, 0, 0, THEMES.light);
         expect(svg).toContain('<svg width="0" height="0"');
     });
 });

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -2,6 +2,7 @@ import { type Dataset, type SeriesConfig, type YAxisConfig, type XAxisConfig } f
 import { worldToScreen } from '../utils/coords';
 import { lttb } from '../utils/lttb';
 import { getColumnIndex } from '../utils/columns';
+import { type Theme } from '../themes';
 
 const AXIS_WIDTH_BASE = 15; // Ticks, gap, and safe margin
 
@@ -30,7 +31,8 @@ export const exportToSVG = (
   yAxes: YAxisConfig[],
   _axisTitles: { x: string, y: string },
   width: number,
-  height: number
+  height: number,
+  theme: Theme
 ): string => {
   // 1. Determine active axes and layout
   const axisToMinDsIdx = new Map<string, number>();
@@ -93,9 +95,9 @@ export const exportToSVG = (
   const chartWidth = Math.max(0, width - padding.left - padding.right);
   const chartHeight = Math.max(0, height - padding.top - padding.bottom);
   
-  let svg = `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" style="background: white; font-family: sans-serif;">`;
+  let svg = `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" style="background: ${theme.plotBg}; font-family: ${theme.fontFamily};">`;
   
-  svg += `<rect width="100%" height="100%" fill="white" />`;
+  svg += `<rect width="100%" height="100%" fill="${theme.plotBg}" />`;
 
   // 2. Draw Grid
   const gridAxis = activeYAxes.find(a => a.showGrid) || activeYAxes[0];
@@ -107,7 +109,7 @@ export const exportToSVG = (
     const vp = { xMin: gridXAxis.min, xMax: gridXAxis.max, yMin: gridAxis.min, yMax: gridAxis.max, width, height, padding };
     for (let t = firstYTick; t <= gridAxis.max; t += yStep) {
       const { y } = worldToScreen(gridXAxis.min, t, vp);
-      svg += `<line x1="${padding.left}" y1="${y}" x2="${width - padding.right}" y2="${y}" stroke="#f0f0f0" stroke-width="1" />`;
+      svg += `<line x1="${padding.left}" y1="${y}" x2="${width - padding.right}" y2="${y}" stroke="${theme.gridColor}" stroke-width="1" />`;
     }
 
     const xRange = gridXAxis.max - gridXAxis.min;
@@ -115,7 +117,7 @@ export const exportToSVG = (
     const firstXTick = Math.ceil(gridXAxis.min / xStep) * xStep;
     for (let t = firstXTick; t <= gridXAxis.max; t += xStep) {
       const { x } = worldToScreen(t, gridAxis.min, vp);
-      svg += `<line x1="${x}" y1="${padding.top}" x2="${x}" y2="${height - padding.bottom}" stroke="#f0f0f0" stroke-width="1" />`;
+      svg += `<line x1="${x}" y1="${padding.top}" x2="${x}" y2="${height - padding.bottom}" stroke="${theme.gridColor}" stroke-width="1" />`;
     }
   }
 
@@ -155,7 +157,7 @@ export const exportToSVG = (
   });
 
   // 4. Draw Axes
-  svg += `<rect x="${padding.left}" y="${padding.top}" width="${chartWidth}" height="${chartHeight}" fill="none" stroke="#333" stroke-width="2" />`;
+  svg += `<rect x="${padding.left}" y="${padding.top}" width="${chartWidth}" height="${chartHeight}" fill="none" stroke="${theme.axisColor}" stroke-width="2" />`;
 
   // Pre-compute dataset and series relationships for O(1) lookups
   const datasetsByXAxisId: Record<string, Dataset[]> = {};
@@ -189,20 +191,20 @@ export const exportToSVG = (
     const vp = { xMin: axis.min, xMax: axis.max, yMin: 0, yMax: 100, width, height, padding };
     const baseY = height - padding.bottom + idx * 60;
 
-    svg += `<line x1="${padding.left}" y1="${baseY}" x2="${width - padding.right + 8}" y2="${baseY}" stroke="#333" stroke-width="1" />`;
+    svg += `<line x1="${padding.left}" y1="${baseY}" x2="${width - padding.right + 8}" y2="${baseY}" stroke="${theme.axisColor}" stroke-width="1" />`;
 
     for (let t = firstXTick; t <= axis.max; t += xStep) {
       const { x } = worldToScreen(t, 0, vp);
       if (x < padding.left || x > width - padding.right) continue;
-      svg += `<line x1="${x}" y1="${baseY}" x2="${x}" y2="${baseY + 6}" stroke="#333" stroke-width="1" />`;
+      svg += `<line x1="${x}" y1="${baseY}" x2="${x}" y2="${baseY + 6}" stroke="${theme.axisColor}" stroke-width="1" />`;
       const label = axis.xMode === 'date' ? formatDate(t, xStep) : t.toFixed(xPrecision);
-      svg += `<text x="${x}" y="${baseY + 20}" text-anchor="middle" font-size="9" fill="#666">${label}</text>`;
+      svg += `<text x="${x}" y="${baseY + 20}" text-anchor="middle" font-size="9" fill="${theme.labelColor}">${label}</text>`;
     }
 
     const datasetsForThisAxis = datasetsByXAxisId[axis.id] || [];
     const seriesForThisAxis = seriesByXAxisId[axis.id] || [];
     const title = Array.from(new Set(datasetsForThisAxis.map(d => d.xAxisColumn))).join(' / ');
-    svg += `<text x="${padding.left + chartWidth / 2}" y="${baseY + 42}" text-anchor="middle" font-size="10" font-weight="bold" fill="${escapeHTML(seriesForThisAxis[0]?.lineColor || '#333')}">${escapeHTML(title)}</text>`;
+    svg += `<text x="${padding.left + chartWidth / 2}" y="${baseY + 42}" text-anchor="middle" font-size="10" font-weight="bold" fill="${escapeHTML(seriesForThisAxis[0]?.lineColor || theme.axisColor)}">${escapeHTML(title)}</text>`;
   });
 
   activeYAxes.forEach(axis => {
@@ -221,15 +223,15 @@ export const exportToSVG = (
 
     // Axis Line
     const lineX = xPos + (isLeft ? axisWidth : 0);
-    svg += `<line x1="${lineX}" y1="${padding.top}" x2="${lineX}" y2="${height - padding.bottom}" stroke="#333" stroke-width="1" />`;
+    svg += `<line x1="${lineX}" y1="${padding.top}" x2="${lineX}" y2="${height - padding.bottom}" stroke="${theme.axisColor}" stroke-width="1" />`;
 
     // Ticks and Labels (Right-Aligned)
     const mainXConf = activeXAxes[0] || xAxes[0];
     for (let t = firstTick; t <= axis.max; t += step) {
       const { y } = worldToScreen(mainXConf.min, t, { xMin: mainXConf.min, xMax: mainXConf.max, yMin: axis.min, yMax: axis.max, width, height, padding });
-      svg += `<line x1="${lineX - (isLeft ? 5 : 0)}" y1="${y}" x2="${lineX + (isLeft ? 0 : 5)}" y2="${y}" stroke="#333" stroke-width="1" />`;
+      svg += `<line x1="${lineX - (isLeft ? 5 : 0)}" y1="${y}" x2="${lineX + (isLeft ? 0 : 5)}" y2="${y}" stroke="${theme.axisColor}" stroke-width="1" />`;
       const labelX = xPos + axisWidth - 8;
-      svg += `<text x="${labelX}" y="${y + 3}" text-anchor="end" font-size="9" fill="#333">${t.toFixed(precision)}</text>`;
+      svg += `<text x="${labelX}" y="${y + 3}" text-anchor="end" font-size="9" fill="${theme.labelColor}">${t.toFixed(precision)}</text>`;
     }
 
     const axisSeries = series.filter(s => s.yAxisId === axis.id);
@@ -238,8 +240,8 @@ export const exportToSVG = (
     const titleY = padding.top + chartHeight / 2, rotate = isLeft ? -90 : 90;
     const estW = Math.min(chartHeight, title.length * 6 + 8);
     svg += `<g transform="translate(${titleX}, ${titleY}) rotate(${rotate})">`;
-    svg += `<rect x="-${estW / 2}" y="-8" width="${estW}" height="16" fill="rgba(255, 255, 255, 0.8)" rx="2" />`;
-    svg += `<text x="0" y="4" text-anchor="middle" font-size="10" font-weight="bold" fill="${escapeHTML(axisSeries[0]?.lineColor || '#333')}">${escapeHTML(title)}</text></g>`;
+    svg += `<rect x="-${estW / 2}" y="-8" width="${estW}" height="16" fill="${theme.secLabelBg}" rx="2" />`;
+    svg += `<text x="0" y="4" text-anchor="middle" font-size="10" font-weight="bold" fill="${escapeHTML(axisSeries[0]?.lineColor || theme.axisColor)}">${escapeHTML(title)}</text></g>`;
   });
 
   svg += `</svg>`; return svg;
@@ -252,14 +254,14 @@ export const formatDate = (val: number, step: number) => {
   return String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
 };
 
-export const exportToPNG = async (datasets: Dataset[], series: SeriesConfig[], xAxes: XAxisConfig[], yAxes: YAxisConfig[], axisTitles: { x: string, y: string }, width: number, height: number): Promise<string> => {
-  const svgString = exportToSVG(datasets, series, xAxes, yAxes, axisTitles, width, height);
+export const exportToPNG = async (datasets: Dataset[], series: SeriesConfig[], xAxes: XAxisConfig[], yAxes: YAxisConfig[], axisTitles: { x: string, y: string }, width: number, height: number, theme: Theme): Promise<string> => {
+  const svgString = exportToSVG(datasets, series, xAxes, yAxes, axisTitles, width, height, theme);
   return new Promise((resolve, reject) => {
     const canvas = document.createElement('canvas'), dpr = window.devicePixelRatio || 1;
     canvas.width = width * dpr; canvas.height = height * dpr;
     const ctx = canvas.getContext('2d')!; ctx.scale(dpr, dpr);
     const img = new Image(), svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' }), url = URL.createObjectURL(svgBlob);
-    img.onload = () => { ctx.fillStyle = 'white'; ctx.fillRect(0, 0, width, height); ctx.drawImage(img, 0, 0, width, height); URL.revokeObjectURL(url); resolve(canvas.toDataURL('image/png')); };
+    img.onload = () => { ctx.fillStyle = theme.plotBg; ctx.fillRect(0, 0, width, height); ctx.drawImage(img, 0, 0, width, height); URL.revokeObjectURL(url); resolve(canvas.toDataURL('image/png')); };
     img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('Failed to load SVG into image for PNG export')); };
     img.src = url;
   });


### PR DESCRIPTION
This change ensures that exported SVG and PNG images match the application's currently active color theme. 

Key modifications:
1.  **Service Layer (`src/services/export.ts`)**: The export functions now utilize the `Theme` interface to dynamically set background colors, grid line colors, axis colors, and label colors. Hardcoded values like `'white'` and `'#333'` have been replaced with their themed counterparts (`theme.plotBg`, `theme.axisColor`, etc.).
2.  **UI Integration (`src/components/Layout/Sidebar.tsx`)**: The `handleExportSVG` and `handleExportPNG` handlers now correctly propagate the current theme object `t` to the underlying export services.
3.  **Test Suite (`src/services/__tests__/export.test.ts`)**: All export tests have been updated to support the new function signatures, ensuring continued test coverage and correctness.

These changes provide a more consistent user experience, especially for users utilizing dark, matrix, or high-contrast themes who wish to preserve that aesthetic in their data exports.

Fixes #244

---
*PR created automatically by Jules for task [12386847536849194368](https://jules.google.com/task/12386847536849194368) started by @michaelkrisper*