### PR TITLE
Colorize Y-axis titles with series colors

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -312,7 +312,7 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
           const range = axis.max - axis.min;
           const chartHeight = Math.max(0, height - padding.top - padding.bottom);
           if (range <= 0 || chartHeight <= 0) return null;
-          const axisSeries = seriesByYAxisId[axis.id] || [], title = axisSeries.map((s: SeriesConfig) => s.name || s.yColumn).join(' / ');
+          const axisSeries = seriesByYAxisId[axis.id] || [];
           const spineX = isLeft ? xPos + axisMetrics.total : xPos;
           const labelX = isLeft ? spineX - 7 - axisMetrics.label : spineX + 7;
           const titleX = isLeft ? xPos + 7.5 : xPos + axisMetrics.total - 7.5;
@@ -324,7 +324,14 @@ const AxesLayer = React.memo(({ xAxes, yAxes, width, height, padding, leftAxes, 
                 const label = Math.abs(t) < 1e-12 ? '0' : t.toFixed(axis.precision);
                 return <div key={`yl-${axis.id}-${t}`} style={{ position: 'absolute', left: labelX, top: y, transform: 'translateY(-50%)', fontSize: isMobile ? '10px' : '9px', color: labelColor, width: axisMetrics.label, textAlign: isLeft ? 'right' : 'left' }}>{label}</div>;
               })}
-              <div style={{ position: 'absolute', top: padding.top + chartHeight / 2, left: titleX, transform: `translate(-50%, -50%) rotate(${isLeft ? -90 : 90}deg)`, fontSize: isMobile ? '14px' : '12px', fontWeight: 'bold', color: axisSeries[0]?.lineColor || labelColor, padding: '2px 4px', borderRadius: '2px', whiteSpace: 'nowrap', textAlign: 'center', maxWidth: chartHeight, overflow: 'hidden', textOverflow: 'ellipsis' }}>{title}</div>
+              <div style={{ position: 'absolute', top: padding.top + chartHeight / 2, left: titleX, transform: `translate(-50%, -50%) rotate(${isLeft ? -90 : 90}deg)`, fontSize: isMobile ? '14px' : '12px', fontWeight: 'bold', color: labelColor, padding: '2px 4px', borderRadius: '2px', whiteSpace: 'nowrap', textAlign: 'center', maxWidth: chartHeight, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {axisSeries.map((s, i) => (
+                  <React.Fragment key={s.id}>
+                    {i > 0 && <span style={{ color: labelColor }}> / </span>}
+                    <span style={{ color: s.lineColor }}>{s.name || s.yColumn}</span>
+                  </React.Fragment>
+                ))}
+              </div>
             </React.Fragment>
           );
         })}

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -264,13 +264,18 @@ export const exportToSVG = (
     }
 
     const axisSeries = series.filter(s => s.yAxisId === axis.id);
-    const title = axisSeries.map(s => s.name || s.yColumn).join(' / ');
+    const fullTitle = axisSeries.map(s => s.name || s.yColumn).join(' / ');
     const titleX = isLeft ? (xPos + 5) : (xPos + axisWidth - 5);
     const titleY = padding.top + chartHeight / 2, rotate = isLeft ? -90 : 90;
-    const estW = Math.min(chartHeight, title.length * 6 + 8);
+    const estW = Math.min(chartHeight, fullTitle.length * 6 + 8);
     svg += `<g transform="translate(${titleX}, ${titleY}) rotate(${rotate})">`;
     svg += `<rect x="-${estW / 2}" y="-8" width="${estW}" height="16" fill="${theme.secLabelBg}" rx="2" />`;
-    svg += `<text x="0" y="4" text-anchor="middle" font-size="10" font-weight="bold" fill="${escapeHTML(axisSeries[0]?.lineColor || theme.axisColor)}">${escapeHTML(title)}</text></g>`;
+    svg += `<text x="0" y="4" text-anchor="middle" font-size="10" font-weight="bold" fill="${theme.labelColor}">`;
+    axisSeries.forEach((s, i) => {
+      if (i > 0) svg += `<tspan fill="${theme.labelColor}"> / </tspan>`;
+      svg += `<tspan fill="${escapeHTML(s.lineColor)}">${escapeHTML(s.name || s.yColumn)}</tspan>`;
+    });
+    svg += `</text></g>`;
   });
 
   svg += `</svg>`; return svg;


### PR DESCRIPTION
Implemented dynamic coloring for Y-axis titles based on the associated data series. When multiple series share an axis, the title is rendered as a combined string where each series name is colored individually using its specific lineColor, while separators use the theme's labelColor. This consistent styling is applied to both the interactive React UI and the SVG export service.

Fixes #277

---
*PR created automatically by Jules for task [12360795039526011527](https://jules.google.com/task/12360795039526011527) started by @michaelkrisper*