### PR TITLE
Enable X-Axis selection for different data sources

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -307,6 +307,17 @@ export const Sidebar: React.FC = () => {
                           </select>
                         </div>
 
+                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+                          <label style={{ fontSize: '0.75rem', fontWeight: 'bold', color: t.textLight }}>X-Axis Assignment</label>
+                          <select
+                            value={ds.xAxisId}
+                            onChange={(e) => updateDataset(ds.id, { xAxisId: e.target.value })}
+                            style={{ fontSize: '0.75rem', padding: '2px 4px', borderRadius: '4px', border: `1px solid ${t.border}`, background: t.selectBg, color: t.selectColor, maxWidth: '120px' }}
+                          >
+                            {xAxes.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+                          </select>
+                        </div>
+
                         <div style={{ fontSize: '0.75rem', fontWeight: 'bold', color: t.textLight, marginBottom: '6px' }}>Series / Columns</div>
                         <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0' }}>
                           {ds.columns.map((col) => {

--- a/src/store/__tests__/alignment.test.ts
+++ b/src/store/__tests__/alignment.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useGraphStore } from '../useGraphStore';
+import { Dataset } from '../../services/persistence';
+
+// Mock persistence to avoid IndexedDB and LocalStorage issues during tests
+vi.mock('../../services/persistence', () => ({
+  persistence: {
+    saveDataset: vi.fn(),
+    loadDataset: vi.fn(),
+    getAllDatasets: vi.fn().mockResolvedValue([]),
+    deleteDataset: vi.fn(),
+    saveAppState: vi.fn(),
+    loadAppState: vi.fn().mockResolvedValue(null),
+    clearAppState: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('useGraphStore Alignment', () => {
+  beforeEach(() => {
+    // Reset store state before each test
+    const store = useGraphStore.getState();
+    useGraphStore.setState({
+      datasets: [],
+      series: [],
+      xAxes: Array.from({ length: 9 }, (_, i) => ({
+        id: `axis-${i + 1}`,
+        name: `X-Axis ${i + 1}`,
+        min: 0,
+        max: 100,
+        showGrid: i === 0,
+        xMode: 'numeric'
+      })),
+      yAxes: Array.from({ length: 9 }, (_, i) => ({
+        id: `axis-${i + 1}`,
+        name: `Axis ${i + 1}`,
+        min: 0,
+        max: 100,
+        position: i % 2 === 0 ? 'left' : 'right',
+        color: '#475569',
+        showGrid: i === 0
+      })),
+      views: [],
+      isLoaded: true,
+    });
+  });
+
+  it('should allow multiple datasets to share the same xAxisId and update bounds accordingly', () => {
+    const ds1: Dataset = {
+      id: 'ds-1',
+      name: 'Dataset 1',
+      columns: ['Time', 'Value'],
+      data: [
+        { isFloat64: true, refPoint: 0, bounds: { min: 10, max: 20 }, data: new Float32Array([10, 20]) },
+        { isFloat64: false, refPoint: 0, bounds: { min: 0, max: 5 }, data: new Float32Array([0, 5]) },
+      ],
+      rowCount: 2,
+      xAxisColumn: 'Time',
+      xAxisId: '',
+    };
+
+    const ds2: Dataset = {
+      id: 'ds-2',
+      name: 'Dataset 2',
+      columns: ['Time', 'Value'],
+      data: [
+        { isFloat64: false, refPoint: 0, bounds: { min: 100, max: 200 }, data: new Float32Array([100, 200]) },
+        { isFloat64: false, refPoint: 0, bounds: { min: 0, max: 50 }, data: new Float32Array([0, 50]) },
+      ],
+      rowCount: 2,
+      xAxisColumn: 'Time',
+      xAxisId: '',
+    };
+
+    useGraphStore.getState().addDataset(ds1); // Should get axis-1, min: 10, max: 20, xMode: date
+    useGraphStore.getState().addDataset(ds2); // Should get axis-2, min: 100, max: 200, xMode: numeric
+
+    const state1 = useGraphStore.getState();
+    expect(state1.datasets[0].xAxisId).toBe('axis-1');
+    expect(state1.datasets[1].xAxisId).toBe('axis-2');
+    expect(state1.xAxes[0].min).toBe(10);
+    expect(state1.xAxes[0].xMode).toBe('date');
+    expect(state1.xAxes[1].min).toBe(100);
+    expect(state1.xAxes[1].xMode).toBe('numeric');
+
+    // Now re-assign ds2 to axis-1
+    useGraphStore.getState().updateDataset('ds-2', { xAxisId: 'axis-1' });
+
+    const state2 = useGraphStore.getState();
+    expect(state2.datasets[1].xAxisId).toBe('axis-1');
+    // axis-1 should now be updated to ds2's bounds and mode because it was the last one assigned/updated
+    expect(state2.xAxes[0].min).toBe(100);
+    expect(state2.xAxes[0].max).toBe(200);
+    expect(state2.xAxes[0].xMode).toBe('numeric');
+  });
+
+  it('should update axis when xAxisColumn changes', () => {
+    const ds1: Dataset = {
+      id: 'ds-1',
+      name: 'Dataset 1',
+      columns: ['Time', 'NumericCol'],
+      data: [
+        { isFloat64: true, refPoint: 0, bounds: { min: 10, max: 20 }, data: new Float32Array([10, 20]) },
+        { isFloat64: false, refPoint: 0, bounds: { min: 50, max: 60 }, data: new Float32Array([50, 60]) },
+      ],
+      rowCount: 2,
+      xAxisColumn: 'Time',
+      xAxisId: '',
+    };
+
+    useGraphStore.getState().addDataset(ds1); // axis-1, min: 10, max: 20, xMode: date
+
+    const state1 = useGraphStore.getState();
+    expect(state1.xAxes[0].min).toBe(10);
+    expect(state1.xAxes[0].xMode).toBe('date');
+
+    // Change X-Axis Column to NumericCol
+    useGraphStore.getState().updateDataset('ds-1', { xAxisColumn: 'NumericCol' });
+
+    const state2 = useGraphStore.getState();
+    expect(state2.xAxes[0].min).toBe(50);
+    expect(state2.xAxes[0].max).toBe(60);
+    expect(state2.xAxes[0].xMode).toBe('numeric');
+  });
+});

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -198,9 +198,34 @@ export const useGraphStore = create<GraphState>((set, get) => ({
   },
 
   updateDataset: (id, updates) => {
-    set((state) => ({
-      datasets: state.datasets.map(d => d.id === id ? { ...d, ...updates } : d)
-    }));
+    set((state) => {
+      const dataset = state.datasets.find(d => d.id === id);
+      if (!dataset) return state;
+
+      const updatedDataset = { ...dataset, ...updates };
+      const nextDatasets = state.datasets.map(d => d.id === id ? updatedDataset : d);
+
+      let nextXAxes = state.xAxes;
+      if (updates.xAxisId !== undefined || updates.xAxisColumn !== undefined) {
+        const xColIdx = getColumnIndex(updatedDataset, updatedDataset.xAxisColumn);
+        const col = updatedDataset.data[xColIdx];
+        if (col) {
+          const bounds = col.bounds || { min: 0, max: 100 };
+          const isDate = col.isFloat64 || false;
+
+          nextXAxes = state.xAxes.map(a =>
+            a.id === updatedDataset.xAxisId
+              ? { ...a, min: bounds.min, max: bounds.max, xMode: (isDate ? 'date' : 'numeric') as 'date' | 'numeric' }
+              : a
+          );
+        }
+      }
+
+      return {
+        datasets: nextDatasets,
+        xAxes: nextXAxes
+      };
+    });
     if (get().isLoaded) debouncedSaveState();
   },
 


### PR DESCRIPTION
This change enables users to align data from different sources (e.g., multiple files) on the same X-axis. 

Key changes:
1. **UI Update**: Each dataset card in the "Data Sources" section of the sidebar now includes an "X-Axis Assignment" selector. This allows users to map a dataset to any of the nine pre-defined X-axes (`axis-1` to `axis-9`).
2. **State Management**: The `updateDataset` action in the Zustand store now detects changes to `xAxisId` or `xAxisColumn` and automatically updates the corresponding X-axis's `min`, `max`, and `xMode` (date vs. numeric) based on the dataset's data.
3. **Alignment**: Since `ChartContainer.tsx` already groups datasets by `xAxisId`, assigning multiple datasets to the same ID correctly aligns them on the plot.
4. **Testing**: A new test suite `src/store/__tests__/alignment.test.ts` was added to ensure the synchronization logic works as expected and supports multiple datasets sharing an axis.
5. **Verification**: Frontend changes were verified with a Playwright script and manual inspection of the generated screenshot.

Fixes #261

---
*PR created automatically by Jules for task [15739709666118824447](https://jules.google.com/task/15739709666118824447) started by @michaelkrisper*