### PR TITLE
🧪 test: add unit tests for rgbToHex utility

### DIFF
--- a/src/utils/__tests__/colors.test.ts
+++ b/src/utils/__tests__/colors.test.ts
@@ -1,7 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { hexToRgba } from "../colors";
+import { hexToRgba, rgbToHex } from "../colors";
 
 describe("colors", () => {
+	describe("rgbToHex", () => {
+		it("should correctly convert standard rgb colors", () => {
+			expect(rgbToHex(0, 0, 0)).toBe("#000000");
+			expect(rgbToHex(255, 255, 255)).toBe("#ffffff");
+			expect(rgbToHex(255, 0, 0)).toBe("#ff0000");
+			expect(rgbToHex(0, 255, 0)).toBe("#00ff00");
+			expect(rgbToHex(0, 0, 255)).toBe("#0000ff");
+		});
+
+		it("should pad single-character hex values with a leading zero", () => {
+			expect(rgbToHex(15, 10, 5)).toBe("#0f0a05");
+			expect(rgbToHex(0, 1, 2)).toBe("#000102");
+		});
+
+		it("should round floating-point numbers", () => {
+			expect(rgbToHex(254.5, 128.2, 63.8)).toBe("#ff8040");
+		});
+
+		it("should clamp out-of-bounds numbers to 0-255", () => {
+			expect(rgbToHex(-10, -100, -1)).toBe("#000000");
+			expect(rgbToHex(256, 1000, 300)).toBe("#ffffff");
+		});
+	});
+
 	describe("hexToRgba", () => {
 		it("should correctly convert valid hex strings", () => {
 			expect(hexToRgba("#000000")).toEqual([0, 0, 0]);


### PR DESCRIPTION
🎯 **What:** Adds missing unit tests for the `rgbToHex` utility function located in `src/utils/colors.ts`.
📊 **Coverage:** The new tests cover:
- Standard RGB colors (e.g. black, white, red, green, blue).
- Padding logic to ensure single-character hex values correctly receive a leading zero.
- Rounding behavior when floating-point numbers are provided as inputs.
- Clamping behavior for inputs outside the 0-255 range (negative numbers clamp to 0, large numbers clamp to 255).
✨ **Result:** Improved overall test coverage for the colors utility module. Confirmed functionality of edge-case handling for RGB conversion.

---
*PR created automatically by Jules for task [7293791904439855321](https://jules.google.com/task/7293791904439855321) started by @michaelkrisper*