### PR TITLE
🧪 testing improvement description

### DIFF
--- a/src/utils/__tests__/data-parser.test.ts
+++ b/src/utils/__tests__/data-parser.test.ts
@@ -21,9 +21,10 @@ function createMockFile(content: string, name: string, type: string) {
 
 describe("data-parser", () => {
 	it("should throw an error for unsupported file types", async () => {
+		const file = createMockFile("content", "test.xml", "application/xml");
 		await expect(
-			parseData(null as unknown as File, "unsupported"),
-		).rejects.toThrow("Unsupported file type");
+			parseData(file, "unsupported"),
+		).rejects.toThrow("Unsupported file type: unsupported");
 	});
 
 	it("should handle native Error instances in catch block", async () => {


### PR DESCRIPTION
🎯 **What:** The testing gap for the unsupported file type error condition in `parseData` (`src/utils/data-parser.ts`) has been addressed. The previous test was passing a `null` value cast as a `File` and only checking a partial substring of the error.
📊 **Coverage:** The scenario where a file of an unsupported type (e.g. `xml`) is passed to `parseData` is now explicitly tested with a valid `File` mock object.
✨ **Result:** Test coverage and reliability for `parseData`'s error handling are improved. The assertion now exactly matches the generated error string, ensuring the branch logic functions as intended.

---
*PR created automatically by Jules for task [18247455824419449578](https://jules.google.com/task/18247455824419449578) started by @michaelkrisper*