### PR TITLE
Simplify data tooltip: series label and header format

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -445,7 +445,7 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
       const yVal = yData[bestI] + refY; const xVal = xData[bestI] + refX;
       const axisTitle = axisTitleMap[axis.id] || '';
       const label = s.name || s.yColumn;
-      const displayLabel = axisTitle && axisTitle !== label ? `${label} [${axisTitle}]` : label;
+      const displayLabel = label;
       const xLab = xAxis.xMode === 'date' ? formatFullDate(xVal) : parseFloat(xVal.toPrecision(7)).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 10 });
       const xAxisName = ds.xAxisColumn || xAxis.name || `X-Axis ${ds.xAxisId}`;
       const groupKey = `${xLab}|${xAxisName}`;
@@ -493,12 +493,12 @@ const Crosshair = React.memo(({ containerRef, padding, width, height, isPanning,
           {snap?.entries.map((group, groupIdx) => (
             <React.Fragment key={`group-${groupIdx}`}>
               <div style={{ color: tooltipSubColor, fontSize: '9px', borderTop: groupIdx > 0 ? `1px solid ${tooltipDividerColor}` : 'none', paddingTop: groupIdx > 0 ? '4px' : 0, marginTop: groupIdx > 0 ? '4px' : 0 }}>
-                <span style={{ fontWeight: 'bold', color: tooltipColor, fontSize: '10px' }}>{group.xLabel}</span> ({group.xAxisName})
+                <span style={{ fontWeight: 'bold', color: tooltipColor, fontSize: '10px' }}>{group.xAxisName}: {group.xLabel}</span>
               </div>
               {group.items.map((item, itemIdx) => (
                 <div key={`item-${groupIdx}-${itemIdx}`} style={{ color: item.color, display: 'flex', justifyContent: 'space-between', gap: '12px' }}>
                   <span>{item.label}:</span>
-                  <span style={{ color: tooltipColor, fontWeight: 'bold' }}>{item.value.toPrecision(7)}</span>
+                  <span style={{ color: tooltipColor, fontWeight: 'bold' }}>{parseFloat(item.value.toPrecision(7)).toLocaleString()}</span>
                 </div>
               ))}
             </React.Fragment>


### PR DESCRIPTION
Simplified the data tooltip in `ChartContainer.tsx` as requested. 

Key changes:
1. **Series Labels:** Removed the `[Axis Title]` suffix from series names in the tooltip to make it more concise.
2. **Tooltip Header:** Switched the format from `Value (Axis Name)` to `Axis Name: Value` for a more standard and readable header.
3. **Numeric Formatting:** Applied `toLocaleString()` to data values in the tooltip. This ensures that large numbers have proper separators and that floating-point numbers do not show excessive trailing zeros (as often happens with `.toPrecision(7)`), resulting in a much cleaner UI.

Verified the changes visually with a Playwright screenshot and confirmed that existing unit tests for the renderer still pass.

Fixes #278

---
*PR created automatically by Jules for task [8615554658773800739](https://jules.google.com/task/8615554658773800739) started by @michaelkrisper*