### PR TITLE
🔒 fix: Secure Content-Security-Policy by removing 'unsafe-inline'

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#007bff">
     <link rel="apple-touch-icon" href="/pwa-192x192.png">
     <!-- Security Enhancement: Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'; upgrade-insecure-requests;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'; upgrade-insecure-requests;" />
     <meta name="referrer" content="no-referrer" />
     <title>WebGraphy - High Performance Visualization</title>
     <meta name="description" content="Professional high-performance data visualization tool using WebGL." />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,15 @@ import { VitePWA } from 'vite-plugin-pwa'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
+    {
+      name: 'dev-csp-plugin',
+      apply: 'serve',
+      transformIndexHtml(html) {
+        return html
+          .replace(/script-src 'self';/g, "script-src 'self' 'unsafe-inline';")
+          .replace(/style-src 'self' https/g, "style-src 'self' 'unsafe-inline' https");
+      }
+    },
     react(),
     VitePWA({
       registerType: 'autoUpdate',


### PR DESCRIPTION
🎯 **What:** The `index.html` file contained a security vulnerability where its Content-Security-Policy (CSP) allowed `'unsafe-inline'` for both scripts and styles, which is flagged by static analysis tools.

⚠️ **Risk:** Allowing `'unsafe-inline'` leaves the application vulnerable to Cross-Site Scripting (XSS) attacks, as it permits the execution of any inline scripts injected by an attacker.

🛡️ **Solution:** Removed `'unsafe-inline'` from both `script-src` and `style-src` within `index.html` to establish a secure default for production. To ensure the Vite development server and Hot Module Replacement (HMR) continue functioning smoothly, a custom plugin (`dev-csp-plugin`) was added to `vite.config.ts`. This plugin strictly applies only during development (`apply: 'serve'`) and dynamically injects `'unsafe-inline'` back into the served HTML. This satisfies security requirements for production while preserving the developer experience.

---
*PR created automatically by Jules for task [8471180117510893986](https://jules.google.com/task/8471180117510893986) started by @michaelkrisper*