### PR TITLE
🧪 test(colors): add missing unit tests for lchToRgb

### DIFF
--- a/src/utils/__tests__/colors.test.ts
+++ b/src/utils/__tests__/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hexToRgba } from "../colors";
+import { hexToRgba, rgbToLch, lchToRgb } from "../colors";
 
 describe("colors", () => {
 	describe("hexToRgba", () => {
@@ -43,4 +43,76 @@ describe("colors", () => {
 			expect(hexToRgba({})).toEqual([0, 0, 0]);
 		});
 	});
+
+	describe("lchToRgb", () => {
+		it("should correctly convert known LCH values to RGB", () => {
+			// Black
+			expect(lchToRgb(0, 0, 0)).toEqual({ r: 0, g: 0, b: 0 });
+
+			// White
+			expect(lchToRgb(100, 0.01, 296.81)).toEqual({ r: 255, g: 255, b: 255 });
+
+			// Red
+			const red = lchToRgb(53.23, 104.58, 40.00);
+			expect(red.r).toBeGreaterThanOrEqual(254);
+			expect(red.g).toBeLessThanOrEqual(1);
+			expect(red.b).toBeLessThanOrEqual(1);
+
+			// Green
+			const green = lchToRgb(87.74, 119.78, 136.02);
+			expect(green.r).toBeLessThanOrEqual(1);
+			expect(green.g).toBeGreaterThanOrEqual(254);
+			expect(green.b).toBeLessThanOrEqual(1);
+
+			// Blue
+			const blue = lchToRgb(32.30, 133.82, 306.29);
+			expect(blue.r).toBeLessThanOrEqual(1);
+			expect(blue.g).toBeLessThanOrEqual(1);
+			expect(blue.b).toBeGreaterThanOrEqual(254);
+		});
+
+		it("should be the inverse of rgbToLch for standard colors", () => {
+			const colors = [
+				{ r: 0, g: 0, b: 0 },
+				{ r: 255, g: 255, b: 255 },
+				{ r: 255, g: 0, b: 0 },
+				{ r: 0, g: 255, b: 0 },
+				{ r: 0, g: 0, b: 255 },
+				{ r: 128, g: 128, b: 128 },
+				{ r: 255, g: 255, b: 0 },
+				{ r: 0, g: 255, b: 255 },
+				{ r: 255, g: 0, b: 255 },
+			];
+
+			for (const c of colors) {
+				const lch = rgbToLch(c.r, c.g, c.b);
+				const rgb = lchToRgb(lch.L, lch.C, lch.h);
+
+				// Allow small precision differences
+				expect(Math.abs(rgb.r - c.r)).toBeLessThanOrEqual(1);
+				expect(Math.abs(rgb.g - c.g)).toBeLessThanOrEqual(1);
+				expect(Math.abs(rgb.b - c.b)).toBeLessThanOrEqual(1);
+			}
+		});
+
+		it("should clamp output to valid RGB ranges (0-255)", () => {
+			// Super high lightness/chroma
+			const overblown = lchToRgb(150, 200, 180);
+			expect(overblown.r).toBeLessThanOrEqual(255);
+			expect(overblown.g).toBeLessThanOrEqual(255);
+			expect(overblown.b).toBeLessThanOrEqual(255);
+			expect(overblown.r).toBeGreaterThanOrEqual(0);
+			expect(overblown.g).toBeGreaterThanOrEqual(0);
+			expect(overblown.b).toBeGreaterThanOrEqual(0);
+
+			// Negative lightness
+			const negativeLightness = lchToRgb(-50, 50, 90);
+			expect(negativeLightness.r).toBeGreaterThanOrEqual(0);
+			expect(negativeLightness.g).toBeGreaterThanOrEqual(0);
+			expect(negativeLightness.b).toBeGreaterThanOrEqual(0);
+			expect(negativeLightness.r).toBeLessThanOrEqual(255);
+			expect(negativeLightness.g).toBeLessThanOrEqual(255);
+			expect(negativeLightness.b).toBeLessThanOrEqual(255);
+		});
+		});
 });


### PR DESCRIPTION
### 🎯 **What**
The `lchToRgb` function in `src/utils/colors.ts` is a mathematical pure function handling the inverse of `rgbToLch`, but it lacked dedicated unit tests. This PR addresses that testing gap.

### 📊 **Coverage**
- **Known Values:** Tests standard color conversions (Black, White, Red, Green, Blue).
- **Inverse Property:** Iterates over a palette of RGB values, converts them to LCH, back to RGB, and asserts they match the original input (accounting for minor float precision differences).
- **Boundary Clamping:** Ensures that extreme inputs (e.g. out-of-gamut LCH or negative lightness) correctly clamp the RGB output values strictly to the 0-255 range.

### ✨ **Result**
Test coverage for the application's color utility module has been significantly increased, ensuring stability for LCH conversions during rendering and data visualization updates. All 6 tests in `colors.test.ts` pass, alongside the broader test suite (315 tests total).

---
*PR created automatically by Jules for task [1558125927826171077](https://jules.google.com/task/1558125927826171077) started by @michaelkrisper*