### PR TITLE
🧹 test(export): reduce deep nesting by extracting mockCanvas definition

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -518,18 +518,18 @@ describe("downloadFile", () => {
 
 	beforeEach(() => {
 		const mockAnchor = { href: "", download: "", click: mockClick };
+		const mockCanvas = {
+			getContext: vi.fn(() => ({
+				scale: vi.fn(),
+				fillRect: vi.fn(),
+				drawImage: vi.fn(),
+			})),
+			toDataURL: vi.fn(() => "data:image/png;base64,mock"),
+		};
 		const documentMock = {
 			createElement: vi.fn((tag: string) => {
 				if (tag === "a") return mockAnchor;
-				if (tag === "canvas")
-					return {
-						getContext: vi.fn(() => ({
-							scale: vi.fn(),
-							fillRect: vi.fn(),
-							drawImage: vi.fn(),
-						})),
-						toDataURL: vi.fn(() => "data:image/png;base64,mock"),
-					};
+				if (tag === "canvas") return mockCanvas;
 				return {};
 			}),
 		};


### PR DESCRIPTION
🎯 **What:** Extracted the inline mock definition for the `canvas` element inside `documentMock.createElement` into a standalone `mockCanvas` variable in `src/services/__tests__/export.test.ts`.

💡 **Why:** The previous code had deep nesting inside the `document.createElement` mock, making it harder to read and maintain. By extracting the object into a variable defined inside `beforeEach`, the setup logic is flattened, more readable, and aligns with other established mock patterns in the file (like `mockAnchor`).

✅ **Verification:** 
- Evaluated test isolation constraints: since `mockCanvas` is declared inside `beforeEach`, a fresh object is created for every test, preserving state isolation.
- Ran `pnpm test src/services/__tests__/export.test.ts` which successfully passed.
- Requested Code Review successfully with no blocking issues or nitpicks.

✨ **Result:** Improved test code maintainability and reduced deep nesting without modifying any test behavior.

---
*PR created automatically by Jules for task [16707815884744449119](https://jules.google.com/task/16707815884744449119) started by @michaelkrisper*