### PR TITLE
🧪 Add tests for formatAxisLabel in axisCalculations.ts

### DIFF
--- a/src/utils/__tests__/axisCalculations.test.ts
+++ b/src/utils/__tests__/axisCalculations.test.ts
@@ -6,6 +6,7 @@ import {
 	calcNumericTicks,
 	calcYAxisTicks,
 	syncAxesWithTargets,
+	formatAxisLabel,
 } from "../axisCalculations";
 
 describe("calcNumericStep", () => {
@@ -16,6 +17,30 @@ describe("calcNumericStep", () => {
 	});
 	it("returns 1 for zero range", () => {
 		expect(calcNumericStep(0, 5)).toBe(1);
+	});
+});
+
+describe("formatAxisLabel", () => {
+	it("returns '0' for values close to zero", () => {
+		expect(formatAxisLabel(0, 2)).toBe("0");
+		expect(formatAxisLabel(1e-13, 2)).toBe("0");
+		expect(formatAxisLabel(-1e-13, 2)).toBe("0");
+	});
+
+	it("formats normal numbers according to precision", () => {
+		expect(formatAxisLabel(1.2345, 2)).toBe("1.23");
+		expect(formatAxisLabel(100, 0)).toBe("100");
+		expect(formatAxisLabel(100.5, 1)).toBe("100.5");
+	});
+
+	it("uses exponential notation for strings longer than 12 characters", () => {
+		expect(formatAxisLabel(1234567890123, 0)).toBe("1e+12");
+		expect(formatAxisLabel(0.000000000001, 12)).toBe("1.0000e-12");
+	});
+
+	it("caps exponential precision at 4 decimal places or given precision", () => {
+		expect(formatAxisLabel(1234567890123, 2)).toBe("1.23e+12");
+		expect(formatAxisLabel(1234567890123, 5)).toBe("1.2346e+12");
 	});
 });
 


### PR DESCRIPTION
🎯 **What:** Added missing tests for the `formatAxisLabel` function in `src/utils/axisCalculations.ts`.
📊 **Coverage:** Covered happy paths (normal formatting with precision), edge cases (values very close to 0 returning "0"), and long strings (>12 chars) correctly falling back to exponential notation and precision caps.
✨ **Result:** Increased test coverage and ensured reliability of axis label formatting, making future refactoring safer.

---
*PR created automatically by Jules for task [8560497394393099374](https://jules.google.com/task/8560497394393099374) started by @michaelkrisper*