### PR TITLE
🔒 [security fix] Mitigate prototype pollution in session import

### DIFF
--- a/src/services/__tests__/session.test.ts
+++ b/src/services/__tests__/session.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { importSession } from '../session';
+import { persistence } from '../persistence';
+
+vi.mock('../persistence', () => ({
+  persistence: {
+    getAllDatasets: vi.fn(),
+    deleteDataset: vi.fn(),
+    saveDataset: vi.fn(),
+    saveAppState: vi.fn(),
+  },
+}));
+
+describe('importSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (persistence.getAllDatasets as any).mockResolvedValue([]);
+  });
+
+  it('should import a valid session', async () => {
+    const session = {
+      version: 1,
+      appState: {
+        xAxes: [],
+        yAxes: [],
+        series: [],
+        axisTitles: { x: 'X', y: 'Y' },
+      },
+      datasets: [],
+    };
+
+    const result = await importSession(JSON.stringify(session));
+    expect(result.appState).toEqual(session.appState);
+    expect(persistence.saveAppState).toHaveBeenCalledWith(session.appState);
+  });
+
+  it('should prevent prototype pollution', async () => {
+    const sessionJson = JSON.stringify({
+      version: 1,
+      appState: {
+        xAxes: [],
+        yAxes: [],
+        series: [],
+        axisTitles: { x: 'X', y: 'Y' },
+      },
+      datasets: [],
+      ['__proto__']: { polluted: 'true' },
+    });
+
+    const result = await importSession(sessionJson);
+    expect((result as any).polluted).toBeUndefined();
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('should throw error for unsupported version', async () => {
+    const session = {
+      version: 2,
+      appState: {},
+      datasets: [],
+    };
+
+    await expect(importSession(JSON.stringify(session))).rejects.toThrow('Unsupported session version: 2');
+  });
+});

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -1,4 +1,5 @@
 import { type Dataset, type AppState, type DataColumn, persistence } from './persistence';
+import { secureJSONParse } from '../utils/json';
 
 interface SessionData {
   version: 1;
@@ -77,7 +78,7 @@ export async function exportSession(): Promise<string> {
 }
 
 export async function importSession(json: string): Promise<{ appState: AppState; datasets: Dataset[] }> {
-  const session: SessionData = JSON.parse(json);
+  const session = secureJSONParse(json) as SessionData;
 
   if (session.version !== 1) {
     throw new Error(`Unsupported session version: ${session.version}`);


### PR DESCRIPTION
### 🎯 What
Replaced the insecure native `JSON.parse` with the `secureJSONParse` utility in the `importSession` function within `src/services/session.ts`.

### ⚠️ Risk
The use of native `JSON.parse` on untrusted input (such as imported session files) is vulnerable to Prototype Pollution. An attacker could craft a malicious JSON payload containing keys like `__proto__` or `constructor` that, when parsed, would modify the global Object prototype. This could lead to application-wide state corruption, logic bypasses, or in some environments, arbitrary code execution.

### 🛡️ Solution
The `secureJSONParse` utility implements a custom reviver function that identifies and filters out dangerous prototype-related keys during the parsing process. By adopting this utility, the application now safely handles untrusted session data without the risk of polluting the global object space. A new test suite `src/services/__tests__/session.test.ts` has been added to specifically verify protection against these attack vectors.

---
*PR created automatically by Jules for task [65938155826249618](https://jules.google.com/task/65938155826249618) started by @michaelkrisper*