### PR TITLE
🧪 Add tests for formula.worker evaluation failure paths

### DIFF
--- a/src/workers/__tests__/formula.worker.test.ts
+++ b/src/workers/__tests__/formula.worker.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+
+// Define a variable to hold the message handler
+let workerMessageHandler: ((event: any) => void) | null = null;
+const postMessageMock = vi.fn();
+
+Object.defineProperty(globalThis, 'self', {
+  value: {
+    postMessage: postMessageMock,
+    set onmessage(fn: (e: any) => void) {
+      workerMessageHandler = fn;
+    },
+    get onmessage() {
+      return workerMessageHandler;
+    }
+  },
+  writable: true
+});
+
+describe('formula.worker', () => {
+  beforeAll(async () => {
+    await import('../formula.worker');
+  });
+
+  beforeEach(() => {
+    postMessageMock.mockClear();
+  });
+
+  it('should be registered as a message listener', () => {
+     expect(workerMessageHandler).toBeTypeOf('function');
+  });
+
+  it('should handle evaluation failure from syntax errors', () => {
+    const event = {
+      data: {
+        datasetId: 'ds-1',
+        name: 'result',
+        formula: 'invalid syntax(',
+        columns: ['A', 'B'],
+        rowCount: 10,
+        columnData: [
+          { data: new Float32Array(10), refPoint: 0 },
+          { data: new Float32Array(10), refPoint: 0 }
+        ]
+      }
+    };
+
+    // @ts-ignore
+    workerMessageHandler!(event);
+
+    expect(postMessageMock).toHaveBeenCalledWith({
+      type: 'error',
+      error: expect.stringContaining('Unknown function or constant')
+    });
+  });
+
+  it('should handle exception during evaluation', () => {
+    const event = {
+      data: {
+        datasetId: 'ds-1',
+        name: 'result',
+        formula: '[A] + [B]',
+        columns: ['A', 'B'],
+        rowCount: 10,
+        columnData: undefined // This will cause TypeError when trying to access columnData in the main loop
+      }
+    };
+
+    // @ts-ignore
+    workerMessageHandler!(event);
+
+    expect(postMessageMock).toHaveBeenCalledWith({
+      type: 'error',
+      error: expect.stringContaining('Cannot read properties of undefined') // Works for typical Node TypeError
+    });
+  });
+});


### PR DESCRIPTION
Added tests to ensure the `formula.worker` correctly intercepts syntax errors and runtime exceptions during evaluation, and posts an appropriate error message back to the main thread. 
- Mocked the `globalThis.self` environment properly for worker execution in Vitest.
- Added tests for `onmessage` assignment, syntax error interception, and runtime `TypeError` (e.g. from undefined objects) interceptions.
- Cleaned up temp testing scripts.

---
*PR created automatically by Jules for task [10296386918482997490](https://jules.google.com/task/10296386918482997490) started by @michaelkrisper*