### PR TITLE
🧪 Add comprehensive test coverage for hexToRgba

### DIFF
--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -144,8 +144,8 @@ export interface WebGLRendererHandle {
   redraw: (xAxes: XAxisConfig[], yAxes: YAxisConfig[]) => void;
 }
 
-const hexToRgba = (hex: string): number[] => {
-  if (!hex || typeof hex !== 'string' || !hex.startsWith('#')) return [0, 0, 0];
+export const hexToRgba = (hex: string): number[] => {
+  if (!hex || typeof hex !== 'string' || !hex.startsWith('#') || hex.length !== 7) return [0, 0, 0];
   try {
     const r = parseInt(hex.slice(1, 3), 16) / 255;
     const g = parseInt(hex.slice(3, 5), 16) / 255;

--- a/src/components/Plot/__tests__/WebGLRenderer.test.tsx
+++ b/src/components/Plot/__tests__/WebGLRenderer.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { hexToRgba } from '../WebGLRenderer';
+
+describe('hexToRgba', () => {
+  it('correctly converts valid full hex strings', () => {
+    // white
+    expect(hexToRgba('#FFFFFF')).toEqual([1, 1, 1]);
+    // black
+    expect(hexToRgba('#000000')).toEqual([0, 0, 0]);
+    // red
+    expect(hexToRgba('#FF0000')).toEqual([1, 0, 0]);
+    // green
+    expect(hexToRgba('#00FF00')).toEqual([0, 1, 0]);
+    // blue
+    expect(hexToRgba('#0000FF')).toEqual([0, 0, 1]);
+    // arbitrary color #804020
+    const [r, g, b] = hexToRgba('#804020');
+    expect(r).toBeCloseTo(128/255);
+    expect(g).toBeCloseTo(64/255);
+    expect(b).toBeCloseTo(32/255);
+  });
+
+  it('handles invalid inputs gracefully', () => {
+    // missing #
+    expect(hexToRgba('FFFFFF')).toEqual([0, 0, 0]);
+    // undefined
+    // @ts-expect-error testing invalid input
+    expect(hexToRgba(undefined)).toEqual([0, 0, 0]);
+    // null
+    // @ts-expect-error testing invalid input
+    expect(hexToRgba(null)).toEqual([0, 0, 0]);
+    // number
+    // @ts-expect-error testing invalid input
+    expect(hexToRgba(123456)).toEqual([0, 0, 0]);
+    // empty string
+    expect(hexToRgba('')).toEqual([0, 0, 0]);
+  });
+
+  it('handles invalid hex formats gracefully', () => {
+    // too short, parses NaN
+    expect(hexToRgba('#FF')).toEqual([0, 0, 0]);
+    // too long
+    expect(hexToRgba('#FFFFFFFF')).toEqual([0, 0, 0]);
+    // nonsense characters
+    expect(hexToRgba('#XXYYZZ')).toEqual([0, 0, 0]);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The pure `hexToRgba` function in `WebGLRenderer.tsx` lacked test coverage and allowed parsing invalid short hex lengths into valid colors.
📊 **Coverage:** Added test suite checking for valid hex parsing, invalid data types, strings without `#`, and incorrectly lengthed strings.
✨ **Result:** Improved test coverage and fixed short hex string bugs.

---
*PR created automatically by Jules for task [15631376671949449039](https://jules.google.com/task/15631376671949449039) started by @michaelkrisper*