### PR TITLE
Update X-axis assignment UI in Sidebar

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -301,6 +301,18 @@ export const Sidebar: React.FC = () => {
                           <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
                             <button
                               onClick={() => {
+                                const currentId = ds.xAxisId || 'axis-1';
+                                const currentNum = parseInt(currentId.split('-')[1]) || 1;
+                                const nextNum = (currentNum % 9) + 1;
+                                updateDataset(ds.id, { xAxisId: `axis-${nextNum}` });
+                              }}
+                              title="Cycle X-Axis (1-9)"
+                              style={{ padding: '0 6px', height: '20px', background: 'none', border: `1px solid ${t.border}`, borderRadius: '4px', cursor: 'pointer', color: t.accent, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.75rem', fontWeight: 'bold' }}
+                            >
+                              {(ds.xAxisId || 'axis-1').split('-')[1]}
+                            </button>
+                            <button
+                              onClick={() => {
                                 const axis = xAxes.find(a => a.id === (ds.xAxisId || 'axis-1'));
                                 if (axis) {
                                   updateXAxis(axis.id, { xMode: axis.xMode === 'date' ? 'numeric' : 'date' });
@@ -319,17 +331,6 @@ export const Sidebar: React.FC = () => {
                               {ds.columns.map(c => <option key={c} value={c}>{c}</option>)}
                             </select>
                           </div>
-                        </div>
-
-                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
-                          <label style={{ fontSize: '0.75rem', fontWeight: 'bold', color: t.textLight }}>X-Axis Assignment</label>
-                          <select
-                            value={ds.xAxisId}
-                            onChange={(e) => updateDataset(ds.id, { xAxisId: e.target.value })}
-                            style={{ fontSize: '0.75rem', padding: '2px 4px', borderRadius: '4px', border: `1px solid ${t.border}`, background: t.selectBg, color: t.selectColor, maxWidth: '120px' }}
-                          >
-                            {xAxes.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
-                          </select>
                         </div>
 
                         <div style={{ fontSize: '0.75rem', fontWeight: 'bold', color: t.textLight, marginBottom: '6px' }}>Series / Columns</div>


### PR DESCRIPTION
The X-axis assignment UI in the Sidebar was updated to be more compact and consistent with the Y-axis assignment. A new cycle button (displaying 1-9) was added next to the X-axis mode toggle (Clock/Hash icon) in the "X-Axis Column" section of each data source. The separate "X-Axis Assignment" label and dropdown were removed to save vertical space. Visual verification and regression tests were performed to ensure correctness.

Fixes #267

---
*PR created automatically by Jules for task [182810457187098825](https://jules.google.com/task/182810457187098825) started by @michaelkrisper*