### PR TITLE
Modernize Data Import and Fix Start Line Preview

### DIFF
--- a/src/components/Layout/ImportSettingsDialog.tsx
+++ b/src/components/Layout/ImportSettingsDialog.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useMemo } from 'react';
-import { Check } from 'lucide-react';
+import { Check, Settings2, Table, Columns, FileType, ArrowRight } from 'lucide-react';
 import { secureJSONParse } from '../../utils/json';
 import type { ImportSettings, ColumnConfig, ColumnType } from '../../types/import';
 import { Modal } from './Modal';
+import { type Theme } from '../../themes';
 
 interface ImportSettingsDialogProps {
   fileName: string;
@@ -10,6 +11,7 @@ interface ImportSettingsDialogProps {
   fileType: 'csv' | 'json';
   onConfirm: (settings: ImportSettings) => void | Promise<void>;
   onCancel: () => void;
+  theme: Theme;
 }
 
 function detectDelimiter(fileContent: string, fileType: 'csv' | 'json'): string {
@@ -51,7 +53,8 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
   fileContent,
   fileType,
   onConfirm,
-  onCancel
+  onCancel,
+  theme: t
 }) => {
   const [delimiter, setDelimiter] = useState<string>(() => detectDelimiter(fileContent, fileType));
   const [decimalPoint, setDecimalPoint] = useState<string>('.');
@@ -76,25 +79,37 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
     const lines = fileContent.split(/\r?\n/).filter(l => l.trim());
     if (lines.length === 0) return { headers: [], rows: [] as string[][] };
 
-    const headers = lines[0].split(delimiter).map(h => h.trim().replace(/^"|"$/g, ''));
-    const rows = lines.slice(1, 11).map(line =>
+    const headerRowIndex = Math.max(0, startRow - 1);
+    const headerLine = lines[headerRowIndex] || '';
+    const headers = headerLine.split(delimiter).map(h => h.trim().replace(/^"|"$/g, ''));
+    const rows = lines.slice(headerRowIndex + 1, headerRowIndex + 11).map(line =>
       line.split(delimiter).map(v => v.trim().replace(/^"|"$/g, ''))
     );
     return { headers, rows };
-  }, [fileContent, fileType, delimiter]);
+  }, [fileContent, fileType, delimiter, startRow]);
 
   // Derived column configs: auto-detected type + user overrides (keyed by column name)
   const columnConfigs = useMemo<ColumnConfig[]>(() => {
     return previewData.headers.map((name, index) => {
       const override = columnOverrides[name];
-      if (override) return { index, name, type: 'numeric' as ColumnType, ...override };
 
       const firstVal = fileType === 'json'
         ? (previewData.rows as Record<string, string>[]).find(row => row[name])?.[name]
         : (previewData.rows as string[][])[0]?.[index];
 
-      const { type, dateFormat } = detectColumnTypeAndFormat(firstVal, decimalPoint);
-      return { index, name, type, dateFormat };
+      const { type: autoType, dateFormat: autoFormat } = detectColumnTypeAndFormat(firstVal, decimalPoint);
+
+      if (override) {
+        return {
+          index,
+          name,
+          type: override.type || autoType,
+          dateFormat: override.dateFormat || autoFormat,
+          ...override
+        };
+      }
+
+      return { index, name, type: autoType, dateFormat: autoFormat };
     });
   }, [previewData, columnOverrides, decimalPoint, fileType]);
 
@@ -115,142 +130,194 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
   return (
     <Modal
       onClose={onCancel}
-      title={`Import Settings: ${fileName}`}
-      maxWidth="1000px"
+      title={
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <FileType size={24} color={t.accent} />
+          <h2 style={{ margin: 0, fontSize: '1.25rem', color: t.text }}>Import Settings: {fileName}</h2>
+        </div>
+      }
+      maxWidth="1100px"
       width="95%"
-      padding="16px"
+      padding="0"
       footer={
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', padding: '16px', borderTop: `1px solid ${t.border}`, backgroundColor: t.bg2 }}>
           <button
             onClick={onCancel}
-            style={{ padding: '12px 24px', borderRadius: '4px', border: '1px solid #ced4da', background: '#fff', cursor: 'pointer', minHeight: '44px', fontSize: '1rem', flex: '1 1 auto' }}
+            style={{ padding: '10px 24px', borderRadius: '6px', border: `1px solid ${t.border}`, background: t.bg, color: t.text, cursor: 'pointer', fontSize: '0.9rem', fontWeight: '600' }}
           >
             Cancel
           </button>
           <button
             onClick={() => onConfirm({ delimiter, decimalPoint, startRow, columnConfigs, xAxisColumn })}
-            style={{ padding: '12px 24px', borderRadius: '4px', border: 'none', background: '#007bff', color: '#fff', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px', minHeight: '44px', fontSize: '1rem', flex: '1 1 auto', fontWeight: 'bold' }}
+            style={{ padding: '10px 24px', borderRadius: '6px', border: 'none', background: t.accent, color: '#fff', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '8px', fontSize: '0.9rem', fontWeight: 'bold', boxShadow: `0 2px 4px ${t.shadow}` }}
           >
-            <Check size={20} /> Import Data
+            <Check size={18} /> Import Data
           </button>
         </div>
       }
     >
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '12px', marginBottom: '20px', padding: '12px', backgroundColor: '#f8f9fa', borderRadius: '4px' }}>
-        {fileType === 'csv' && (
+      <div style={{ padding: '20px', backgroundColor: t.bg }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '16px' }}>
+          <Settings2 size={18} color={t.textMuted} />
+          <h3 style={{ margin: 0, fontSize: '0.9rem', color: t.textMuted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>General Settings</h3>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '20px', marginBottom: '30px', padding: '20px', backgroundColor: t.bg2, borderRadius: '8px', border: `1px solid ${t.border}` }}>
+          {fileType === 'csv' && (
+            <div>
+              <label htmlFor="import-delimiter" style={{ display: 'block', fontSize: '13px', fontWeight: 'bold', marginBottom: '8px', color: t.textMid }}>Delimiter</label>
+              <select
+                id="import-delimiter"
+                value={delimiter}
+                onChange={e => setDelimiter(e.target.value)}
+                style={{ width: '100%', padding: '8px 12px', borderRadius: '6px', border: `1px solid ${t.border}`, background: t.bg, color: t.text, height: '40px', fontSize: '14px' }}
+              >
+                <option value=",">Comma (,)</option>
+                <option value=";">Semicolon (;)</option>
+                <option value="\t">Tab</option>
+                <option value="|">Pipe (|)</option>
+              </select>
+            </div>
+          )}
           <div>
-            <label htmlFor="import-delimiter" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>Delimiter</label>
+            <label htmlFor="import-decimal" style={{ display: 'block', fontSize: '13px', fontWeight: 'bold', marginBottom: '8px', color: t.textMid }}>Decimal Point</label>
             <select
-              id="import-delimiter"
-              value={delimiter}
-              onChange={e => setDelimiter(e.target.value)}
-              style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
+              id="import-decimal"
+              value={decimalPoint}
+              onChange={e => setDecimalPoint(e.target.value)}
+              style={{ width: '100%', padding: '8px 12px', borderRadius: '6px', border: `1px solid ${t.border}`, background: t.bg, color: t.text, height: '40px', fontSize: '14px' }}
             >
+              <option value=".">Dot (.)</option>
               <option value=",">Comma (,)</option>
-              <option value=";">Semicolon (;)</option>
-              <option value="\t">Tab</option>
-              <option value="|">Pipe (|)</option>
             </select>
           </div>
-        )}
-        <div>
-          <label htmlFor="import-decimal" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>Decimal Point</label>
-          <select
-            id="import-decimal"
-            value={decimalPoint}
-            onChange={e => setDecimalPoint(e.target.value)}
-            style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
-          >
-            <option value=".">Dot (.)</option>
-            <option value=",">Comma (,)</option>
-          </select>
-        </div>
-        <div>
-          <label htmlFor="import-start-row" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>Start Row</label>
-          <input
-            id="import-start-row"
-            type="number"
-            min="1"
-            value={startRow}
-            onChange={e => setStartRow(parseInt(e.target.value) || 1)}
-            style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
-          />
-        </div>
-        <div>
-          <label htmlFor="import-x-axis" style={{ display: 'block', fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>X-Axis Column</label>
-          <select
-            id="import-x-axis"
-            value={xAxisColumn}
-            onChange={e => setXAxisColumnOverride(e.target.value)}
-            style={{ width: '100%', padding: '8px', borderRadius: '4px', border: '1px solid #ced4da', height: '40px', fontSize: '14px' }}
-          >
-            {columnConfigs.filter(c => c.type !== 'ignore').map(c => (
-              <option key={c.index} value={c.name}>{c.name}</option>
-            ))}
-          </select>
-        </div>
-      </div>
-
-      <div style={{ marginBottom: '20px', overflowX: 'auto' }}>
-        <h3 style={{ fontSize: '1rem', marginBottom: '10px' }}>Column Configuration & Preview</h3>
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
-          <thead>
-            <tr style={{ backgroundColor: '#e9ecef' }}>
-              {columnConfigs.map((config, i) => (
-                <th key={i} style={{ border: '1px solid #dee2e6', padding: '12px', textAlign: 'left', minWidth: '180px' }}>
-                  <input
-                    type="text"
-                    maxLength={100}
-                    value={config.name}
-                    aria-label={`Column ${i + 1} name`}
-                    onChange={e => handleUpdateColumn(i, { name: e.target.value })}
-                    style={{ width: '100%', marginBottom: '8px', fontWeight: 'bold', border: '1px solid #dee2e6', background: '#fff', padding: '4px', fontSize: '14px', borderRadius: '4px' }}
-                  />
-                  <select
-                    value={config.type}
-                    aria-label={`Column ${i + 1} data type`}
-                    onChange={e => handleUpdateColumn(i, { type: e.target.value as ColumnType })}
-                    style={{ width: '100%', fontSize: '14px', marginBottom: '8px', height: '36px', borderRadius: '4px' }}
-                  >
-                    <option value="numeric">Numeric</option>
-                    <option value="date">Date/Time</option>
-                    <option value="categorical">Categorical</option>
-                    <option value="ignore">Ignore</option>
-                  </select>
-                  {config.type === 'date' && (
-                    <input
-                      type="text"
-                      placeholder="Format (e.g. YYYY-MM-DD)"
-                      maxLength={50}
-                      aria-label={`Column ${i + 1} date format`}
-                      value={config.dateFormat || ''}
-                      onChange={e => handleUpdateColumn(i, { dateFormat: e.target.value })}
-                      style={{ width: '100%', fontSize: '14px', padding: '6px', border: '1px solid #dee2e6', borderRadius: '4px' }}
-                    />
-                  )}
-                </th>
+          {fileType === 'csv' && (
+            <div>
+              <label htmlFor="import-start-row" style={{ display: 'block', fontSize: '13px', fontWeight: 'bold', marginBottom: '8px', color: t.textMid }}>Start Row</label>
+              <input
+                id="import-start-row"
+                type="number"
+                min="1"
+                value={startRow}
+                onChange={e => setStartRow(parseInt(e.target.value) || 1)}
+                style={{ width: '100%', padding: '8px 12px', borderRadius: '6px', border: `1px solid ${t.border}`, background: t.bg, color: t.text, height: '40px', fontSize: '14px' }}
+              />
+            </div>
+          )}
+          <div>
+            <label htmlFor="import-x-axis" style={{ display: 'block', fontSize: '13px', fontWeight: 'bold', marginBottom: '8px', color: t.textMid }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                X-Axis Column <ArrowRight size={14} />
+              </div>
+            </label>
+            <select
+              id="import-x-axis"
+              value={xAxisColumn}
+              onChange={e => setXAxisColumnOverride(e.target.value)}
+              style={{ width: '100%', padding: '8px 12px', borderRadius: '6px', border: `1px solid ${t.border}`, background: t.bg, color: t.text, height: '40px', fontSize: '14px' }}
+            >
+              {columnConfigs.filter(c => c.type !== 'ignore').map(c => (
+                <option key={c.index} value={c.name}>{c.name}</option>
               ))}
-            </tr>
-          </thead>
-          <tbody>
-            {previewData.rows.map((row, rowIndex) => (
-              <tr key={rowIndex}>
-                {columnConfigs.map((config, colIndex) => (
-                  <td key={colIndex} style={{
-                    border: '1px solid #dee2e6',
-                    padding: '12px',
-                    color: config.type === 'ignore' ? '#adb5bd' : '#212529',
-                    backgroundColor: config.type === 'ignore' ? '#f8f9fa' : 'transparent'
-                  }}>
-                    {fileType === 'json'
-                      ? (row as Record<string, string>)[previewData.headers[colIndex]]
-                      : (row as string[])[colIndex]}
-                  </td>
+            </select>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '16px' }}>
+          <Table size={18} color={t.textMuted} />
+          <h3 style={{ margin: 0, fontSize: '0.9rem', color: t.textMuted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Column Configuration & Preview</h3>
+        </div>
+
+        <div style={{ position: 'relative', border: `1px solid ${t.border}`, borderRadius: '8px', overflow: 'hidden' }}>
+          <div style={{ overflowX: 'auto', maxHeight: '500px' }}>
+            <table style={{ width: '100%', borderCollapse: 'separate', borderSpacing: 0, fontSize: '14px' }}>
+              <thead>
+                <tr>
+                  {columnConfigs.map((config, i) => (
+                    <th key={i} style={{
+                      position: 'sticky',
+                      top: 0,
+                      zIndex: 10,
+                      backgroundColor: t.bg2,
+                      borderBottom: `2px solid ${t.border}`,
+                      borderRight: i < columnConfigs.length - 1 ? `1px solid ${t.border}` : 'none',
+                      padding: '16px',
+                      textAlign: 'left',
+                      minWidth: '200px'
+                    }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '10px' }}>
+                        <Columns size={14} color={t.accent} />
+                        <input
+                          type="text"
+                          maxLength={100}
+                          value={config.name}
+                          aria-label={`Column ${i + 1} name`}
+                          onChange={e => handleUpdateColumn(i, { name: e.target.value })}
+                          style={{
+                            flex: 1,
+                            fontWeight: 'bold',
+                            border: 'none',
+                            background: 'transparent',
+                            padding: '4px',
+                            fontSize: '14px',
+                            color: t.text,
+                            outline: 'none',
+                            borderBottom: `1px dashed ${t.border2}`
+                          }}
+                        />
+                      </div>
+                      <select
+                        value={config.type}
+                        aria-label={`Column ${i + 1} data type`}
+                        onChange={e => handleUpdateColumn(i, { type: e.target.value as ColumnType })}
+                        style={{ width: '100%', fontSize: '13px', marginBottom: config.type === 'date' ? '8px' : 0, height: '32px', borderRadius: '4px', background: t.bg, color: t.text, border: `1px solid ${t.border}` }}
+                      >
+                        <option value="numeric">Numeric</option>
+                        <option value="date">Date/Time</option>
+                        <option value="categorical">Categorical</option>
+                        <option value="ignore">Ignore</option>
+                      </select>
+                      {config.type === 'date' && (
+                        <input
+                          type="text"
+                          placeholder="Format (e.g. YYYY-MM-DD)"
+                          maxLength={50}
+                          aria-label={`Column ${i + 1} date format`}
+                          value={config.dateFormat || ''}
+                          onChange={e => handleUpdateColumn(i, { dateFormat: e.target.value })}
+                          style={{ width: '100%', fontSize: '12px', padding: '6px 8px', border: `1px solid ${t.border}`, borderRadius: '4px', background: t.bg, color: t.text }}
+                        />
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {previewData.rows.map((row, rowIndex) => (
+                  <tr key={rowIndex} style={{ backgroundColor: rowIndex % 2 === 0 ? t.bg : t.bg2 }}>
+                    {columnConfigs.map((config, colIndex) => (
+                      <td key={colIndex} style={{
+                        borderBottom: `1px solid ${t.border}`,
+                        borderRight: colIndex < columnConfigs.length - 1 ? `1px solid ${t.border}` : 'none',
+                        padding: '12px 16px',
+                        color: config.type === 'ignore' ? t.textLight : t.text,
+                        backgroundColor: config.type === 'ignore' ? t.bg3 : 'transparent',
+                        opacity: config.type === 'ignore' ? 0.6 : 1,
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        maxWidth: '300px'
+                      }}>
+                        {fileType === 'json'
+                          ? (row as Record<string, string>)[previewData.headers[colIndex]]
+                          : (row as string[])[colIndex]}
+                      </td>
+                    ))}
+                  </tr>
                 ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
     </Modal>
   );

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -460,7 +460,7 @@ export const Sidebar: React.FC = () => {
       </aside>
 
       {/* Modals */}
-      {pendingFile && <ImportSettingsDialog fileName={pendingFile.file.name} fileContent={pendingFile.preview} fileType={pendingFile.type} onConfirm={confirmImport} onCancel={cancelImport} />}
+      {pendingFile && <ImportSettingsDialog fileName={pendingFile.file.name} fileContent={pendingFile.preview} fileType={pendingFile.type} onConfirm={confirmImport} onCancel={cancelImport} theme={t} />}
       {selectedDatasetForView && <DataViewModal dataset={selectedDatasetForView} onClose={() => setViewingDatasetId(null)} />}
       {selectedDatasetForCalc && <CalculatedColumnModal dataset={selectedDatasetForCalc} onClose={() => setCalculatingDatasetId(null)} />}
       {showImprint && <ImprintModal onClose={() => setShowImprint(false)} />}

--- a/src/components/Layout/__tests__/ImportSettingsDialog.test.tsx
+++ b/src/components/Layout/__tests__/ImportSettingsDialog.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { ImportSettingsDialog } from '../ImportSettingsDialog';
+import { THEMES } from '../../../themes';
+
+const theme = THEMES.light;
 
 describe('ImportSettingsDialog', () => {
   it('handles invalid JSON gracefully', () => {
@@ -18,6 +22,7 @@ describe('ImportSettingsDialog', () => {
         fileType="json"
         onConfirm={onConfirm}
         onCancel={onCancel}
+        theme={theme}
       />
     );
 
@@ -29,5 +34,35 @@ describe('ImportSettingsDialog', () => {
     // so no column configurations are rendered (no inputs with role column header)
     const inputs = screen.queryAllByRole('textbox', { name: /Column .* name/i });
     expect(inputs).toHaveLength(0);
+  });
+
+  it('updates headers and preview when startRow changes', () => {
+    const csvContent = 'Comment Line\nHeader1,Header2\nData1,Data2';
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <ImportSettingsDialog
+        fileName="test.csv"
+        fileContent={csvContent}
+        fileType="csv"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        theme={theme}
+      />
+    );
+
+    // Initial state: startRow=1, headers: "Comment Line"
+    expect(screen.getByLabelText(/Column 1 name/i)).toHaveValue('Comment Line');
+
+    // Change startRow to 2
+    const startRowInput = screen.getByLabelText(/Start Row/i);
+    fireEvent.change(startRowInput, { target: { value: '2' } });
+
+    // New state: startRow=2, headers: lines[1] split by "," -> ["Header1", "Header2"]
+    expect(screen.getByLabelText(/Column 1 name/i)).toHaveValue('Header1');
+    expect(screen.getByLabelText(/Column 2 name/i)).toHaveValue('Header2');
+    expect(screen.getByText('Data1')).toBeInTheDocument();
+    expect(screen.getByText('Data2')).toBeInTheDocument();
   });
 });

--- a/src/workers/data-parser.worker.ts
+++ b/src/workers/data-parser.worker.ts
@@ -282,7 +282,7 @@ async function parseCSV(file: File, settings?: ParseSettings) {
         continue;
       }
 
-      if (isFirstLine && lineCount === 0) {
+      if (isFirstLine && lineCount === startRow - 1) {
         const headerResult = processCSVHeader(line, delimiter, columnConfigs, capacity);
         configsByIndex = headerResult.configsByIndex;
         activeCols = headerResult.activeCols;
@@ -293,7 +293,7 @@ async function parseCSV(file: File, settings?: ParseSettings) {
         isFirstLine = false;
       }
       
-      if (lineCount >= startRow) {
+      if (lineCount >= startRow && !isFirstLine) {
         // Ensure capacity
         if (actualRowCount >= capacity) {
           capacity *= 2;


### PR DESCRIPTION
This PR addresses the issue where the data import preview didn't update when the starting line was changed. 

Key changes:
1. **Dynamic Preview**: The `ImportSettingsDialog` now correctly re-calculates headers and data rows whenever the `startRow` or `delimiter` is modified.
2. **Synchronized Worker**: The `data-parser.worker.ts` has been updated to use the same logic for header detection (`startRow - 1`), ensuring the final imported dataset matches the user's preview configuration.
3. **UI Modernization**: 
   - The dialog now accepts the active theme and uses theme variables for all colors.
   - The layout has been reorganized into "General Settings" and "Column Configuration & Preview" sections.
   - Used `lucide-react` icons for better visual guidance.
   - The column configuration table now features sticky headers and improved styling, including dimmed rows for ignored columns.
4. **Testing**: Added a unit test to verify that changing the start row correctly updates the column name inputs in the UI. Verified all other tests pass.

Fixes #260

---
*PR created automatically by Jules for task [18009156877144701967](https://jules.google.com/task/18009156877144701967) started by @michaelkrisper*