### PR TITLE
Remove trailing zeroes from data tooltip

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -498,7 +498,7 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
               {group.items.map((item, itemIdx) => (
                 <div key={`item-${groupIdx}-${itemIdx}`} style={{ color: item.color, display: 'flex', justifyContent: 'space-between', gap: '12px' }}>
                   <span>{item.label}:</span>
-                  <span style={{ color: tooltipColor, fontWeight: 'bold' }}>{item.value.toPrecision(7)}</span>
+                  <span style={{ color: tooltipColor, fontWeight: 'bold' }}>{Number(item.value.toPrecision(7))}</span>
                 </div>
               ))}
             </React.Fragment>


### PR DESCRIPTION
Modified `src/components/Plot/ChartContainer.tsx` to remove trailing zeros from data values displayed in the chart tooltip. This was achieved by wrapping the result of `item.value.toPrecision(7)` in a `Number()` constructor, which strips trailing zeros during the conversion back to a string for rendering. Verified with unit tests and visual inspection via Playwright screenshots.

Fixes #274

---
*PR created automatically by Jules for task [1018163834003641061](https://jules.google.com/task/1018163834003641061) started by @michaelkrisper*