### PR TITLE
🧹 [code health] Remove unused backward shift logic in formula worker

### DIFF
--- a/src/workers/__tests__/formula.worker.test.ts
+++ b/src/workers/__tests__/formula.worker.test.ts
@@ -74,4 +74,52 @@ describe('formula.worker', () => {
       error: expect.stringContaining('Cannot read properties of undefined') // Works for typical Node TypeError
     });
   });
+
+  it('should apply forward shift for count-based rolling average (central alignment)', () => {
+    // Formula: avg3([A]) -> num=3, align='c' (default) -> shift = floor(3/2) = 1
+    // Input [10, 20, 30, 40]
+    // resultData before shift:
+    // i=0: [10]/1 = 10
+    // i=1: [10,20]/2 = 15
+    // i=2: [10,20,30]/3 = 20
+    // i=3: [20,30,40]/3 = 30
+    // resultData: [10, 15, 20, 30]
+    // After shift forward by 1:
+    // out[0] = resultData[1] = 15
+    // out[1] = resultData[2] = 20
+    // out[2] = resultData[3] = 30
+    // out[3] = resultData[3] = 30 (padding with last)
+    // Final: [15, 20, 30, 30]
+
+    const data = new Float32Array([10, 20, 30, 40]);
+    const event = {
+      data: {
+        datasetId: 'ds-1',
+        name: 'result',
+        formula: 'avg3([A])',
+        columns: ['A'],
+        rowCount: 4,
+        columnData: [
+          { data, refPoint: 0 }
+        ]
+      }
+    };
+
+    // @ts-expect-error - Event type mismatch in test
+    workerMessageHandler!(event);
+
+    expect(postMessageMock).toHaveBeenCalled();
+    const lastCall = postMessageMock.mock.calls[postMessageMock.mock.calls.length - 1][0];
+    expect(lastCall.type).toBe('success');
+
+    // The data is returned as a Float32Array via processRawColumn
+    // resultData in worker is Float64Array, processRawColumn might downcast or keep it
+    const outputData = lastCall.newColumn.data;
+    const ref = lastCall.newColumn.refPoint;
+
+    expect(outputData[0] + ref).toBeCloseTo(15);
+    expect(outputData[1] + ref).toBeCloseTo(20);
+    expect(outputData[2] + ref).toBeCloseTo(30);
+    expect(outputData[3] + ref).toBeCloseTo(30);
+  });
 });

--- a/src/workers/formula.worker.ts
+++ b/src/workers/formula.worker.ts
@@ -235,18 +235,11 @@ self.onmessage = (event) => {
         // 'l': shift = 0
       }
 
-      if (shift !== 0 && shift < rowCount) {
+      if (shift > 0 && shift < rowCount) {
         const out = new Float64Array(rowCount);
-        if (shift > 0) {
-          // Shift forward: each row i gets value from row i+shift (center/right lookahead)
-          for (let i = 0; i < rowCount - shift; i++) out[i] = resultData[i + shift];
-          for (let i = rowCount - shift; i < rowCount; i++) out[i] = resultData[rowCount - 1];
-        } else {
-          // Shift backward: leading window (unused currently but kept for symmetry)
-          const s = -shift;
-          for (let i = s; i < rowCount; i++) out[i] = resultData[i - s];
-          for (let i = 0; i < s; i++) out[i] = resultData[0];
-        }
+        // Shift forward: each row i gets value from row i+shift (center/right lookahead)
+        for (let i = 0; i < rowCount - shift; i++) out[i] = resultData[i + shift];
+        for (let i = rowCount - shift; i < rowCount; i++) out[i] = resultData[rowCount - 1];
         resultData.set(out);
       }
     }


### PR DESCRIPTION
🎯 **What:** Removed the unused backward shift logic in `src/workers/formula.worker.ts` and simplified the surrounding conditional check. Added a unit test to verify the remaining forward shift logic used in rolling averages.
💡 **Why:** The backward shift code was explicitly marked as unused and kept only for symmetry. Removing dead code improves maintainability, reduces technical debt, and clarifies the intended execution paths of the formula worker.
✅ **Verification:** Performed manual code inspection and successful code review. Added a new test case in `src/workers/__tests__/formula.worker.test.ts` that specifically validates the forward-shifting path for a rolling average calculation, ensuring the core functionality remains intact.
✨ **Result:** Cleaned up the formula worker by removing unreachable code while maintaining full support for existing alignment-based shifts.

---
*PR created automatically by Jules for task [17070056397705672938](https://jules.google.com/task/17070056397705672938) started by @michaelkrisper*