### PR TITLE
Show template colors first in color selection

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { useGraphStore } from '../../store/useGraphStore';
 import { useDataImport } from '../../hooks/useDataImport';
 import { useTheme } from '../../hooks/useTheme';
-import { THEMES, type ThemeName } from '../../themes';
+import { THEMES, type ThemeName, COLOR_PALETTE } from '../../themes';
 import { SeriesConfigUI } from '../Sidebar/SeriesConfig';
 import ErrorBoundary from '../ErrorBoundary';
 import { FilePlus, Trash2, ChevronRight, ChevronDown, HelpCircle, X, Eye, FileImage, Image, Bookmark, Calculator, ArrowUpDown, Hash, MoveHorizontal, Rows, Minus, Circle, Palette, Sun, Moon, Terminal, Sparkles, Wand2, List, FlaskConical, RotateCcw, Save, FolderOpen, Clock } from 'lucide-react';
@@ -16,10 +16,6 @@ import { ImprintModal } from './ImprintModal';
 import { HelpModal } from './HelpModal';
 import { LicenseModal } from './LicenseModal';
 import { CollapsedMenuButton } from './CollapsedMenuButton';
-
-const COLOR_PALETTE = [
-  '#2563eb', '#e11d48', '#059669', '#d97706', '#7c3aed', '#db2777', '#0891b2', '#ea580c'
-];
 
 const THEME_ICONS: Record<ThemeName, React.ReactNode> = {
   light: <Sun size={18} />,

--- a/src/components/Sidebar/ColorPicker.tsx
+++ b/src/components/Sidebar/ColorPicker.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { THEMES, type ThemeName, COLOR_PALETTE } from '../../themes';
+import { Palette } from 'lucide-react';
+
+interface ColorPickerProps {
+  color: string;
+  onChange: (color: string) => void;
+  themeName: ThemeName;
+  ariaLabel?: string;
+}
+
+export const ColorPicker: React.FC<ColorPickerProps> = ({ color, onChange, themeName, ariaLabel }) => {
+  const t = THEMES[themeName];
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const nativePickerRef = useRef<HTMLInputElement>(null);
+  const [popoverCoords, setPopoverCoords] = useState({ top: 0, left: 0 });
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        // Check if the click was inside the portal-ed popover
+        const popover = document.getElementById('color-picker-popover');
+        if (popover && popover.contains(event.target as Node)) {
+          return;
+        }
+        setIsOpen(false);
+      }
+    };
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const toggleOpen = () => {
+    if (!isOpen && containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      setPopoverCoords({
+        top: rect.bottom + window.scrollY,
+        left: rect.left + window.scrollX
+      });
+    }
+    setIsOpen(!isOpen);
+  };
+
+  const handleSelectTemplate = (selectedColor: string) => {
+    onChange(selectedColor);
+    setIsOpen(false);
+  };
+
+  const triggerNativePicker = () => {
+    nativePickerRef.current?.click();
+    setIsOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative', width: 'var(--touch-target-size)', height: 'var(--touch-target-size)', flexShrink: 0 }}>
+      {/* Current Color Indicator / Button */}
+      <button
+        onClick={toggleOpen}
+        title="Select Color"
+        aria-label={ariaLabel || "Select Color"}
+        style={{
+          width: '100%',
+          height: '100%',
+          padding: 0,
+          border: 'none',
+          borderRight: `1px solid ${t.border2}`,
+          backgroundColor: color,
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}
+      >
+        <div style={{
+          width: '12px',
+          height: '12px',
+          borderRadius: '2px',
+          border: '1px solid rgba(255,255,255,0.5)',
+          boxShadow: '0 0 0 1px rgba(0,0,0,0.1)'
+        }} />
+      </button>
+
+      {/* Popover using Portal */}
+      {isOpen && createPortal(
+        <div
+          id="color-picker-popover"
+          style={{
+            position: 'absolute',
+            top: popoverCoords.top + 4,
+            left: popoverCoords.left,
+            zIndex: 10001,
+            backgroundColor: t.bg,
+            border: `1px solid ${t.border}`,
+            borderRadius: '4px',
+            boxShadow: `0 4px 12px ${t.shadow}`,
+            padding: '8px',
+            width: '120px'
+          }}
+        >
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '6px', marginBottom: '8px' }}>
+            {COLOR_PALETTE.map((paletteColor) => (
+              <button
+                key={paletteColor}
+                onClick={() => handleSelectTemplate(paletteColor)}
+                style={{
+                  width: '20px',
+                  height: '20px',
+                  backgroundColor: paletteColor,
+                  border: color === paletteColor ? `2px solid ${t.text}` : `1px solid ${t.border}`,
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  padding: 0
+                }}
+                title={paletteColor}
+              />
+            ))}
+          </div>
+          <button
+            onClick={triggerNativePicker}
+            style={{
+              width: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '4px',
+              padding: '4px',
+              fontSize: '0.75rem',
+              backgroundColor: t.bg2,
+              border: `1px solid ${t.border}`,
+              borderRadius: '4px',
+              cursor: 'pointer',
+              color: t.text
+            }}
+          >
+            <Palette size={12} />
+            <span>Custom</span>
+          </button>
+        </div>,
+        document.body
+      )}
+
+      {/* Hidden Native Picker */}
+      <input
+        ref={nativePickerRef}
+        type="color"
+        value={color}
+        onChange={(e) => onChange(e.target.value)}
+        style={{
+          position: 'absolute',
+          opacity: 0,
+          width: 0,
+          height: 0,
+          pointerEvents: 'none'
+        }}
+      />
+    </div>
+  );
+};

--- a/src/components/Sidebar/SeriesConfig.tsx
+++ b/src/components/Sidebar/SeriesConfig.tsx
@@ -3,6 +3,7 @@ import { useGraphStore } from '../../store/useGraphStore';
 import { type SeriesConfig, type Dataset } from '../../services/persistence';
 import { THEMES, type ThemeName } from '../../themes';
 import { Trash2, Circle, Square, X, Rows, Ban, ChevronUp, ChevronDown, Eye, EyeOff } from 'lucide-react';
+import { ColorPicker } from './ColorPicker';
 
 interface Props {
   series: SeriesConfig;
@@ -168,17 +169,11 @@ export const SeriesConfigUI: React.FC<Props> = ({ series, dataset, isFirst, isLa
 
 
       {/* Color Picker */}
-      <input
-        type="color"
-        name={`series-color-${series.id}`}
-        aria-label={`Color for ${series.name || series.yColumn}`}
-        value={series.lineColor}
-        onInput={(e) => {
-          const inputColor = (e.target as HTMLInputElement).value;
-          handleUpdate({ lineColor: inputColor, pointColor: inputColor });
-        }}
-        style={{ width: 'var(--touch-target-size)', height: 'var(--touch-target-size)', padding: 0, border: 'none', borderRight: sep, cursor: 'pointer', flexShrink: 0 }}
-        title="Color"
+      <ColorPicker
+        color={series.lineColor}
+        themeName={themeName}
+        onChange={(newColor) => handleUpdate({ lineColor: newColor, pointColor: newColor })}
+        ariaLabel={`Color for ${series.name || series.yColumn}`}
       />
 
       {/* Y Column Selector */}

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -141,4 +141,8 @@ export const THEMES: Record<ThemeName, Theme> = {
   },
 };
 
+export const COLOR_PALETTE = [
+  '#2563eb', '#e11d48', '#059669', '#d97706', '#7c3aed', '#db2777', '#0891b2', '#ea580c'
+];
+
 export const THEME_CYCLE: ThemeName[] = ['light', 'dark', 'matrix', 'unicorn'];


### PR DESCRIPTION
This PR implements a new color selection UX that prioritizes template colors.

Key changes:
- Centralized the default color palette in `src/themes.ts`.
- Developed a new `ColorPicker` component that displays a grid of these template colors by default.
- Added a "Custom" button to the `ColorPicker` to allow users to open the native RGB color selector on demand.
- Integrated the `ColorPicker` into the series configuration rows in the sidebar.
- Used React Portals for the color palette popover to ensure it remains visible and unclipped by the sidebar's overflow settings.
- Verified the changes with unit tests and a Playwright-based frontend verification script.

Fixes #268

---
*PR created automatically by Jules for task [8114903526447769648](https://jules.google.com/task/8114903526447769648) started by @michaelkrisper*