### PR TITLE
Compact Data Tables and Prefix Stripping

### DIFF
--- a/src/components/Layout/DataViewModal.tsx
+++ b/src/components/Layout/DataViewModal.tsx
@@ -2,24 +2,27 @@ import React from 'react';
 import { type Dataset } from '../../services/persistence';
 import { formatFullDate } from '../../utils/time';
 import { Modal } from './Modal';
+import { type Theme } from '../../themes';
 
 interface DataViewModalProps {
   dataset: Dataset;
   onClose: () => void;
+  theme: Theme;
 }
 
 /**
  * DataViewModal Component
  * Displays a table of the dataset's values (up to 100 rows).
  */
-export const DataViewModal: React.FC<DataViewModalProps> = ({ dataset, onClose }) => {
+export const DataViewModal: React.FC<DataViewModalProps> = ({ dataset, onClose, theme: t }) => {
   const maxRows = Math.min(dataset.rowCount, 100);
   const rows = Array.from({ length: maxRows }, (_, i) => i);
+  const displayName = dataset.name.includes(': ') ? dataset.name.split(': ')[1] : dataset.name;
 
   return (
     <Modal
       onClose={onClose}
-      title={`Data Source: ${dataset.name}`}
+      title={`Data Source: ${displayName}`}
       maxWidth="1000px"
       width="95%"
       padding="16px"
@@ -27,31 +30,31 @@ export const DataViewModal: React.FC<DataViewModalProps> = ({ dataset, onClose }
         <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
           <button
             onClick={onClose}
-            style={{ padding: '12px 32px', borderRadius: '4px', border: '1px solid #ced4da', background: '#fff', cursor: 'pointer', fontWeight: 'bold', minHeight: '44px', fontSize: '1rem' }}
+            style={{ padding: '8px 24px', borderRadius: '4px', border: `1px solid ${t.border}`, background: t.bg, color: t.text, cursor: 'pointer', fontWeight: 'bold', minHeight: '36px', fontSize: '0.9rem' }}
           >
             Close
           </button>
         </div>
       }
     >
-      <div style={{ marginBottom: '12px', fontSize: '1rem', color: '#666' }}>
+      <div style={{ marginBottom: '12px', fontSize: '0.9rem', color: t.textMuted }}>
         Showing first {maxRows} of {dataset.rowCount.toLocaleString()} rows.
       </div>
 
-      <div style={{ overflowX: 'auto', border: '1px solid #dee2e6', borderRadius: '4px' }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
+      <div style={{ overflowX: 'auto', border: `1px solid ${t.border}`, borderRadius: '4px', backgroundColor: t.bg }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
           <thead>
-            <tr style={{ backgroundColor: '#f8f9fa', borderBottom: '2px solid #dee2e6' }}>
+            <tr style={{ backgroundColor: t.bg2, borderBottom: `2px solid ${t.border}` }}>
               {(dataset.columns || []).map((col, i) => (
-                <th key={i} style={{ border: '1px solid #dee2e6', padding: '12px', textAlign: 'left', whiteSpace: 'nowrap' }}>
-                  {col}
+                <th key={i} style={{ border: `1px solid ${t.border}`, padding: '6px 10px', textAlign: 'left', whiteSpace: 'nowrap', color: t.textMid }}>
+                  {col.includes(': ') ? col.split(': ')[1] : col}
                 </th>
               ))}
             </tr>
           </thead>
           <tbody>
             {rows.map(rowIndex => (
-              <tr key={rowIndex} style={{ borderBottom: '1px solid #eee' }}>
+              <tr key={rowIndex} style={{ borderBottom: `1px solid ${t.border}`, backgroundColor: rowIndex % 2 === 0 ? t.bg : t.bg2 }}>
                 {(dataset.data || []).map((colData, colIndex) => {
                   const rawValue = colData.data[rowIndex];
                   const absoluteValue = rawValue + colData.refPoint;
@@ -69,7 +72,7 @@ export const DataViewModal: React.FC<DataViewModalProps> = ({ dataset, onClose }
                   }
 
                   return (
-                    <td key={colIndex} style={{ border: '1px solid #dee2e6', padding: '12px' }}>
+                    <td key={colIndex} style={{ border: `1px solid ${t.border}`, padding: '4px 8px', color: t.text }}>
                       {displayValue}
                     </td>
                   );

--- a/src/components/Layout/ImportSettingsDialog.tsx
+++ b/src/components/Layout/ImportSettingsDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Check, Settings2, Table, Columns, FileType, ArrowRight } from 'lucide-react';
+import { Check, Settings2, Table, Columns, FileType, ArrowRight, Hash, Clock, Type, EyeOff } from 'lucide-react';
 import { secureJSONParse } from '../../utils/json';
 import type { ImportSettings, ColumnConfig, ColumnType } from '../../types/import';
 import { Modal } from './Modal';
@@ -232,7 +232,7 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
 
         <div style={{ position: 'relative', border: `1px solid ${t.border}`, borderRadius: '8px', overflow: 'hidden' }}>
           <div style={{ overflowX: 'auto', maxHeight: '500px' }}>
-            <table style={{ width: '100%', borderCollapse: 'separate', borderSpacing: 0, fontSize: '14px' }}>
+            <table style={{ width: '100%', borderCollapse: 'separate', borderSpacing: 0, fontSize: '12px' }}>
               <thead>
                 <tr>
                   {columnConfigs.map((config, i) => (
@@ -243,12 +243,11 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
                       backgroundColor: t.bg2,
                       borderBottom: `2px solid ${t.border}`,
                       borderRight: i < columnConfigs.length - 1 ? `1px solid ${t.border}` : 'none',
-                      padding: '16px',
+                      padding: '8px',
                       textAlign: 'left',
-                      minWidth: '120px'
+                      minWidth: '80px'
                     }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '10px' }}>
-                        <Columns size={14} color={t.accent} />
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '8px' }}>
                         <input
                           type="text"
                           maxLength={100}
@@ -260,34 +259,53 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
                             fontWeight: 'bold',
                             border: 'none',
                             background: 'transparent',
-                            padding: '4px',
-                            fontSize: '14px',
+                            padding: '2px',
+                            fontSize: '12px',
                             color: t.text,
                             outline: 'none',
-                            borderBottom: `1px dashed ${t.border2}`
+                            borderBottom: `1px dashed ${t.border2}`,
+                            width: '100%'
                           }}
                         />
                       </div>
-                      <select
-                        value={config.type}
-                        aria-label={`Column ${i + 1} data type`}
-                        onChange={e => handleUpdateColumn(i, { type: e.target.value as ColumnType })}
-                        style={{ width: '100%', fontSize: '13px', marginBottom: config.type === 'date' ? '8px' : 0, height: '32px', borderRadius: '4px', background: t.bg, color: t.text, border: `1px solid ${t.border}` }}
-                      >
-                        <option value="numeric">Numeric</option>
-                        <option value="date">Date/Time</option>
-                        <option value="categorical">Categorical</option>
-                        <option value="ignore">Ignore</option>
-                      </select>
+                      <div style={{ display: 'flex', gap: '2px' }}>
+                        {[
+                          { type: 'numeric', icon: Hash, label: 'Numeric' },
+                          { type: 'date', icon: Clock, label: 'Date/Time' },
+                          { type: 'categorical', icon: Type, label: 'Categorical' },
+                          { type: 'ignore', icon: EyeOff, label: 'Ignore' }
+                        ].map(opt => (
+                          <button
+                            key={opt.type}
+                            title={`Type: ${opt.label}`}
+                            onClick={() => handleUpdateColumn(i, { type: opt.type as ColumnType })}
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              width: '24px',
+                              height: '24px',
+                              borderRadius: '4px',
+                              border: `1px solid ${config.type === opt.type ? t.accent : t.border}`,
+                              background: config.type === opt.type ? t.accent : t.bg,
+                              color: config.type === opt.type ? '#fff' : t.textMuted,
+                              cursor: 'pointer',
+                              padding: 0
+                            }}
+                          >
+                            <opt.icon size={12} />
+                          </button>
+                        ))}
+                      </div>
                       {config.type === 'date' && (
                         <input
                           type="text"
-                          placeholder="Format (e.g. YYYY-MM-DD)"
+                          placeholder="YYYY-MM-DD"
                           maxLength={50}
                           aria-label={`Column ${i + 1} date format`}
                           value={config.dateFormat || ''}
                           onChange={e => handleUpdateColumn(i, { dateFormat: e.target.value })}
-                          style={{ width: '100%', fontSize: '12px', padding: '6px 8px', border: `1px solid ${t.border}`, borderRadius: '4px', background: t.bg, color: t.text }}
+                          style={{ width: '100%', fontSize: '11px', padding: '4px 6px', border: `1px solid ${t.border}`, borderRadius: '4px', background: t.bg, color: t.text, marginTop: '4px' }}
                         />
                       )}
                     </th>
@@ -301,14 +319,14 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
                       <td key={colIndex} style={{
                         borderBottom: `1px solid ${t.border}`,
                         borderRight: colIndex < columnConfigs.length - 1 ? `1px solid ${t.border}` : 'none',
-                        padding: '12px 16px',
+                        padding: '4px 8px',
                         color: config.type === 'ignore' ? t.textLight : t.text,
                         backgroundColor: config.type === 'ignore' ? t.bg3 : 'transparent',
                         opacity: config.type === 'ignore' ? 0.6 : 1,
                         whiteSpace: 'nowrap',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
-                        maxWidth: '200px'
+                        maxWidth: '120px'
                       }}>
                         {fileType === 'json'
                           ? (row as Record<string, string>)[previewData.headers[colIndex]]

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -282,8 +282,8 @@ export const Sidebar: React.FC = () => {
 
                   {datasets.map((ds) => (
                     <div key={ds.id} style={{ backgroundColor: t.bg, borderRadius: '10px', border: `1px solid ${t.cardBorder}`, overflow: 'hidden', boxShadow: `0 1px 3px ${t.shadow}` }}>
-                      <div style={{ padding: '10px 12px', borderBottom: `1px solid ${t.bg3}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                        <span style={{ fontWeight: '700', fontSize: '0.9rem', color: t.textMid, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '180px' }} title={ds.name}>{ds.name}</span>
+                      <div style={{ padding: '6px 10px', borderBottom: `1px solid ${t.bg3}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <span style={{ fontWeight: '700', fontSize: '0.85rem', color: t.textMid, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '180px' }} title={ds.name}>{ds.name.includes(': ') ? ds.name.split(': ')[1] : ds.name}</span>
                         <div style={{ display: 'flex', gap: '4px' }}>
                           <button onClick={() => setCalculatingDatasetId(ds.id)} style={{ padding: '4px', background: 'none', border: 'none', cursor: 'pointer', color: t.textMuted }} title="Add Calculated Column"><Calculator size={16} /></button>
                           <button onClick={() => setViewingDatasetId(ds.id)} style={{ padding: '4px', background: 'none', border: 'none', cursor: 'pointer', color: t.textMuted }} title="View Data"><Eye size={16} /></button>
@@ -291,7 +291,7 @@ export const Sidebar: React.FC = () => {
                         </div>
                       </div>
 
-                      <div style={{ padding: '10px 12px' }}>
+                      <div style={{ padding: '6px 10px' }}>
                         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
                           <label style={{ fontSize: '0.75rem', fontWeight: 'bold', color: t.textLight }}>X-Axis Column</label>
                           <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
@@ -324,7 +324,7 @@ export const Sidebar: React.FC = () => {
                               onChange={(e) => updateDataset(ds.id, { xAxisColumn: e.target.value })}
                               style={{ fontSize: '0.75rem', padding: '2px 4px', borderRadius: '4px', border: `1px solid ${t.border}`, background: t.selectBg, color: t.selectColor, maxWidth: '100px' }}
                             >
-                              {ds.columns.map(c => <option key={c} value={c}>{c}</option>)}
+                              {ds.columns.map(c => <option key={c} value={c}>{c.includes(': ') ? c.split(': ')[1] : c}</option>)}
                             </select>
                           </div>
                         </div>
@@ -483,7 +483,7 @@ export const Sidebar: React.FC = () => {
 
       {/* Modals */}
       {pendingFile && <ImportSettingsDialog fileName={pendingFile.file.name} fileContent={pendingFile.preview} fileType={pendingFile.type} onConfirm={confirmImport} onCancel={cancelImport} theme={t} />}
-      {selectedDatasetForView && <DataViewModal dataset={selectedDatasetForView} onClose={() => setViewingDatasetId(null)} />}
+      {selectedDatasetForView && <DataViewModal dataset={selectedDatasetForView} onClose={() => setViewingDatasetId(null)} theme={t} />}
       {selectedDatasetForCalc && <CalculatedColumnModal dataset={selectedDatasetForCalc} onClose={() => setCalculatingDatasetId(null)} />}
       {showImprint && <ImprintModal onClose={() => setShowImprint(false)} />}
       {showHelp && <HelpModal onClose={() => setShowHelp(false)} />}


### PR DESCRIPTION
This update significantly improves the information density and usability of data-heavy views.

Key changes:
- **Compacted UI**: Reduced padding and font sizes in the \`ImportSettingsDialog\` and \`DataViewModal\` tables, and the Sidebar's dataset cards.
- **Modernized Data Type Selection**: In the import settings, the traditional dropdown for column types has been replaced with a row of intuitive icon buttons, allowing for much faster configuration.
- **Cleaned Up Display Names**: Automatically strips system prefixes like "A: " from dataset and column names in the UI, providing a cleaner and more professional look while keeping the underlying data intact.
- **Theme Consistency**: Ensured the data view modal correctly respects and applies the application's active theme colors.

Fixes #275

---
*PR created automatically by Jules for task [10607911248895005221](https://jules.google.com/task/10607911248895005221) started by @michaelkrisper*