### PR TITLE
🧪 Add missing error test for unexpected comma in formula

### DIFF
--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -256,6 +256,10 @@ describe("compileFormula", () => {
 		const resComma = compileFormula("1 , 2", columns);
 		expect(resComma.error).toBe("Unexpected comma");
 
+		// Testing "Unexpected comma" error when parsing comma within parentheses but outside of a function
+		const resCommaParen = compileFormula("(1, 2)", columns);
+		expect(resCommaParen.error).toBe("Unexpected comma");
+
 		// Extra edge cases requested by reviewer
 		const resMismatched1 = compileFormula("((1+2)", columns);
 		expect(resMismatched1.error).toContain("Mismatched parentheses");


### PR DESCRIPTION
🎯 **What:** 
The testing gap addressed is the missing branch coverage for the "Unexpected comma" error thrown at `src/utils/formula.ts:499`. While commas between expressions (like `1, 2`) or other invalid placements were partially tested, a comma properly lexed but invalidly structured inside parentheses (like `(1, 2)`) outside of a function wasn't explicitly asserting the correct error state. 

📊 **Coverage:** 
The scenarios now tested include passing a correctly bracketed sub-expression with a comma where no function is applied, explicitly `(1, 2)`. This hits the condition `argCountStack.length === 0` after an `LPAREN` is pushed, causing the explicit `throw new Error("Unexpected comma")` error path.

✨ **Result:** 
Test coverage is improved, specifically targeting the internal comma evaluation paths. The test correctly validates that formulas containing stray commas that are not handled by valid function boundaries are caught and handled gracefully as expected.

---
*PR created automatically by Jules for task [7978250406095401488](https://jules.google.com/task/7978250406095401488) started by @michaelkrisper*