### PR TITLE
🧪 Add error path tests for invalid tokens in formula compilation

### DIFF
--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -140,4 +140,38 @@ describe('compileFormula', () => {
     const { error } = compileFormula('window.alert(1)', columns);
     expect(error).toBeDefined();
   });
+
+  it('should handle error paths for invalid tokens and compilation errors', () => {
+    // Missing closing bracket
+    const res1 = compileFormula('[Temp', columns);
+    expect(res1.error).toContain('Missing closing bracket ]');
+    expect(res1.evaluate([])).toBeNaN();
+    expect(res1.usedColumnIndices).toEqual([]);
+
+    // Unknown function
+    const res2 = compileFormula('unknownfunc([Temp])', columns);
+    expect(res2.error).toContain('Unknown function or constant: unknownfunc');
+    expect(res2.evaluate([])).toBeNaN();
+
+    // Unexpected comma
+    const res3 = compileFormula('10, 20', columns);
+    expect(res3.error).toContain('Unexpected comma');
+    expect(res3.evaluate([])).toBeNaN();
+
+    // Mismatched parentheses - missing opening
+    const res4 = compileFormula('10 + 20)', columns);
+    expect(res4.error).toContain('Mismatched parentheses');
+    expect(res4.evaluate([])).toBeNaN();
+
+    // Mismatched parentheses - missing closing
+    const res5 = compileFormula('(10 + 20', columns);
+    expect(res5.error).toContain('Mismatched parentheses');
+    expect(res5.evaluate([])).toBeNaN();
+
+    // Unexpected character during lexing
+    const res6 = compileFormula('10 $ 20', columns);
+    expect(res6.error).toContain('Unexpected character: $');
+    expect(res6.evaluate([])).toBeNaN();
+    expect(res6.usedColumnIndices).toEqual([]);
+  });
 });


### PR DESCRIPTION
🎯 What: Added a new test suite to cover missing error paths for invalid tokens and syntax during formula compilation in `src/utils/formula.ts`.
📊 Coverage: Tested mismatched parentheses (missing open/close), unexpected comma outside of a function, missing closing bracket in variable names, unknown functions, and unexpected characters during lexing.
✨ Result: Improved test coverage for compilation fallback behavior and error messaging, guaranteeing correct error handling behavior when formulas have syntax issues.

---
*PR created automatically by Jules for task [13053754864038278734](https://jules.google.com/task/13053754864038278734) started by @michaelkrisper*