### PR TITLE
🧹 [Code Health] Remove explicit any casts in Chart Container logic

### DIFF
--- a/src/hooks/useAutoScale.ts
+++ b/src/hooks/useAutoScale.ts
@@ -97,8 +97,7 @@ export function useAutoScale({
       });
       if (xMin !== Infinity) {
         const pad = (xMax - xMin || 1) * 0.05;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (xs as any)[id] = { min: xMin - pad, max: xMax + pad };
+        xs[id] = { min: xMin - pad, max: xMax + pad };
       }
     });
     startAnimation();
@@ -144,8 +143,7 @@ export function useAutoScale({
         if (bounds.min !== Infinity) {
           const pad = (bounds.max - bounds.min || 1) * 0.05;
           const nextX = { min: bounds.min - pad, max: bounds.max + pad };
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (xs as any)[id] = nextX;
+          xs[id] = nextX;
           state.updateXAxis(id, nextX);
         }
       });
@@ -169,8 +167,7 @@ export function useAutoScale({
         if (yMin !== Infinity) {
           const pad = (yMax - yMin || 1) * 0.05;
           const nextY = { min: yMin - pad, max: yMax + pad };
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (ys as any)[axis.id] = nextY;
+          ys[axis.id] = nextY;
           state.updateYAxis(axis.id, nextY);
         }
       });
@@ -184,12 +181,10 @@ export function useAutoScale({
     const view = useGraphStore.getState().views.find(v => v.id === lastAppliedViewId.id);
     if (!view) return;
     const xs = targetXAxes.current;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    view.xAxes.forEach(axis => { (xs as any)[axis.id] = { min: axis.min, max: axis.max }; });
+    view.xAxes.forEach(axis => { xs[axis.id] = { min: axis.min, max: axis.max }; });
     if (view.yAxes.length > 0) {
       const ys = targetYs.current;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      view.yAxes.forEach(axis => { (ys as any)[axis.id] = { min: axis.min, max: axis.max }; });
+      view.yAxes.forEach(axis => { ys[axis.id] = { min: axis.min, max: axis.max }; });
     } else {
       activeYAxes.forEach(a => handleAutoScaleY(a.id));
     }

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -90,7 +90,7 @@ export function usePanZoom({
 
   const performZoom = useCallback((zoomFactor: number, mouseX: number, mouseY: number, target: PanTarget = 'all', shiftKey = false) => {
     if (target === 'all' || (typeof target === 'object' && 'xAxisId' in target)) {
-      const axesToZoom = (target === 'all' || shiftKey) ? activeXAxes : [xAxesById.get((target as { xAxisId: string }).xAxisId)!];
+      const axesToZoom = (target === 'all' || shiftKey) ? activeXAxes : [xAxesById.get(target.xAxisId)!];
       axesToZoom.forEach(axis => {
         if (!axis) return;
         const vp = { xMin: axis.min, xMax: axis.max, yMin: 0, yMax: 100, width, height, padding };
@@ -102,7 +102,7 @@ export function usePanZoom({
       });
     }
     if ((target === 'all' && !shiftKey) || (typeof target === 'object' && 'yAxisId' in target)) {
-      const axesToZoom = target === 'all' ? activeYAxes : [yAxesById.get((target as { yAxisId: string }).yAxisId)!];
+      const axesToZoom = target === 'all' ? activeYAxes : [yAxesById.get(target.yAxisId)!];
       axesToZoom.forEach(axis => {
         if (!axis) return;
         const axisVp = { xMin: 0, xMax: 100, yMin: axis.min, yMax: axis.max, width, height, padding };
@@ -119,7 +119,7 @@ export function usePanZoom({
   const performPan = useCallback((dx: number, dy: number, target: PanTarget = 'all', shiftKey = false) => {
     const state = useGraphStore.getState();
     if (target === 'all' || (typeof target === 'object' && 'xAxisId' in target)) {
-      const axes = (target === 'all' || shiftKey) ? activeXAxes : [xAxesById.get(((target as { xAxisId: string }).xAxisId))!];
+      const axes = (target === 'all' || shiftKey) ? activeXAxes : [xAxesById.get(target.xAxisId)!];
       axes.forEach(axis => {
         if (!axis) return;
         const xr = axis.max - axis.min;


### PR DESCRIPTION
This PR removes explicit type casts (`target as any`, `target as { xAxisId: string }`, `(xs as any)`) in favor of proper TypeScript type guards and inference in the newly extracted `usePanZoom` and `useAutoScale` hooks, fulfilling the original code health task requested for the Chart container logic.

---
*PR created automatically by Jules for task [10188922140169914939](https://jules.google.com/task/10188922140169914939) started by @michaelkrisper*