### PR TITLE
🔒 fix: prevent prototype pollution in session import

### DIFF
--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -1,4 +1,5 @@
 import { type Dataset, type AppState, type DataColumn, persistence } from './persistence';
+import { secureJSONParse } from '../utils/json';
 
 interface SessionData {
   version: 1;
@@ -77,7 +78,7 @@ export async function exportSession(): Promise<string> {
 }
 
 export async function importSession(json: string): Promise<{ appState: AppState; datasets: Dataset[] }> {
-  const session: SessionData = JSON.parse(json);
+  const session = secureJSONParse(json) as SessionData;
 
   if (session.version !== 1) {
     throw new Error(`Unsupported session version: ${session.version}`);


### PR DESCRIPTION
🎯 **What:** Fixed a potential prototype pollution vulnerability in `importSession` within `src/services/session.ts`.

⚠️ **Risk:** If a malicious user imports a specially crafted JSON session file containing `__proto__` or `constructor.prototype` payloads, it could lead to prototype pollution, potentially altering the application's base object behavior or enabling further exploits depending on how those polluted properties are accessed elsewhere in the app.

🛡️ **Solution:** Replaced the vulnerable native `JSON.parse` call with the project's existing `secureJSONParse` utility, which acts as a reviver to safely strip out dangerous prototype-modifying keys during deserialization. Verified type safety and ran the full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [1512108388522412409](https://jules.google.com/task/1512108388522412409) started by @michaelkrisper*