### PR TITLE
Add subtle hover effect to header buttons

### DIFF
--- a/src/components/components.css
+++ b/src/components/components.css
@@ -37,6 +37,11 @@
 	justify-content: center;
 	min-width: var(--touch-target-size);
 	min-height: var(--touch-target-size);
+	transition: background-color 0.2s;
+}
+.modal-close:hover {
+	background-color: var(--bg3);
+	border-radius: 4px;
 }
 .modal-body {
 	flex: 1;
@@ -342,6 +347,11 @@
 	justify-content: center;
 	cursor: pointer;
 	color: var(--text-muted);
+	transition: background-color 0.2s;
+}
+.collapsed-menu-btn:hover {
+	background-color: var(--bg3);
+	border-radius: 4px;
 }
 .collapsed-menu-btn img {
 	width: 18px;
@@ -985,6 +995,11 @@
 	border: none;
 	cursor: pointer;
 	position: relative;
+	transition: background-color 0.2s;
+}
+.sb-hdr-btn:hover {
+	background-color: var(--bg3);
+	border-radius: 4px;
 }
 .sb-hdr-btn--off::after {
 	content: "";


### PR DESCRIPTION
The user requested a subtle mouse hover effect for buttons in the header. I identified the relevant buttons in the sidebar, modals, and collapsed menu, and implemented the hover effect in `src/components/components.css`. The effect uses a theme-aware background color (`--bg3`), rounded corners, and a smooth transition. I verified the change visually using a Playwright script and confirmed that existing tests pass.

Fixes #328

---
*PR created automatically by Jules for task [15517031097046962092](https://jules.google.com/task/15517031097046962092) started by @michaelkrisper*