### PR TITLE
Allow adding duplicate data series from the same column

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -342,14 +342,14 @@ export const Sidebar: React.FC = () => {
                               <button
                                 key={col}
                                 onClick={() => createSeries(ds.id, col)}
-                                disabled={isUsed}
                                 style={{
                                   fontSize: '0.7rem', padding: '3px 8px', borderRadius: '0',
-                                  border: isUsed ? `1px solid ${t.border}` : `1px solid ${t.accent}`,
-                                  backgroundColor: isUsed ? t.bg3 : t.bg3,
-                                  color: isUsed ? t.textLight : t.accent,
-                                  cursor: isUsed ? 'default' : 'pointer',
-                                  fontWeight: '600'
+                                  border: `1px solid ${t.accent}`,
+                                  backgroundColor: t.bg3,
+                                  color: t.accent,
+                                  cursor: 'pointer',
+                                  fontWeight: '600',
+                                  opacity: isUsed ? 0.7 : 1
                                 }}
                               >
                                 {col.includes(': ') ? col.split(': ')[1] : col}

--- a/src/components/Layout/__tests__/Sidebar.test.tsx
+++ b/src/components/Layout/__tests__/Sidebar.test.tsx
@@ -67,9 +67,12 @@ Object.defineProperty(window, 'localStorage', {
 });
 
 // Mock hooks
-vi.mock('../../../store/useGraphStore', () => ({
-  useGraphStore: vi.fn(),
-}));
+vi.mock('../../../store/useGraphStore', () => {
+  const store = vi.fn();
+  (store as any).getState = vi.fn();
+  (store as any).setState = vi.fn();
+  return { useGraphStore: store };
+});
 
 vi.mock('../../../hooks/useDataImport', () => ({
   useDataImport: vi.fn(),
@@ -230,6 +233,51 @@ describe('Sidebar Component', () => {
 
     render(<Sidebar />);
     expect(screen.getByTestId('import-settings-dialog')).toBeInTheDocument();
+  });
+
+  it('does not disable the button for an already used data column', () => {
+    const mockDatasets = [
+      { id: 'ds-1', name: 'Dataset 1', columns: ['time', 'value1', 'value2'], xAxisColumn: 'time', xAxisId: 'axis-1' }
+    ];
+    const mockSeries = [
+      { id: 's-1', sourceId: 'ds-1', yColumn: 'value1', yAxisId: 'axis-1', hidden: false }
+    ];
+    const mockXAxes = [{ id: 'axis-1', name: 'X-Axis 1', xMode: 'numeric' }];
+    const mockAddSeries = vi.fn();
+
+    (useGraphStore as unknown as Mock).mockReturnValue({
+      datasets: mockDatasets,
+      series: mockSeries,
+      xAxes: mockXAxes,
+      yAxes: [],
+      axisTitles: [],
+      views: [],
+      removeDataset: vi.fn(),
+      updateDataset: vi.fn(),
+      updateXAxis: vi.fn(),
+      setHighlightedSeries: vi.fn(),
+    });
+
+    // Mock useGraphStore.getState()
+    (useGraphStore.getState as unknown as Mock).mockReturnValue({
+      addSeries: mockAddSeries,
+    });
+
+    render(<Sidebar />);
+
+    // value1 is used, but its button should NOT be disabled anymore
+    const value1Button = screen.getByRole('button', { name: 'value1' });
+    expect(value1Button).not.toBeDisabled();
+    expect(value1Button).toHaveStyle({ opacity: '0.7' });
+
+    // Clicking it should call addSeries
+    fireEvent.click(value1Button);
+    expect(mockAddSeries).toHaveBeenCalled();
+
+    // value2 is not used, so its button should be enabled and full opacity
+    const value2Button = screen.getByRole('button', { name: 'value2' });
+    expect(value2Button).not.toBeDisabled();
+    expect(value2Button).toHaveStyle({ opacity: '1' });
   });
 
 });


### PR DESCRIPTION
This PR enables users to add the same data column from a data source multiple times. 

Previously, the button for a data column was disabled once it was added as a series. Now, the button remains active, allowing for redundant additions (e.g., for different styles or shifted views of the same data). 

Key changes:
- Removed `disabled={isUsed}` from data column buttons in `Sidebar.tsx`.
- Updated button styling to provide visual feedback (opacity: 0.7) when a column is already in use, while maintaining interactivity.
- Updated `Sidebar.test.tsx` to verify that used columns remain clickable and correctly invoke the add series action.
- Verified the fix with a Playwright script and manual inspection of the generated screenshot/video.

Fixes #269

---
*PR created automatically by Jules for task [16811993447889520542](https://jules.google.com/task/16811993447889520542) started by @michaelkrisper*