### PR TITLE
🧪 [testing] add unit tests for rgbToLch in colors.ts

### DIFF
--- a/src/utils/__tests__/colors.test.ts
+++ b/src/utils/__tests__/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hexToRgba } from "../colors";
+import { hexToRgba, rgbToLch } from "../colors";
 
 describe("colors", () => {
 	describe("hexToRgba", () => {
@@ -41,6 +41,42 @@ describe("colors", () => {
 
 			// @ts-expect-error testing runtime invalid type
 			expect(hexToRgba({})).toEqual([0, 0, 0]);
+		});
+	});
+
+	describe("rgbToLch", () => {
+		it("should correctly convert black", () => {
+			const { L, C, h } = rgbToLch(0, 0, 0);
+			expect(L).toBeCloseTo(0, 1);
+			expect(C).toBeCloseTo(0, 1);
+			expect(h).toBeCloseTo(0, 1);
+		});
+
+		it("should correctly convert white", () => {
+			const { L, C, h } = rgbToLch(255, 255, 255);
+			expect(L).toBeCloseTo(100, 1);
+			expect(C).toBeCloseTo(0, 1);
+		});
+
+		it("should correctly convert red", () => {
+			const { L, C, h } = rgbToLch(255, 0, 0);
+			expect(L).toBeCloseTo(53.2, 1);
+			expect(C).toBeCloseTo(104.6, 1);
+			expect(h).toBeCloseTo(40.0, 1);
+		});
+
+		it("should correctly convert green", () => {
+			const { L, C, h } = rgbToLch(0, 255, 0);
+			expect(L).toBeCloseTo(87.7, 1);
+			expect(C).toBeCloseTo(119.8, 1);
+			expect(h).toBeCloseTo(136.0, 1);
+		});
+
+		it("should correctly convert blue", () => {
+			const { L, C, h } = rgbToLch(0, 0, 255);
+			expect(L).toBeCloseTo(32.3, 1);
+			expect(C).toBeCloseTo(133.8, 1);
+			expect(h).toBeCloseTo(306.3, 1);
 		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** The testing gap in `src/utils/colors.ts` for the `rgbToLch` function has been addressed.
📊 **Coverage:** Test coverage has been expanded to cover the conversions of key baseline colors (black, white, red, green, and blue) into CIELCH formatting.
✨ **Result:** Enhanced the overall reliability and safety net around the math operations involved in standard-to-LCH color space conversions, allowing confident future refactoring. All existing and new tests pass cleanly.

---
*PR created automatically by Jules for task [580211075215040400](https://jules.google.com/task/580211075215040400) started by @michaelkrisper*