### PR TITLE
🧪 Add error path test for clearAppState

### DIFF
--- a/src/services/__tests__/persistence.test.ts
+++ b/src/services/__tests__/persistence.test.ts
@@ -311,5 +311,19 @@ describe('persistence', () => {
 
       await expect(persistence.deleteDataset('1')).rejects.toThrow('Delete failed');
     });
+
+    it('should catch error when clearAppState fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const error = new Error('Delete failed');
+      const mockDb = {
+        delete: vi.fn().mockRejectedValueOnce(error),
+      };
+      openDBMock.mockResolvedValueOnce(mockDb);
+
+      await persistence.clearAppState();
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to clear state from IndexedDB:', error);
+      consoleSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing error path test for `clearAppState` in `src/services/persistence.ts`.
📊 **Coverage:** The test now verifies the behavior when `IndexedDB.delete()` throws an error, making sure it logs via `console.error` and doesn't re-throw the error up the stack.
✨ **Result:** Enhanced test coverage and ensures robust error handling for IndexedDB state wiping.

---
*PR created automatically by Jules for task [1041983273742363400](https://jules.google.com/task/1041983273742363400) started by @michaelkrisper*