### PR TITLE
🧪 Add missing test for mismatched left parentheses in formula compilation

### DIFF
--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -263,6 +263,9 @@ describe("compileFormula", () => {
 		const resMismatched3 = compileFormula(")", columns);
 		expect(resMismatched3.error).toContain("Mismatched parentheses");
 
+		const resMismatchedLeft = compileFormula("(1+1", columns);
+		expect(resMismatchedLeft.error).toContain("Mismatched parentheses");
+
 		// Test for 'avg1' without unit
 		const resAvg1 = compileFormula("avg1([Temp])", columns);
 		const ctxAvg1 = resAvg1.createContext?.();


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `src/utils/__tests__/formula.test.ts` to trigger the exact error condition in `src/utils/formula.ts:548` when a formula contains an unmatched left parenthesis.
📊 **Coverage:** The new test passes `"(1+1"` to `compileFormula()`, covering the branch inside the final operator stack cleanup loop that throws a "Mismatched parentheses" Error when an `LPAREN` is left unresolved.
✨ **Result:** Improved parser test coverage and explicitly verified expected error handling for malformed input strings.

---
*PR created automatically by Jules for task [3682867240595810574](https://jules.google.com/task/3682867240595810574) started by @michaelkrisper*