### PR TITLE
🧪 test: add coverage for mismatched parentheses in formula util

### DIFF
--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -174,6 +174,21 @@ describe("compileFormula", () => {
 		expect(res5.error).toContain("Mismatched parentheses");
 		expect(res5.evaluate([])).toBeNaN();
 
+		// Mismatched parentheses - extra closing parenthesis
+		const resExtraClose = compileFormula("1+1)", columns);
+		expect(resExtraClose.error).toContain("Mismatched parentheses");
+		expect(resExtraClose.evaluate([])).toBeNaN();
+
+		// Mismatched parentheses - missing closing on simple expression
+		const resMissingClose = compileFormula("(1+1", columns);
+		expect(resMissingClose.error).toContain("Mismatched parentheses");
+		expect(resMissingClose.evaluate([])).toBeNaN();
+
+		// Mismatched parentheses - extra closing parenthesis on function
+		const resExtraCloseFunc = compileFormula("min(1,2))", columns);
+		expect(resExtraCloseFunc.error).toContain("Mismatched parentheses");
+		expect(resExtraCloseFunc.evaluate([])).toBeNaN();
+
 		// Unexpected character during lexing
 		const res6 = compileFormula("10 $ 20", columns);
 		expect(res6.error).toContain("Unexpected character: $");


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap where the "Mismatched parentheses" error for formula parsing (`src/utils/formula.ts:525`) lacked coverage when processing closing brackets with an empty operator stack.

📊 **Coverage:**
* Added tests for missing opening brackets: `1+1)`
* Added tests for missing closing brackets: `(1+1`
* Added tests for extra closing brackets on function calls: `min(1,2))`

✨ **Result:** Test coverage for `src/utils/formula.ts` has been improved, explicitly ensuring robustness and regression protection against common parenthesis parsing errors in the Shunting-yard algorithm implementation. All tests are passing correctly.

---
*PR created automatically by Jules for task [16884095888738938612](https://jules.google.com/task/16884095888738938612) started by @michaelkrisper*