### PR TITLE
perf+refactor: workers for parser/formula, renderer split, util cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Webgraphy is a precision-focused, high-performance data visualization applicatio
 ## Key Features
 
 - **Ultra High Performance:** Render millions of data points smoothly using raw WebGL with custom high-precision shaders.
-- **Advanced Data Handling:** Multi-threaded data parsing (CSV/JSON) using Web Workers to ensure a responsive UI even with large datasets.
+- **Advanced Data Handling:** CSV/JSON parsing and formula evaluation run in dedicated Web Workers, keeping the UI responsive even with very large datasets.
 - **Precision Rendering:** Raw data rendering using custom WebGL shaders for maximum visual integrity and accuracy, utilizing relative offsets (`refPoint`) to avoid floating-point artifacts.
 - **Rich Interaction:**
   - **Interactive Axes:** Pan and zoom directly on individual X or Y axes.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { useGraphStore } from "./store/useGraphStore";
 import "./index.css";
 
 export default function App() {
-	const { loadPersistedState } = useGraphStore();
+	const loadPersistedState = useGraphStore((s) => s.loadPersistedState);
 
 	useEffect(() => {
 		loadPersistedState();

--- a/src/components/Layout/CalculatedColumnModal.tsx
+++ b/src/components/Layout/CalculatedColumnModal.tsx
@@ -21,7 +21,8 @@ export const CalculatedColumnModal: React.FC<CalculatedColumnModalProps> = ({
 	initialName,
 	initialFormula,
 }) => {
-	const { addCalculatedColumn, removeCalculatedColumn } = useGraphStore();
+	const addCalculatedColumn = useGraphStore((s) => s.addCalculatedColumn);
+	const removeCalculatedColumn = useGraphStore((s) => s.removeCalculatedColumn);
 	const isEditing = !!initialName;
 	const [manualName, setManualName] = useState(initialName ?? "");
 	const [nameUserEdited, setNameUserEdited] = useState(isEditing);

--- a/src/components/Plot/Crosshair.tsx
+++ b/src/components/Plot/Crosshair.tsx
@@ -6,6 +6,7 @@ import type {
 	XAxisConfig,
 	YAxisConfig,
 } from "../../services/persistence";
+import { findClosest } from "../../utils/binarySearch";
 import { getColumnIndex } from "../../utils/columns";
 import { screenToWorld, worldToScreen } from "../../utils/coords";
 import { escapeHTML } from "../../utils/dom";
@@ -173,21 +174,7 @@ const Crosshair = React.memo(
 							padding,
 						};
 						const sMouseWorld = screenToWorld(pos.x, pos.y, sVp);
-						let lo = 0,
-							hi = xData.length - 1;
-						while (lo < hi) {
-							const mid = (lo + hi) >>> 1;
-							if (xData[mid] + refX < sMouseWorld.x) lo = mid + 1;
-							else hi = mid;
-						}
-						let bestI = lo;
-						if (
-							lo > 0 &&
-							Math.abs(xData[lo - 1] + refX - sMouseWorld.x) <
-								Math.abs(xData[lo] + refX - sMouseWorld.x)
-						)
-							bestI = lo - 1;
-						cachedIdx = bestI;
+						cachedIdx = findClosest(xData, sMouseWorld.x, refX);
 						closestIdxByDataset.set(ds.id, cachedIdx);
 					}
 					const sVp = {

--- a/src/components/Plot/GLStateCache.ts
+++ b/src/components/Plot/GLStateCache.ts
@@ -1,0 +1,164 @@
+/**
+ * Cached WebGL state for the renderer's draw loop.
+ *
+ * Each setter is a no-op when the new value matches the cached value, so the
+ * driver-side `gl.uniform*` / `gl.lineWidth` / `gl.vertexAttrib*` calls only
+ * happen on actual changes. The cache persists across frames and is reset by
+ * `reset()` whenever the program is (re-)linked.
+ */
+
+export interface WebGLLocations {
+	xLoc: number;
+	yLoc: number;
+	otherLoc: number;
+	tLoc: number;
+	distStartLoc: number;
+	xScaleOffLoc: WebGLUniformLocation | null;
+	yScaleOffLoc: WebGLUniformLocation | null;
+	padLoc: WebGLUniformLocation | null;
+	resLoc: WebGLUniformLocation | null;
+	colorLoc: WebGLUniformLocation | null;
+	styleLoc: WebGLUniformLocation | null;
+	lineStyleLoc: WebGLUniformLocation | null;
+	dprLoc: WebGLUniformLocation | null;
+	sizeLoc: WebGLUniformLocation | null;
+	screenSpaceLoc: WebGLUniformLocation | null;
+}
+
+export class GLStateCache {
+	readonly gl: WebGLRenderingContext;
+	readonly locs: WebGLLocations;
+
+	private colorSet = false;
+	private colorR = 0;
+	private colorG = 0;
+	private colorB = 0;
+	private colorA = 0;
+	private style = -2;
+	private lineStyle = -2;
+	private screenSpace = -1;
+	private pointSize = -1;
+	private lineWidth = -1;
+	private xScaleSet = false;
+	private xScaleA = 0;
+	private xScaleB = 0;
+	private yScaleSet = false;
+	private yScaleA = 0;
+	private yScaleB = 0;
+	private attribEnabled = new Map<number, boolean>();
+	private attribConst = new Map<number, string>();
+
+	constructor(gl: WebGLRenderingContext, locs: WebGLLocations) {
+		this.gl = gl;
+		this.locs = locs;
+	}
+
+	reset(): void {
+		this.colorSet = false;
+		this.style = -2;
+		this.lineStyle = -2;
+		this.screenSpace = -1;
+		this.pointSize = -1;
+		this.lineWidth = -1;
+		this.xScaleSet = false;
+		this.yScaleSet = false;
+		this.attribEnabled.clear();
+		this.attribConst.clear();
+	}
+
+	setColor(r: number, g: number, b: number, a: number): void {
+		if (
+			this.colorSet &&
+			this.colorR === r &&
+			this.colorG === g &&
+			this.colorB === b &&
+			this.colorA === a
+		) {
+			return;
+		}
+		this.gl.uniform4f(this.locs.colorLoc, r, g, b, a);
+		this.colorR = r;
+		this.colorG = g;
+		this.colorB = b;
+		this.colorA = a;
+		this.colorSet = true;
+	}
+
+	setStyle(v: number): void {
+		if (this.style === v) return;
+		this.gl.uniform1i(this.locs.styleLoc, v);
+		this.style = v;
+	}
+
+	setLineStyle(v: number): void {
+		if (this.lineStyle === v) return;
+		this.gl.uniform1i(this.locs.lineStyleLoc, v);
+		this.lineStyle = v;
+	}
+
+	setScreenSpace(v: number): void {
+		if (this.screenSpace === v) return;
+		this.gl.uniform1i(this.locs.screenSpaceLoc, v);
+		this.screenSpace = v;
+	}
+
+	setPointSize(v: number): void {
+		if (this.pointSize === v) return;
+		this.gl.uniform1f(this.locs.sizeLoc, v);
+		this.pointSize = v;
+	}
+
+	setLineWidth(v: number): void {
+		if (this.lineWidth === v) return;
+		this.gl.lineWidth(v);
+		this.lineWidth = v;
+	}
+
+	setXScaleOff(a: number, b: number): void {
+		if (this.xScaleSet && this.xScaleA === a && this.xScaleB === b) return;
+		this.gl.uniform2f(this.locs.xScaleOffLoc, a, b);
+		this.xScaleA = a;
+		this.xScaleB = b;
+		this.xScaleSet = true;
+	}
+
+	setYScaleOff(a: number, b: number): void {
+		if (this.yScaleSet && this.yScaleA === a && this.yScaleB === b) return;
+		this.gl.uniform2f(this.locs.yScaleOffLoc, a, b);
+		this.yScaleA = a;
+		this.yScaleB = b;
+		this.yScaleSet = true;
+	}
+
+	enableAttrib(loc: number): void {
+		if (this.attribEnabled.get(loc) !== true) {
+			this.gl.enableVertexAttribArray(loc);
+			this.attribEnabled.set(loc, true);
+			this.attribConst.delete(loc);
+		}
+	}
+
+	disableAttribConst1(loc: number, v: number): void {
+		const key = `1:${v}`;
+		if (this.attribEnabled.get(loc) !== false) {
+			this.gl.disableVertexAttribArray(loc);
+			this.attribEnabled.set(loc, false);
+		}
+		if (this.attribConst.get(loc) !== key) {
+			this.gl.vertexAttrib1f(loc, v);
+			this.attribConst.set(loc, key);
+		}
+	}
+
+	disableAttribConst2(loc: number, x: number, y: number): void {
+		const key = `2:${x},${y}`;
+		if (this.attribEnabled.get(loc) !== false) {
+			this.gl.disableVertexAttribArray(loc);
+			this.attribEnabled.set(loc, false);
+		}
+		if (this.attribConst.get(loc) !== key) {
+			this.gl.vertexAttrib2f(loc, x, y);
+			this.attribConst.set(loc, key);
+		}
+	}
+}

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -12,6 +12,7 @@ import type {
 	YAxisConfig,
 } from "../../services/persistence";
 import { useGraphStore } from "../../store/useGraphStore";
+import { findFirstGE, findLastLE } from "../../utils/binarySearch";
 import { hexToRgba } from "../../utils/colors";
 import { getColumnIndex } from "../../utils/columns";
 import { m4ByXFloat32 } from "../../utils/decimation";
@@ -1012,27 +1013,11 @@ export const WebGLRenderer = React.memo(
 						}
 
 						const xDataLen = xData.length;
-						let rawStart = 0,
-							rawEnd = xDataLen - 1;
+						let rawStart = 0;
+						let rawEnd = xDataLen - 1;
 						if (isMonotonic) {
-							let lo = 0,
-								hi = xDataLen - 1;
-							while (lo <= hi) {
-								const m = (lo + hi) >>> 1;
-								if (xData[m] + xRef <= xAxis.min) {
-									rawStart = m;
-									lo = m + 1;
-								} else hi = m - 1;
-							}
-							lo = 0;
-							hi = xDataLen - 1;
-							while (lo <= hi) {
-								const m = (lo + hi) >>> 1;
-								if (xData[m] + xRef >= xAxis.max) {
-									rawEnd = m;
-									hi = m - 1;
-								} else lo = m + 1;
-							}
+							rawStart = findLastLE(xData, xAxis.min, xRef, 0);
+							rawEnd = findFirstGE(xData, xAxis.max, xRef, xDataLen - 1);
 						}
 
 						const sliceStart = isMonotonic
@@ -1399,30 +1384,12 @@ export const WebGLRenderer = React.memo(
 									pointDecimCacheRef.current.set(yData, entry);
 								}
 								if (entry.xBuf && entry.yBuf && entry.count >= 1) {
-									// Binary-search visible range in decimated X (still monotonic
-									// because m4 emits indices in order within each bucket).
+									// m4 emits indices in order within each bucket, so the
+									// decimated X array remains monotonic.
 									const xArr = entry.xArr;
 									const cnt = entry.count;
-									let lo = 0,
-										hi = cnt - 1,
-										lowIdx = 0;
-									while (lo <= hi) {
-										const m = (lo + hi) >>> 1;
-										if (xArr[m] + xRef <= xAxis.min) {
-											lowIdx = m;
-											lo = m + 1;
-										} else hi = m - 1;
-									}
-									lo = 0;
-									hi = cnt - 1;
-									let highIdx = cnt - 1;
-									while (lo <= hi) {
-										const m = (lo + hi) >>> 1;
-										if (xArr[m] + xRef >= xAxis.max) {
-											highIdx = m;
-											hi = m - 1;
-										} else lo = m + 1;
-									}
+									const lowIdx = findLastLE(xArr, xAxis.min, xRef, 0);
+									const highIdx = findFirstGE(xArr, xAxis.max, xRef, cnt - 1);
 									const dStart = Math.max(0, lowIdx > 0 ? lowIdx - 1 : 0);
 									const dEnd = Math.min(
 										cnt - 1,

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -15,7 +15,14 @@ import { useGraphStore } from "../../store/useGraphStore";
 import { findFirstGE, findLastLE } from "../../utils/binarySearch";
 import { hexToRgba } from "../../utils/colors";
 import { getColumnIndex } from "../../utils/columns";
-import { m4ByXFloat32 } from "../../utils/decimation";
+import { GLStateCache, type WebGLLocations } from "./GLStateCache";
+import {
+	type DecimEntry,
+	drawOverlay,
+	drawSeriesLines,
+	drawSeriesPoints,
+	type SeriesDrawBundle,
+} from "./drawSeries";
 
 const VERTEX_SHADER_SOURCE = `
       // === VERTEX SHADER ===
@@ -140,24 +147,6 @@ const FRAGMENT_SHADER_SOURCE = `
       }
 `;
 
-interface WebGLLocations {
-	xLoc: number;
-	yLoc: number;
-	otherLoc: number;
-	tLoc: number;
-	distStartLoc: number;
-	xScaleOffLoc: WebGLUniformLocation | null;
-	yScaleOffLoc: WebGLUniformLocation | null;
-	padLoc: WebGLUniformLocation | null;
-	resLoc: WebGLUniformLocation | null;
-	colorLoc: WebGLUniformLocation | null;
-	styleLoc: WebGLUniformLocation | null;
-	lineStyleLoc: WebGLUniformLocation | null;
-	dprLoc: WebGLUniformLocation | null;
-	sizeLoc: WebGLUniformLocation | null;
-	screenSpaceLoc: WebGLUniformLocation | null; // kept for shader compatibility
-}
-
 interface Props {
 	datasets: Dataset[];
 	series: SeriesConfig[];
@@ -223,6 +212,7 @@ export const WebGLRenderer = React.memo(
 		const glRef = useRef<WebGLRenderingContext | null>(null);
 		const programRef = useRef<WebGLProgram | null>(null);
 		const locationsRef = useRef<WebGLLocations | null>(null);
+		const stateCacheRef = useRef<GLStateCache | null>(null);
 		const buffersRef = useRef<Map<string, WebGLBuffer>>(new Map());
 		const segParamsRef = useRef<Map<string, string>>(new Map());
 		const segmentCacheRef = useRef<
@@ -234,16 +224,6 @@ export const WebGLRenderer = React.memo(
 		const columnBufferRef = useRef<WeakMap<Float32Array, WebGLBuffer>>(
 			new WeakMap(),
 		);
-		// M4 decimation cache, keyed by yData identity (xData+yData pair).
-		// Holds decimated arrays + GPU buffers + signature for cache validation.
-		interface DecimEntry {
-			sig: string; // bucket count + xMin + xMax quantum
-			xArr: Float32Array; // decimated x (zero-ref, matches xData refPoint)
-			yArr: Float32Array; // decimated y (zero-ref, matches yData refPoint)
-			count: number; // valid samples
-			xBuf: WebGLBuffer | null;
-			yBuf: WebGLBuffer | null;
-		}
 		const decimCacheRef = useRef<WeakMap<Float32Array, DecimEntry>>(
 			new WeakMap(),
 		);
@@ -251,18 +231,7 @@ export const WebGLRenderer = React.memo(
 			x: new Float32Array(0),
 			y: new Float32Array(0),
 		});
-		// Point M4 decimation cache: per yData → entry with sig.
-		// Buckets emit (first, min, max, last) — preserves Y extrema, so
-		// visually distinct points are kept regardless of dense X clustering.
-		interface PointDecimEntry {
-			sig: string;
-			xArr: Float32Array;
-			yArr: Float32Array;
-			count: number;
-			xBuf: WebGLBuffer | null;
-			yBuf: WebGLBuffer | null;
-		}
-		const pointDecimCacheRef = useRef<WeakMap<Float32Array, PointDecimEntry>>(
+		const pointDecimCacheRef = useRef<WeakMap<Float32Array, DecimEntry>>(
 			new WeakMap(),
 		);
 		const pointDecimScratchRef = useRef<{ x: Float32Array; y: Float32Array }>({
@@ -272,59 +241,16 @@ export const WebGLRenderer = React.memo(
 		// Overlay screen-space: one packed Float32Array (x,y pairs) for all primitives.
 		// Groups reference offsets/counts into this buffer.
 		const overlayRef = useRef<{
-			packed: Float32Array; // (x,y) pairs in device pixels
-			packedLen: number; // valid floats in packed
+			packed: Float32Array;
+			packedLen: number;
 			groups: Array<{
 				topology: "LINES" | "TRIANGLES";
 				rgba: [number, number, number, number];
 				width: number;
-				offset: number; // vertex offset
-				count: number; // vertex count
+				offset: number;
+				count: number;
 			}>;
 		}>({ packed: new Float32Array(2048), packedLen: 0, groups: [] });
-
-		// GL state cache — survives across draw frames. Cleared on program/init.
-		// Scalars instead of tuple arrays to avoid per-frame allocations.
-		// colorSet=false flags an unseeded color cache (replaces null sentinel).
-		const glStateRef = useRef<{
-			colorSet: boolean;
-			colorR: number;
-			colorG: number;
-			colorB: number;
-			colorA: number;
-			style: number;
-			lineStyle: number;
-			screenSpace: number;
-			pointSize: number;
-			lineWidth: number;
-			xScaleSet: boolean;
-			xScaleA: number;
-			xScaleB: number;
-			yScaleSet: boolean;
-			yScaleA: number;
-			yScaleB: number;
-			attribEnabled: Map<number, boolean>;
-			attribConst: Map<number, string>;
-		}>({
-			colorSet: false,
-			colorR: 0,
-			colorG: 0,
-			colorB: 0,
-			colorA: 0,
-			style: -2,
-			lineStyle: -2,
-			screenSpace: -1,
-			pointSize: -1,
-			lineWidth: -1,
-			xScaleSet: false,
-			xScaleA: 0,
-			xScaleB: 0,
-			yScaleSet: false,
-			yScaleA: 0,
-			yScaleB: 0,
-			attribEnabled: new Map(),
-			attribConst: new Map(),
-		});
 
 		const drawRangesScratchRef = useRef<{ start: number; count: number }[]>([]);
 		const xAxisByIdRef = useRef<Map<string, XAxisConfig>>(new Map());
@@ -664,17 +590,7 @@ export const WebGLRenderer = React.memo(
 				return;
 			}
 			programRef.current = program;
-			glStateRef.current.colorSet = false;
-			glStateRef.current.style = -2;
-			glStateRef.current.lineStyle = -2;
-			glStateRef.current.screenSpace = -1;
-			glStateRef.current.pointSize = -1;
-			glStateRef.current.lineWidth = -1;
-			glStateRef.current.xScaleSet = false;
-			glStateRef.current.yScaleSet = false;
-			glStateRef.current.attribEnabled.clear();
-			glStateRef.current.attribConst.clear();
-			locationsRef.current = {
+			const locs: WebGLLocations = {
 				xScaleOffLoc: gl.getUniformLocation(program, "u_x_scale_offset"),
 				yScaleOffLoc: gl.getUniformLocation(program, "u_y_scale_offset"),
 				padLoc: gl.getUniformLocation(program, "u_padding"),
@@ -691,6 +607,8 @@ export const WebGLRenderer = React.memo(
 				tLoc: gl.getAttribLocation(program, "a_t"),
 				distStartLoc: gl.getAttribLocation(program, "a_dist_start"),
 			};
+			locationsRef.current = locs;
+			stateCacheRef.current = new GLStateCache(gl, locs);
 
 			if (drawFrameRef.current) {
 				drawFrameRef.current(liveXAxesRef.current, liveYAxesRef.current);
@@ -767,7 +685,7 @@ export const WebGLRenderer = React.memo(
 
 		useEffect(() => {
 			const gl = glRef.current;
-			if (!gl || !programRef.current || !locationsRef.current) return;
+			if (!gl || !programRef.current || !locationsRef.current || !stateCacheRef.current) return;
 
 			const drawFrame = (
 				currentXAxes: XAxisConfig[],
@@ -775,7 +693,8 @@ export const WebGLRenderer = React.memo(
 			) => {
 				const program = programRef.current;
 				const locs = locationsRef.current;
-				if (!program || !locs) return;
+				const st = stateCacheRef.current;
+				if (!program || !locs || !st) return;
 
 				const { width, height, padding, highlightedSeriesId } =
 					propsRef.current;
@@ -785,8 +704,8 @@ export const WebGLRenderer = React.memo(
 				if (chartWidth <= 0 || chartHeight <= 0) return;
 
 				const dpr = window.devicePixelRatio || 1;
-				const pw = width * dpr,
-					ph = height * dpr;
+				const pw = width * dpr;
+				const ph = height * dpr;
 
 				gl.viewport(0, 0, pw, ph);
 				const bg = plotBgRgbaRef.current;
@@ -794,98 +713,6 @@ export const WebGLRenderer = React.memo(
 				gl.clear(gl.COLOR_BUFFER_BIT);
 
 				gl.useProgram(program);
-				const st = glStateRef.current;
-				const setColor = (r: number, g: number, b: number, a: number) => {
-					if (
-						!st.colorSet ||
-						st.colorR !== r ||
-						st.colorG !== g ||
-						st.colorB !== b ||
-						st.colorA !== a
-					) {
-						gl.uniform4f(locs.colorLoc, r, g, b, a);
-						st.colorR = r;
-						st.colorG = g;
-						st.colorB = b;
-						st.colorA = a;
-						st.colorSet = true;
-					}
-				};
-				const setStyle = (v: number) => {
-					if (st.style !== v) {
-						gl.uniform1i(locs.styleLoc, v);
-						st.style = v;
-					}
-				};
-				const setLineStyle = (v: number) => {
-					if (st.lineStyle !== v) {
-						gl.uniform1i(locs.lineStyleLoc, v);
-						st.lineStyle = v;
-					}
-				};
-				const setScreenSpace = (v: number) => {
-					if (st.screenSpace !== v) {
-						gl.uniform1i(locs.screenSpaceLoc, v);
-						st.screenSpace = v;
-					}
-				};
-				const setPointSize = (v: number) => {
-					if (st.pointSize !== v) {
-						gl.uniform1f(locs.sizeLoc, v);
-						st.pointSize = v;
-					}
-				};
-				const setLineWidth = (v: number) => {
-					if (st.lineWidth !== v) {
-						gl.lineWidth(v);
-						st.lineWidth = v;
-					}
-				};
-				const setXScaleOff = (a: number, b: number) => {
-					if (!st.xScaleSet || st.xScaleA !== a || st.xScaleB !== b) {
-						gl.uniform2f(locs.xScaleOffLoc, a, b);
-						st.xScaleA = a;
-						st.xScaleB = b;
-						st.xScaleSet = true;
-					}
-				};
-				const setYScaleOff = (a: number, b: number) => {
-					if (!st.yScaleSet || st.yScaleA !== a || st.yScaleB !== b) {
-						gl.uniform2f(locs.yScaleOffLoc, a, b);
-						st.yScaleA = a;
-						st.yScaleB = b;
-						st.yScaleSet = true;
-					}
-				};
-				const enableAttrib = (loc: number) => {
-					if (st.attribEnabled.get(loc) !== true) {
-						gl.enableVertexAttribArray(loc);
-						st.attribEnabled.set(loc, true);
-						st.attribConst.delete(loc);
-					}
-				};
-				const disableAttribConst1 = (loc: number, v: number) => {
-					const key = `1:${v}`;
-					if (st.attribEnabled.get(loc) !== false) {
-						gl.disableVertexAttribArray(loc);
-						st.attribEnabled.set(loc, false);
-					}
-					if (st.attribConst.get(loc) !== key) {
-						gl.vertexAttrib1f(loc, v);
-						st.attribConst.set(loc, key);
-					}
-				};
-				const disableAttribConst2 = (loc: number, x: number, y: number) => {
-					const key = `2:${x},${y}`;
-					if (st.attribEnabled.get(loc) !== false) {
-						gl.disableVertexAttribArray(loc);
-						st.attribEnabled.set(loc, false);
-					}
-					if (st.attribConst.get(loc) !== key) {
-						gl.vertexAttrib2f(loc, x, y);
-						st.attribConst.set(loc, key);
-					}
-				};
 
 				gl.uniform4f(
 					locs.padLoc,
@@ -897,51 +724,20 @@ export const WebGLRenderer = React.memo(
 				gl.uniform2f(locs.resLoc, pw, ph);
 				gl.uniform1f(locs.dprLoc, dpr);
 
-				// --- Draw overlay (bg, grid, spines, ticks, arrows, zero lines) ---
 				const overlay = overlayRef.current;
-				if (overlay && overlay.packedLen > 0 && overlay.groups.length > 0) {
-					setScreenSpace(1);
-					setStyle(3);
-					setLineStyle(0);
-					disableAttribConst2(locs.otherLoc, 0, 0);
-					disableAttribConst1(locs.tLoc, 0);
-					disableAttribConst1(locs.distStartLoc, 0);
-
-					let overlayBuf = buffersRef.current.get("__overlay");
-					if (!overlayBuf) {
-						const b = gl.createBuffer();
-						if (b) {
-							overlayBuf = b;
-							buffersRef.current.set("__overlay", overlayBuf);
-						}
-					}
-					if (overlayBuf) {
-						gl.bindBuffer(gl.ARRAY_BUFFER, overlayBuf);
-						gl.bufferData(
-							gl.ARRAY_BUFFER,
-							overlay.packed.subarray(0, overlay.packedLen),
-							gl.STREAM_DRAW,
-						);
-						enableAttrib(locs.xLoc);
-						gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 8, 0);
-						enableAttrib(locs.yLoc);
-						gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 8, 4);
-
-						for (const grp of overlay.groups) {
-							if (grp.count === 0) continue;
-							const c = grp.rgba;
-							setColor(c[0], c[1], c[2], c[3]);
-							if (grp.topology === "LINES") {
-								setLineWidth(grp.width);
-								gl.drawArrays(gl.LINES, grp.offset, grp.count);
-							} else {
-								gl.drawArrays(gl.TRIANGLES, grp.offset, grp.count);
-							}
-						}
+				let overlayBuf = buffersRef.current.get("__overlay");
+				if (!overlayBuf) {
+					const b = gl.createBuffer();
+					if (b) {
+						overlayBuf = b;
+						buffersRef.current.set("__overlay", overlayBuf);
 					}
 				}
+				if (overlayBuf) {
+					drawOverlay(st, overlay, overlayBuf);
+				}
 
-				setScreenSpace(0);
+				st.setScreenSpace(0);
 				gl.enable(gl.SCISSOR_TEST);
 				gl.scissor(
 					padding.left * dpr,
@@ -962,486 +758,191 @@ export const WebGLRenderer = React.memo(
 
 				const t0 = performance.now();
 				for (let idx = 0; idx < seriesMetadata.length; idx++) {
-					const { series: s, ds, xIdx, yIdx, lineColorRgba, pointColorRgba } = seriesMetadata[idx];
+					const { series: s, ds, xIdx, yIdx, lineColorRgba, pointColorRgba } =
+						seriesMetadata[idx];
 
 					const xAxis = xAxisById.get(ds.xAxisId || "axis-1");
 					const yAxis = yAxisById.get(s.yAxisId);
-
 					if (!xAxis || !yAxis) continue;
-
 					if (s.hidden) continue;
+
 					const colX = ds.data[xIdx];
 					const colY = ds.data[yIdx];
 					if (!colX || !colY) continue;
 
-						const xData = colX.data;
-						const yData = colY.data;
-						const xRef = colX.refPoint;
+					const xData = colX.data;
+					const yData = colY.data;
+					const xRef = colX.refPoint;
+					const yRef = colY.refPoint;
 
-						const xRange = xAxis.max - xAxis.min || 1;
-						const yRange = yAxis.max - yAxis.min || 1;
+					const xRange = xAxis.max - xAxis.min || 1;
+					const yRange = yAxis.max - yAxis.min || 1;
 
-						let isMonotonic = monoCacheRef.current.get(xData);
-						if (isMonotonic === undefined) {
-							isMonotonic = true;
-							for (let i = 1; i < xData.length; i++) {
-								if (xData[i] < xData[i - 1]) {
-									isMonotonic = false;
-									break;
-								}
+					let isMonotonic = monoCacheRef.current.get(xData);
+					if (isMonotonic === undefined) {
+						isMonotonic = true;
+						for (let i = 1; i < xData.length; i++) {
+							if (xData[i] < xData[i - 1]) {
+								isMonotonic = false;
+								break;
 							}
-							monoCacheRef.current.set(xData, isMonotonic);
 						}
+						monoCacheRef.current.set(xData, isMonotonic);
+					}
 
-						let cachedSegments = segmentCacheRef.current.get(yData);
-						if (!cachedSegments) {
-							cachedSegments = [];
-							let segStart = -1;
-							for (let i = 0; i <= yData.length; i++) {
-								const nan = i === yData.length || Number.isNaN(yData[i]);
-								const xDrop =
-									!nan && i > 0 && segStart !== -1 && xData[i] < xData[i - 1];
-								const break_ = nan || xDrop;
-								if (!break_ && segStart === -1) segStart = i;
-								else if (break_ && segStart !== -1) {
-									cachedSegments.push({ start: segStart, end: i - 1 });
-									segStart = -1;
-									if (xDrop && !nan) segStart = i;
-								}
+					let cachedSegments = segmentCacheRef.current.get(yData);
+					if (!cachedSegments) {
+						cachedSegments = [];
+						let segStart = -1;
+						for (let i = 0; i <= yData.length; i++) {
+							const nan = i === yData.length || Number.isNaN(yData[i]);
+							const xDrop =
+								!nan && i > 0 && segStart !== -1 && xData[i] < xData[i - 1];
+							const break_ = nan || xDrop;
+							if (!break_ && segStart === -1) segStart = i;
+							else if (break_ && segStart !== -1) {
+								cachedSegments.push({ start: segStart, end: i - 1 });
+								segStart = -1;
+								if (xDrop && !nan) segStart = i;
 							}
-							segmentCacheRef.current.set(yData, cachedSegments);
 						}
+						segmentCacheRef.current.set(yData, cachedSegments);
+					}
 
-						const xDataLen = xData.length;
-						let rawStart = 0;
-						let rawEnd = xDataLen - 1;
-						if (isMonotonic) {
-							rawStart = findLastLE(xData, xAxis.min, xRef, 0);
-							rawEnd = findFirstGE(xData, xAxis.max, xRef, xDataLen - 1);
-						}
+					const xDataLen = xData.length;
+					let rawStart = 0;
+					let rawEnd = xDataLen - 1;
+					if (isMonotonic) {
+						rawStart = findLastLE(xData, xAxis.min, xRef, 0);
+						rawEnd = findFirstGE(xData, xAxis.max, xRef, xDataLen - 1);
+					}
 
-						const sliceStart = isMonotonic
-							? Math.max(0, rawStart > 0 ? rawStart - 1 : 0)
-							: 0;
-						const sliceEnd = isMonotonic
-							? Math.min(
-									xDataLen - 1,
-									rawEnd < xDataLen - 1 ? rawEnd + 1 : rawEnd,
-								)
-							: xDataLen - 1;
+					const sliceStart = isMonotonic
+						? Math.max(0, rawStart > 0 ? rawStart - 1 : 0)
+						: 0;
+					const sliceEnd = isMonotonic
+						? Math.min(
+								xDataLen - 1,
+								rawEnd < xDataLen - 1 ? rawEnd + 1 : rawEnd,
+							)
+						: xDataLen - 1;
 
-						const xScaleVal = (chartWidth * dpr) / xRange;
-						const xOffsetVal =
-							padding.left * dpr - (xAxis.min - xRef) * xScaleVal;
-						const yScaleVal =
-							(padding.top * dpr - (height - padding.bottom) * dpr) / yRange;
-						const yOffsetVal =
-							(height - padding.bottom) * dpr -
-							(yAxis.min - colY.refPoint) * yScaleVal;
+					const xScaleVal = (chartWidth * dpr) / xRange;
+					const xOffsetVal =
+						padding.left * dpr - (xAxis.min - xRef) * xScaleVal;
+					const yScaleVal =
+						(padding.top * dpr - (height - padding.bottom) * dpr) / yRange;
+					const yOffsetVal =
+						(height - padding.bottom) * dpr -
+						(yAxis.min - yRef) * yScaleVal;
 
-						// Cache GPU buffers per source Float32Array identity (xData/yData).
-						// Avoids re-uploading during pan/zoom — only uniforms change.
-						let xBuffer = columnBufferRef.current.get(xData);
-						if (!xBuffer) {
-							const b = gl.createBuffer();
-							if (!b) return;
-							xBuffer = b;
-							gl.bindBuffer(gl.ARRAY_BUFFER, xBuffer);
-							gl.bufferData(gl.ARRAY_BUFFER, xData, gl.STATIC_DRAW);
-							columnBufferRef.current.set(xData, xBuffer);
-						}
-						let yBuffer = columnBufferRef.current.get(yData);
-						if (!yBuffer) {
-							const b = gl.createBuffer();
-							if (!b) return;
-							yBuffer = b;
-							gl.bindBuffer(gl.ARRAY_BUFFER, yBuffer);
-							gl.bufferData(gl.ARRAY_BUFFER, yData, gl.STATIC_DRAW);
-							columnBufferRef.current.set(yData, yBuffer);
-						}
+					let xBuffer = columnBufferRef.current.get(xData);
+					if (!xBuffer) {
+						const b = gl.createBuffer();
+						if (!b) return;
+						xBuffer = b;
+						gl.bindBuffer(gl.ARRAY_BUFFER, xBuffer);
+						gl.bufferData(gl.ARRAY_BUFFER, xData, gl.STATIC_DRAW);
+						columnBufferRef.current.set(xData, xBuffer);
+					}
+					let yBuffer = columnBufferRef.current.get(yData);
+					if (!yBuffer) {
+						const b = gl.createBuffer();
+						if (!b) return;
+						yBuffer = b;
+						gl.bindBuffer(gl.ARRAY_BUFFER, yBuffer);
+						gl.bufferData(gl.ARRAY_BUFFER, yData, gl.STATIC_DRAW);
+						columnBufferRef.current.set(yData, yBuffer);
+					}
 
-						// Build draw ranges directly in original buffer indices using cachedSegments
-						// clipped to [sliceStart, sliceEnd]. Reuses scratch to avoid per-frame alloc.
-						const drawRanges = drawRangesScratchRef.current;
-						let drCount = 0;
-						const pushRange = (start: number, count: number) => {
-							if (drCount < drawRanges.length) {
-								drawRanges[drCount].start = start;
-								drawRanges[drCount].count = count;
-							} else {
-								drawRanges.push({ start, count });
-							}
-							drCount++;
-						};
-						if (isMonotonic) {
-							let segLo = 0,
-								segHi = cachedSegments.length - 1;
-							let startSegIdx = 0;
-							while (segLo <= segHi) {
-								const m = (segLo + segHi) >>> 1;
-								if (cachedSegments[m].end >= sliceStart) {
-									startSegIdx = m;
-									segHi = m - 1;
-								} else segLo = m + 1;
-							}
-							for (let i = startSegIdx; i < cachedSegments.length; i++) {
-								const seg = cachedSegments[i];
-								if (seg.start > sliceEnd) break;
-								const s = Math.max(seg.start, sliceStart);
-								const e = Math.min(seg.end, sliceEnd);
-								if (e >= s) pushRange(s, e - s + 1);
-							}
+					// Build draw ranges in original buffer indices using cachedSegments
+					// clipped to [sliceStart, sliceEnd]. Reuses scratch to avoid per-frame alloc.
+					const drawRanges = drawRangesScratchRef.current;
+					let drCount = 0;
+					const pushRange = (start: number, count: number) => {
+						if (drCount < drawRanges.length) {
+							drawRanges[drCount].start = start;
+							drawRanges[drCount].count = count;
 						} else {
-							for (const seg of cachedSegments) {
-								pushRange(seg.start, seg.end - seg.start + 1);
-							}
+							drawRanges.push({ start, count });
 						}
-						drawRanges.length = drCount;
-
-						setXScaleOff(xScaleVal, xOffsetVal);
-						setYScaleOff(yScaleVal, yOffsetVal);
-
-						const isHighlighted = highlightedSeriesId === s.id;
-						const baseLineWidth = isHighlighted ? 2.5 : 1;
-
-						if (s.lineStyle !== "none") {
-							const c = lineColorRgba;
-							setColor(c[0], c[1], c[2], 1.0);
-							setPointSize((isHighlighted ? 2.5 : 1.5) * dpr);
-							const lStyle =
-								s.lineStyle === "solid" ? 0 : s.lineStyle === "dashed" ? 1 : 2;
-							setLineStyle(lStyle);
-							setStyle(-1);
-
-							if (lStyle === 0) {
-								disableAttribConst2(locs.otherLoc, 0, 0);
-								disableAttribConst1(locs.tLoc, 0);
-								disableAttribConst1(locs.distStartLoc, 0);
-
-								// M4 decimation: only when monotonic and visible slice
-								// has > 4 samples per device pixel. Output preserves
-								// per-bucket (first,min,max,last) — vertical extrema kept.
-								const chartWidthPx = chartWidth * dpr;
-								const numBuckets = Math.max(8, Math.ceil(chartWidthPx));
-								const visibleCount = sliceEnd - sliceStart + 1;
-								const useDecim =
-									isMonotonic &&
-									cachedSegments.length === 1 &&
-									visibleCount > numBuckets * 4;
-
-								if (useDecim) {
-									// Decimate over a padded window so panning within
-									// ±½ viewport reuses the cached result.
-									const pad = xRange * 0.5;
-									const decimMin = xAxis.min - pad;
-									const decimMax = xAxis.max + pad;
-									// Quantize cache key to xRange so wheel zoom rebuilds
-									// gracefully; pan within window hits cache.
-									const q = 2 ** Math.floor(Math.log2(xRange / 8));
-									const qMin = Math.floor(decimMin / q) * q;
-									const qMax = Math.ceil(decimMax / q) * q;
-									const bucketWidth = xRange / (numBuckets * 3);
-									const sig = `${bucketWidth}|${qMin}|${qMax}|${colY.refPoint}`;
-									let entry = decimCacheRef.current.get(yData);
-									if (!entry || entry.sig !== sig) {
-										const scratch = decimScratchRef.current;
-										const { x: dx, y: dy } = m4ByXFloat32(
-											xData,
-											yData,
-											xRef,
-											qMin,
-											qMax,
-											bucketWidth,
-											scratch,
-										);
-										// Copy into entry-owned buffers so the WeakMap
-										// retains stable arrays (subarray returned by m4
-										// shares underlying buffer with scratch).
-										const xArr = new Float32Array(dx.length);
-										const yArr = new Float32Array(dy.length);
-										xArr.set(dx);
-										yArr.set(dy);
-										// Reuse existing GPU buffers when present.
-										let xBuf = entry?.xBuf ?? null;
-										let yBuf = entry?.yBuf ?? null;
-										if (!xBuf) xBuf = gl.createBuffer();
-										if (!yBuf) yBuf = gl.createBuffer();
-										if (xBuf) {
-											gl.bindBuffer(gl.ARRAY_BUFFER, xBuf);
-											gl.bufferData(gl.ARRAY_BUFFER, xArr, gl.DYNAMIC_DRAW);
-										}
-										if (yBuf) {
-											gl.bindBuffer(gl.ARRAY_BUFFER, yBuf);
-											gl.bufferData(gl.ARRAY_BUFFER, yArr, gl.DYNAMIC_DRAW);
-										}
-										entry = {
-											sig,
-											xArr,
-											yArr,
-											count: xArr.length,
-											xBuf,
-											yBuf,
-										};
-										decimCacheRef.current.set(yData, entry);
-									}
-									if (entry.xBuf && entry.yBuf && entry.count >= 2) {
-										gl.bindBuffer(gl.ARRAY_BUFFER, entry.xBuf);
-										enableAttrib(locs.xLoc);
-										gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 0, 0);
-										gl.bindBuffer(gl.ARRAY_BUFFER, entry.yBuf);
-										enableAttrib(locs.yLoc);
-										gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 0, 0);
-										setLineWidth(baseLineWidth);
-										gl.drawArrays(gl.LINE_STRIP, 0, entry.count);
-									}
-								} else {
-									gl.bindBuffer(gl.ARRAY_BUFFER, xBuffer);
-									enableAttrib(locs.xLoc);
-									gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 0, 0);
-
-									gl.bindBuffer(gl.ARRAY_BUFFER, yBuffer);
-									enableAttrib(locs.yLoc);
-									gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 0, 0);
-
-									setLineWidth(baseLineWidth);
-									for (const seg of drawRanges) {
-										if (seg.count >= 2)
-											gl.drawArrays(gl.LINE_STRIP, seg.start, seg.count);
-									}
-								}
-							} else {
-								const segBufferKey = `seg-${ds.id}-${xIdx}-${yIdx}-dyn`;
-								let totalLineSegs = 0;
-								const STEPS: number[] = [];
-								for (const r of drawRanges) {
-									const n = Math.max(0, r.count - 1);
-									const step = Math.max(1, Math.floor(n / 4000));
-									STEPS.push(step);
-									totalLineSegs += Math.ceil(n / step);
-								}
-								// Quantize float ranges so micro pan jitter hits cache.
-								// Pan = translation (xRange constant) so cache hits every frame.
-								// Zoom changes range slowly; rebuild cost amortized over many frames.
-								const qx = xRange.toPrecision(4);
-								const qy = yRange.toPrecision(4);
-								const paramKey = `${qx}-${qy}-${chartWidth}-${chartHeight}-${dpr}-${totalLineSegs}-${drawRanges.length}-${drawRanges[0]?.start ?? 0}`;
-								let segBuffer = buffersRef.current.get(segBufferKey);
-								if (!segBuffer) {
-									segBuffer = gl.createBuffer();
-									if (!segBuffer) return;
-									buffersRef.current.set(segBufferKey, segBuffer);
-								}
-
-								if (segParamsRef.current.get(segBufferKey) !== paramKey) {
-									const sharedArr = new Float32Array(totalLineSegs * 12);
-									const scaleX = (chartWidth * dpr) / xRange;
-									const scaleY = (chartHeight * dpr) / yRange;
-
-									let outIdx = 0;
-									for (let rIdx = 0; rIdx < drawRanges.length; rIdx++) {
-										const r = drawRanges[rIdx];
-										const step = STEPS[rIdx];
-										let cumDist = 0;
-										const n = r.count - 1;
-										for (let i = 0; i < n; i += step) {
-											const ai = r.start + i;
-											let bi = ai + step;
-											if (bi > r.start + n) bi = r.start + n;
-
-											const ax = xData[ai],
-												ay = yData[ai];
-											const bx = xData[bi],
-												by = yData[bi];
-											const sLen = Math.sqrt(
-												((bx - ax) * scaleX) ** 2 + ((by - ay) * scaleY) ** 2,
-											);
-											const off = outIdx * 12;
-											sharedArr[off] = ax;
-											sharedArr[off + 1] = ay;
-											sharedArr[off + 2] = bx;
-											sharedArr[off + 3] = by;
-											sharedArr[off + 4] = 0;
-											sharedArr[off + 5] = cumDist;
-											sharedArr[off + 6] = bx;
-											sharedArr[off + 7] = by;
-											sharedArr[off + 8] = ax;
-											sharedArr[off + 9] = ay;
-											sharedArr[off + 10] = 1;
-											sharedArr[off + 11] = cumDist;
-											cumDist += sLen;
-											outIdx++;
-										}
-									}
-									gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
-									gl.bufferData(gl.ARRAY_BUFFER, sharedArr, gl.STREAM_DRAW);
-									segParamsRef.current.set(segBufferKey, paramKey);
-								} else {
-									gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
-								}
-								enableAttrib(locs.xLoc);
-								gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 24, 0);
-								enableAttrib(locs.yLoc);
-								gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 24, 4);
-								enableAttrib(locs.otherLoc);
-								gl.vertexAttribPointer(
-									locs.otherLoc,
-									2,
-									gl.FLOAT,
-									false,
-									24,
-									8,
-								);
-								enableAttrib(locs.tLoc);
-								gl.vertexAttribPointer(locs.tLoc, 1, gl.FLOAT, false, 24, 16);
-								enableAttrib(locs.distStartLoc);
-								gl.vertexAttribPointer(
-									locs.distStartLoc,
-									1,
-									gl.FLOAT,
-									false,
-									24,
-									20,
-								);
-								setLineWidth(baseLineWidth);
-								gl.drawArrays(gl.LINES, 0, totalLineSegs * 2);
-							}
+						drCount++;
+					};
+					if (isMonotonic) {
+						let segLo = 0;
+						let segHi = cachedSegments.length - 1;
+						let startSegIdx = 0;
+						while (segLo <= segHi) {
+							const m = (segLo + segHi) >>> 1;
+							if (cachedSegments[m].end >= sliceStart) {
+								startSegIdx = m;
+								segHi = m - 1;
+							} else segLo = m + 1;
 						}
-
-						if (s.pointStyle !== "none") {
-							const interact = isInteractingRef.current;
-							const visibleCount = sliceEnd - sliceStart + 1;
-							const chartWidthPx = chartWidth * dpr;
-							const pixelDensity = visibleCount / Math.max(1, chartWidthPx);
-
-							const c = pointColorRgba;
-							const baseSize = (isHighlighted ? 8.0 : 6.0) * dpr;
-							const pStyle =
-								s.pointStyle === "circle"
-									? 0
-									: s.pointStyle === "square"
-										? 1
-										: 2;
-							setStyle(pStyle);
-
-							disableAttribConst2(locs.otherLoc, 0, 0);
-							disableAttribConst1(locs.tLoc, 0);
-							disableAttribConst1(locs.distStartLoc, 0);
-
-							// M4 point decimation: per X-pixel bucket emit (first,min,max,last)
-							// so Y-extrema survive. Drops only adjacent points that share both
-							// an X-pixel column AND a similar Y — i.e. truly redundant ones.
-							let useDecim = false;
-							let decimEntry: PointDecimEntry | null = null;
-							let decimDrawStart = 0;
-							let decimDrawCount = 0;
-							if (interact && isMonotonic && pixelDensity > 1) {
-								const numBuckets = Math.max(8, Math.ceil(chartWidthPx));
-								// Pad window so panning within ±½ viewport hits cache.
-								const pad = xRange * 0.5;
-								const decimMin = xAxis.min - pad;
-								const decimMax = xAxis.max + pad;
-								const q = 2 ** Math.floor(Math.log2(xRange / 8));
-								const qMin = Math.floor(decimMin / q) * q;
-								const qMax = Math.ceil(decimMax / q) * q;
-								const bucketWidth = xRange / numBuckets;
-								const sig = `${bucketWidth}|${qMin}|${qMax}|${xRef}`;
-								let entry = pointDecimCacheRef.current.get(yData);
-								if (!entry || entry.sig !== sig) {
-									const scratch = pointDecimScratchRef.current;
-									const { x: dx, y: dy } = m4ByXFloat32(
-										xData,
-										yData,
-										xRef,
-										qMin,
-										qMax,
-										bucketWidth,
-										scratch,
-									);
-									const xArr = new Float32Array(dx.length);
-									const yArr = new Float32Array(dy.length);
-									xArr.set(dx);
-									yArr.set(dy);
-									let xBuf = entry?.xBuf ?? null;
-									let yBuf = entry?.yBuf ?? null;
-									if (!xBuf) xBuf = gl.createBuffer();
-									if (!yBuf) yBuf = gl.createBuffer();
-									if (xBuf) {
-										gl.bindBuffer(gl.ARRAY_BUFFER, xBuf);
-										gl.bufferData(gl.ARRAY_BUFFER, xArr, gl.DYNAMIC_DRAW);
-									}
-									if (yBuf) {
-										gl.bindBuffer(gl.ARRAY_BUFFER, yBuf);
-										gl.bufferData(gl.ARRAY_BUFFER, yArr, gl.DYNAMIC_DRAW);
-									}
-									entry = {
-										sig,
-										xArr,
-										yArr,
-										count: xArr.length,
-										xBuf,
-										yBuf,
-									};
-									pointDecimCacheRef.current.set(yData, entry);
-								}
-								if (entry.xBuf && entry.yBuf && entry.count >= 1) {
-									// m4 emits indices in order within each bucket, so the
-									// decimated X array remains monotonic.
-									const xArr = entry.xArr;
-									const cnt = entry.count;
-									const lowIdx = findLastLE(xArr, xAxis.min, xRef, 0);
-									const highIdx = findFirstGE(xArr, xAxis.max, xRef, cnt - 1);
-									const dStart = Math.max(0, lowIdx > 0 ? lowIdx - 1 : 0);
-									const dEnd = Math.min(
-										cnt - 1,
-										highIdx < cnt - 1 ? highIdx + 1 : highIdx,
-									);
-									if (dEnd >= dStart) {
-										useDecim = true;
-										decimEntry = entry;
-										decimDrawStart = dStart;
-										decimDrawCount = dEnd - dStart + 1;
-									}
-								}
-							}
-
-							if (useDecim && decimEntry) {
-								gl.bindBuffer(gl.ARRAY_BUFFER, decimEntry.xBuf!);
-								enableAttrib(locs.xLoc);
-								gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 0, 0);
-								gl.bindBuffer(gl.ARRAY_BUFFER, decimEntry.yBuf!);
-								enableAttrib(locs.yLoc);
-								gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 0, 0);
-							} else {
-								gl.bindBuffer(gl.ARRAY_BUFFER, xBuffer);
-								enableAttrib(locs.xLoc);
-								gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 0, 0);
-								gl.bindBuffer(gl.ARRAY_BUFFER, yBuffer);
-								enableAttrib(locs.yLoc);
-								gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 0, 0);
-							}
-
-							setColor(plotBgRgba[0], plotBgRgba[1], plotBgRgba[2], 1.0);
-							setPointSize(baseSize + (pStyle === 2 ? 3.0 : 2.0) * dpr);
-							if (useDecim) {
-								gl.drawArrays(gl.POINTS, decimDrawStart, decimDrawCount);
-							} else {
-								for (const seg of drawRanges) {
-									if (seg.count >= 1)
-										gl.drawArrays(gl.POINTS, seg.start, seg.count);
-								}
-							}
-
-							setColor(c[0], c[1], c[2], 1.0);
-							setPointSize(baseSize);
-							if (useDecim) {
-								gl.drawArrays(gl.POINTS, decimDrawStart, decimDrawCount);
-							} else {
-								for (const seg of drawRanges) {
-									if (seg.count >= 1)
-										gl.drawArrays(gl.POINTS, seg.start, seg.count);
-								}
-							}
+						for (let i = startSegIdx; i < cachedSegments.length; i++) {
+							const seg = cachedSegments[i];
+							if (seg.start > sliceEnd) break;
+							const segS = Math.max(seg.start, sliceStart);
+							const segE = Math.min(seg.end, sliceEnd);
+							if (segE >= segS) pushRange(segS, segE - segS + 1);
 						}
+					} else {
+						for (const seg of cachedSegments) {
+							pushRange(seg.start, seg.end - seg.start + 1);
+						}
+					}
+					drawRanges.length = drCount;
+
+					st.setXScaleOff(xScaleVal, xOffsetVal);
+					st.setYScaleOff(yScaleVal, yOffsetVal);
+
+					const isHighlighted = highlightedSeriesId === s.id;
+
+					const bundle: SeriesDrawBundle = {
+						xData,
+						yData,
+						xRef,
+						yRef,
+						xAxisMin: xAxis.min,
+						xAxisMax: xAxis.max,
+						xRange,
+						yRange,
+						chartWidth,
+						chartHeight,
+						padding,
+						height,
+						dpr,
+						lineColorRgba,
+						pointColorRgba,
+						plotBgRgba,
+						isHighlighted,
+						isMonotonic,
+						cachedSegments,
+						drawRanges,
+						xBuffer,
+						yBuffer,
+						sliceStart,
+						sliceEnd,
+						lineStyle: s.lineStyle,
+						pointStyle: s.pointStyle,
+					};
+
+					drawSeriesLines(
+						st,
+						bundle,
+						decimCacheRef.current,
+						decimScratchRef.current,
+						buffersRef.current,
+						segParamsRef.current,
+						`seg-${ds.id}-${xIdx}-${yIdx}-dyn`,
+					);
+					drawSeriesPoints(
+						st,
+						bundle,
+						pointDecimCacheRef.current,
+						pointDecimScratchRef.current,
+						isInteractingRef.current,
+					);
 				}
 				gl.disable(gl.SCISSOR_TEST);
 

--- a/src/components/Plot/drawSeries.ts
+++ b/src/components/Plot/drawSeries.ts
@@ -1,0 +1,491 @@
+/**
+ * Pure draw helpers for the WebGL renderer.
+ *
+ * `drawOverlay` renders the background / grid / spines / ticks group buffer that
+ * the WebGLRenderer prepares via `setOverlay`. `drawSeriesLines` and
+ * `drawSeriesPoints` render the per-series geometry; both share the M4 cache
+ * logic in `getOrComputeM4` (line and point modes only differ in `bucketDivisor`).
+ */
+
+import { findFirstGE, findLastLE } from "../../utils/binarySearch";
+import { m4ByXFloat32 } from "../../utils/decimation";
+import type { GLStateCache, WebGLLocations } from "./GLStateCache";
+
+export interface OverlayState {
+	packed: Float32Array;
+	packedLen: number;
+	groups: Array<{
+		topology: "LINES" | "TRIANGLES";
+		rgba: [number, number, number, number];
+		width: number;
+		offset: number;
+		count: number;
+	}>;
+}
+
+export interface DecimEntry {
+	sig: string;
+	xArr: Float32Array;
+	yArr: Float32Array;
+	count: number;
+	xBuf: WebGLBuffer | null;
+	yBuf: WebGLBuffer | null;
+}
+
+export interface DrawRange {
+	start: number;
+	count: number;
+}
+
+export interface SeriesDrawBundle {
+	xData: Float32Array;
+	yData: Float32Array;
+	xRef: number;
+	yRef: number;
+	xAxisMin: number;
+	xAxisMax: number;
+	xRange: number;
+	yRange: number;
+	chartWidth: number;
+	chartHeight: number;
+	padding: { top: number; right: number; bottom: number; left: number };
+	height: number;
+	dpr: number;
+	lineColorRgba: number[];
+	pointColorRgba: number[];
+	plotBgRgba: number[];
+	isHighlighted: boolean;
+	isMonotonic: boolean;
+	cachedSegments: { start: number; end: number }[];
+	drawRanges: DrawRange[];
+	xBuffer: WebGLBuffer;
+	yBuffer: WebGLBuffer;
+	sliceStart: number;
+	sliceEnd: number;
+	lineStyle: "solid" | "dashed" | "dotted" | "none";
+	pointStyle: "circle" | "square" | "cross" | "none";
+}
+
+/**
+ * Pixel-anchored M4 decimation with a result cache keyed by yData identity.
+ * `bucketDivisor = 3` is used for line decimation (sub-pixel buckets keep
+ * the polyline visually identical), `1` for point decimation (one bucket per
+ * pixel column emits the four extrema).
+ */
+export function getOrComputeM4(
+	gl: WebGLRenderingContext,
+	cache: WeakMap<Float32Array, DecimEntry>,
+	scratch: { x: Float32Array; y: Float32Array },
+	xData: Float32Array,
+	yData: Float32Array,
+	xRef: number,
+	xAxisMin: number,
+	xAxisMax: number,
+	xRange: number,
+	numBuckets: number,
+	bucketDivisor: number,
+): DecimEntry {
+	// Pad the cached window so panning within ±½ viewport reuses the result.
+	const pad = xRange * 0.5;
+	const decimMin = xAxisMin - pad;
+	const decimMax = xAxisMax + pad;
+	// Quantize the cache key to a power-of-two xRange step so wheel zoom
+	// rebuilds gracefully while pan-within-window hits the cache.
+	const q = 2 ** Math.floor(Math.log2(xRange / 8));
+	const qMin = Math.floor(decimMin / q) * q;
+	const qMax = Math.ceil(decimMax / q) * q;
+	const bucketWidth = xRange / (numBuckets * bucketDivisor);
+	const sig = `${bucketWidth}|${qMin}|${qMax}|${xRef}`;
+
+	let entry = cache.get(yData);
+	if (entry && entry.sig === sig) return entry;
+
+	const { x: dx, y: dy } = m4ByXFloat32(
+		xData,
+		yData,
+		xRef,
+		qMin,
+		qMax,
+		bucketWidth,
+		scratch,
+	);
+	// Copy into entry-owned buffers so the cache retains stable arrays;
+	// `subarray` returned by m4 shares the underlying scratch buffer.
+	const xArr = new Float32Array(dx.length);
+	const yArr = new Float32Array(dy.length);
+	xArr.set(dx);
+	yArr.set(dy);
+
+	let xBuf = entry?.xBuf ?? null;
+	let yBuf = entry?.yBuf ?? null;
+	if (!xBuf) xBuf = gl.createBuffer();
+	if (!yBuf) yBuf = gl.createBuffer();
+	if (xBuf) {
+		gl.bindBuffer(gl.ARRAY_BUFFER, xBuf);
+		gl.bufferData(gl.ARRAY_BUFFER, xArr, gl.DYNAMIC_DRAW);
+	}
+	if (yBuf) {
+		gl.bindBuffer(gl.ARRAY_BUFFER, yBuf);
+		gl.bufferData(gl.ARRAY_BUFFER, yArr, gl.DYNAMIC_DRAW);
+	}
+	entry = { sig, xArr, yArr, count: xArr.length, xBuf, yBuf };
+	cache.set(yData, entry);
+	return entry;
+}
+
+export function drawOverlay(
+	st: GLStateCache,
+	overlay: OverlayState,
+	overlayBuf: WebGLBuffer,
+): void {
+	const { gl, locs } = st;
+	if (overlay.packedLen <= 0 || overlay.groups.length === 0) return;
+
+	st.setScreenSpace(1);
+	st.setStyle(3);
+	st.setLineStyle(0);
+	st.disableAttribConst2(locs.otherLoc, 0, 0);
+	st.disableAttribConst1(locs.tLoc, 0);
+	st.disableAttribConst1(locs.distStartLoc, 0);
+
+	gl.bindBuffer(gl.ARRAY_BUFFER, overlayBuf);
+	gl.bufferData(
+		gl.ARRAY_BUFFER,
+		overlay.packed.subarray(0, overlay.packedLen),
+		gl.STREAM_DRAW,
+	);
+	st.enableAttrib(locs.xLoc);
+	gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 8, 0);
+	st.enableAttrib(locs.yLoc);
+	gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 8, 4);
+
+	for (const grp of overlay.groups) {
+		if (grp.count === 0) continue;
+		const c = grp.rgba;
+		st.setColor(c[0], c[1], c[2], c[3]);
+		if (grp.topology === "LINES") {
+			st.setLineWidth(grp.width);
+			gl.drawArrays(gl.LINES, grp.offset, grp.count);
+		} else {
+			gl.drawArrays(gl.TRIANGLES, grp.offset, grp.count);
+		}
+	}
+}
+
+function drawDecimatedLines(
+	st: GLStateCache,
+	bundle: SeriesDrawBundle,
+	lineDecimCache: WeakMap<Float32Array, DecimEntry>,
+	scratch: { x: Float32Array; y: Float32Array },
+	chartWidthPx: number,
+	numBuckets: number,
+	baseLineWidth: number,
+): void {
+	const { gl, locs } = st;
+	const entry = getOrComputeM4(
+		gl,
+		lineDecimCache,
+		scratch,
+		bundle.xData,
+		bundle.yData,
+		bundle.xRef,
+		bundle.xAxisMin,
+		bundle.xAxisMax,
+		bundle.xRange,
+		numBuckets,
+		3,
+	);
+	if (!entry.xBuf || !entry.yBuf || entry.count < 2) return;
+	void chartWidthPx;
+
+	gl.bindBuffer(gl.ARRAY_BUFFER, entry.xBuf);
+	st.enableAttrib(locs.xLoc);
+	gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 0, 0);
+	gl.bindBuffer(gl.ARRAY_BUFFER, entry.yBuf);
+	st.enableAttrib(locs.yLoc);
+	gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 0, 0);
+	st.setLineWidth(baseLineWidth);
+	gl.drawArrays(gl.LINE_STRIP, 0, entry.count);
+}
+
+function drawPlainLines(
+	st: GLStateCache,
+	bundle: SeriesDrawBundle,
+	baseLineWidth: number,
+): void {
+	const { gl, locs } = st;
+	gl.bindBuffer(gl.ARRAY_BUFFER, bundle.xBuffer);
+	st.enableAttrib(locs.xLoc);
+	gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 0, 0);
+	gl.bindBuffer(gl.ARRAY_BUFFER, bundle.yBuffer);
+	st.enableAttrib(locs.yLoc);
+	gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 0, 0);
+	st.setLineWidth(baseLineWidth);
+	for (const seg of bundle.drawRanges) {
+		if (seg.count >= 2) gl.drawArrays(gl.LINE_STRIP, seg.start, seg.count);
+	}
+}
+
+function drawDashedLines(
+	st: GLStateCache,
+	bundle: SeriesDrawBundle,
+	lStyle: number,
+	baseLineWidth: number,
+	segBuffersRef: Map<string, WebGLBuffer>,
+	segParamsRef: Map<string, string>,
+	segBufferKey: string,
+): void {
+	const { gl, locs } = st;
+	const { drawRanges, xData, yData, xRange, yRange, chartWidth, chartHeight, dpr } =
+		bundle;
+	const STEPS: number[] = [];
+	let totalLineSegs = 0;
+	for (const r of drawRanges) {
+		const n = Math.max(0, r.count - 1);
+		const step = Math.max(1, Math.floor(n / 4000));
+		STEPS.push(step);
+		totalLineSegs += Math.ceil(n / step);
+	}
+	// Quantize float ranges so micro pan jitter hits cache.
+	// Pan = translation (xRange constant) so cache hits every frame.
+	// Zoom changes range slowly; rebuild cost amortized over many frames.
+	const qx = xRange.toPrecision(4);
+	const qy = yRange.toPrecision(4);
+	const paramKey = `${qx}-${qy}-${chartWidth}-${chartHeight}-${dpr}-${totalLineSegs}-${drawRanges.length}-${drawRanges[0]?.start ?? 0}`;
+
+	let segBuffer = segBuffersRef.get(segBufferKey);
+	if (!segBuffer) {
+		const b = gl.createBuffer();
+		if (!b) return;
+		segBuffer = b;
+		segBuffersRef.set(segBufferKey, segBuffer);
+	}
+
+	if (segParamsRef.get(segBufferKey) !== paramKey) {
+		const sharedArr = new Float32Array(totalLineSegs * 12);
+		const scaleX = (chartWidth * dpr) / xRange;
+		const scaleY = (chartHeight * dpr) / yRange;
+
+		let outIdx = 0;
+		for (let rIdx = 0; rIdx < drawRanges.length; rIdx++) {
+			const r = drawRanges[rIdx];
+			const step = STEPS[rIdx];
+			let cumDist = 0;
+			const n = r.count - 1;
+			for (let i = 0; i < n; i += step) {
+				const ai = r.start + i;
+				let bi = ai + step;
+				if (bi > r.start + n) bi = r.start + n;
+
+				const ax = xData[ai];
+				const ay = yData[ai];
+				const bx = xData[bi];
+				const by = yData[bi];
+				const sLen = Math.sqrt(
+					((bx - ax) * scaleX) ** 2 + ((by - ay) * scaleY) ** 2,
+				);
+				const off = outIdx * 12;
+				sharedArr[off] = ax;
+				sharedArr[off + 1] = ay;
+				sharedArr[off + 2] = bx;
+				sharedArr[off + 3] = by;
+				sharedArr[off + 4] = 0;
+				sharedArr[off + 5] = cumDist;
+				sharedArr[off + 6] = bx;
+				sharedArr[off + 7] = by;
+				sharedArr[off + 8] = ax;
+				sharedArr[off + 9] = ay;
+				sharedArr[off + 10] = 1;
+				sharedArr[off + 11] = cumDist;
+				cumDist += sLen;
+				outIdx++;
+			}
+		}
+		gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
+		gl.bufferData(gl.ARRAY_BUFFER, sharedArr, gl.STREAM_DRAW);
+		segParamsRef.set(segBufferKey, paramKey);
+	} else {
+		gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
+	}
+	void lStyle;
+	st.enableAttrib(locs.xLoc);
+	gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 24, 0);
+	st.enableAttrib(locs.yLoc);
+	gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 24, 4);
+	st.enableAttrib(locs.otherLoc);
+	gl.vertexAttribPointer(locs.otherLoc, 2, gl.FLOAT, false, 24, 8);
+	st.enableAttrib(locs.tLoc);
+	gl.vertexAttribPointer(locs.tLoc, 1, gl.FLOAT, false, 24, 16);
+	st.enableAttrib(locs.distStartLoc);
+	gl.vertexAttribPointer(locs.distStartLoc, 1, gl.FLOAT, false, 24, 20);
+	st.setLineWidth(baseLineWidth);
+	gl.drawArrays(gl.LINES, 0, totalLineSegs * 2);
+}
+
+export function drawSeriesLines(
+	st: GLStateCache,
+	bundle: SeriesDrawBundle,
+	lineDecimCache: WeakMap<Float32Array, DecimEntry>,
+	lineDecimScratch: { x: Float32Array; y: Float32Array },
+	segBuffersRef: Map<string, WebGLBuffer>,
+	segParamsRef: Map<string, string>,
+	segBufferKey: string,
+): void {
+	if (bundle.lineStyle === "none") return;
+	const { locs } = st;
+	const c = bundle.lineColorRgba;
+	st.setColor(c[0], c[1], c[2], 1.0);
+	st.setPointSize((bundle.isHighlighted ? 2.5 : 1.5) * bundle.dpr);
+	const lStyle =
+		bundle.lineStyle === "solid" ? 0 : bundle.lineStyle === "dashed" ? 1 : 2;
+	st.setLineStyle(lStyle);
+	st.setStyle(-1);
+
+	const baseLineWidth = bundle.isHighlighted ? 2.5 : 1;
+
+	if (lStyle === 0) {
+		st.disableAttribConst2(locs.otherLoc, 0, 0);
+		st.disableAttribConst1(locs.tLoc, 0);
+		st.disableAttribConst1(locs.distStartLoc, 0);
+
+		// M4 decimation: only when the visible slice is denser than 4 samples
+		// per device pixel. Output preserves per-bucket (first,min,max,last) so
+		// vertical extrema survive the downsample.
+		const chartWidthPx = bundle.chartWidth * bundle.dpr;
+		const numBuckets = Math.max(8, Math.ceil(chartWidthPx));
+		const visibleCount = bundle.sliceEnd - bundle.sliceStart + 1;
+		const useDecim =
+			bundle.isMonotonic &&
+			bundle.cachedSegments.length === 1 &&
+			visibleCount > numBuckets * 4;
+
+		if (useDecim) {
+			drawDecimatedLines(
+				st,
+				bundle,
+				lineDecimCache,
+				lineDecimScratch,
+				chartWidthPx,
+				numBuckets,
+				baseLineWidth,
+			);
+		} else {
+			drawPlainLines(st, bundle, baseLineWidth);
+		}
+	} else {
+		drawDashedLines(
+			st,
+			bundle,
+			lStyle,
+			baseLineWidth,
+			segBuffersRef,
+			segParamsRef,
+			segBufferKey,
+		);
+	}
+}
+
+export function drawSeriesPoints(
+	st: GLStateCache,
+	bundle: SeriesDrawBundle,
+	pointDecimCache: WeakMap<Float32Array, DecimEntry>,
+	pointDecimScratch: { x: Float32Array; y: Float32Array },
+	isInteracting: boolean,
+): void {
+	if (bundle.pointStyle === "none") return;
+
+	const { gl, locs } = st;
+	const visibleCount = bundle.sliceEnd - bundle.sliceStart + 1;
+	const chartWidthPx = bundle.chartWidth * bundle.dpr;
+	const pixelDensity = visibleCount / Math.max(1, chartWidthPx);
+
+	const c = bundle.pointColorRgba;
+	const baseSize = (bundle.isHighlighted ? 8.0 : 6.0) * bundle.dpr;
+	const pStyle =
+		bundle.pointStyle === "circle" ? 0 : bundle.pointStyle === "square" ? 1 : 2;
+	st.setStyle(pStyle);
+
+	st.disableAttribConst2(locs.otherLoc, 0, 0);
+	st.disableAttribConst1(locs.tLoc, 0);
+	st.disableAttribConst1(locs.distStartLoc, 0);
+
+	// M4 point decimation: per X-pixel bucket emit (first,min,max,last) so
+	// Y-extrema survive. Only used during interaction (pan/zoom) where the
+	// visible density exceeds one sample per device pixel.
+	let useDecim = false;
+	let decimEntry: DecimEntry | null = null;
+	let decimDrawStart = 0;
+	let decimDrawCount = 0;
+	if (isInteracting && bundle.isMonotonic && pixelDensity > 1) {
+		const numBuckets = Math.max(8, Math.ceil(chartWidthPx));
+		const entry = getOrComputeM4(
+			gl,
+			pointDecimCache,
+			pointDecimScratch,
+			bundle.xData,
+			bundle.yData,
+			bundle.xRef,
+			bundle.xAxisMin,
+			bundle.xAxisMax,
+			bundle.xRange,
+			numBuckets,
+			1,
+		);
+		if (entry.xBuf && entry.yBuf && entry.count >= 1) {
+			const xArr = entry.xArr;
+			const cnt = entry.count;
+			const lowIdx = findLastLE(xArr, bundle.xAxisMin, bundle.xRef, 0);
+			const highIdx = findFirstGE(xArr, bundle.xAxisMax, bundle.xRef, cnt - 1);
+			const dStart = Math.max(0, lowIdx > 0 ? lowIdx - 1 : 0);
+			const dEnd = Math.min(
+				cnt - 1,
+				highIdx < cnt - 1 ? highIdx + 1 : highIdx,
+			);
+			if (dEnd >= dStart) {
+				useDecim = true;
+				decimEntry = entry;
+				decimDrawStart = dStart;
+				decimDrawCount = dEnd - dStart + 1;
+			}
+		}
+	}
+
+	if (useDecim && decimEntry) {
+		gl.bindBuffer(gl.ARRAY_BUFFER, decimEntry.xBuf!);
+		st.enableAttrib(locs.xLoc);
+		gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 0, 0);
+		gl.bindBuffer(gl.ARRAY_BUFFER, decimEntry.yBuf!);
+		st.enableAttrib(locs.yLoc);
+		gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 0, 0);
+	} else {
+		gl.bindBuffer(gl.ARRAY_BUFFER, bundle.xBuffer);
+		st.enableAttrib(locs.xLoc);
+		gl.vertexAttribPointer(locs.xLoc, 1, gl.FLOAT, false, 0, 0);
+		gl.bindBuffer(gl.ARRAY_BUFFER, bundle.yBuffer);
+		st.enableAttrib(locs.yLoc);
+		gl.vertexAttribPointer(locs.yLoc, 1, gl.FLOAT, false, 0, 0);
+	}
+
+	const bg = bundle.plotBgRgba;
+	st.setColor(bg[0], bg[1], bg[2], 1.0);
+	st.setPointSize(baseSize + (pStyle === 2 ? 3.0 : 2.0) * bundle.dpr);
+	if (useDecim) {
+		gl.drawArrays(gl.POINTS, decimDrawStart, decimDrawCount);
+	} else {
+		for (const seg of bundle.drawRanges) {
+			if (seg.count >= 1) gl.drawArrays(gl.POINTS, seg.start, seg.count);
+		}
+	}
+
+	st.setColor(c[0], c[1], c[2], 1.0);
+	st.setPointSize(baseSize);
+	if (useDecim) {
+		gl.drawArrays(gl.POINTS, decimDrawStart, decimDrawCount);
+	} else {
+		for (const seg of bundle.drawRanges) {
+			if (seg.count >= 1) gl.drawArrays(gl.POINTS, seg.start, seg.count);
+		}
+	}
+}
+
+export type { WebGLLocations };

--- a/src/components/Sidebar/SeriesConfig.tsx
+++ b/src/components/Sidebar/SeriesConfig.tsx
@@ -15,15 +15,13 @@ export const SeriesConfigUI: React.FC<Props> = ({
 	datasets,
 	onHandleMouseDown,
 }) => {
-	const {
-		updateSeries,
-		removeSeries,
-		yAxes,
-		updateYAxis,
-		updateSeriesVisibility,
-		series: allSeries,
-		setPreviewColor,
-	} = useGraphStore();
+	const updateSeries = useGraphStore((s) => s.updateSeries);
+	const removeSeries = useGraphStore((s) => s.removeSeries);
+	const yAxes = useGraphStore((s) => s.yAxes);
+	const updateYAxis = useGraphStore((s) => s.updateYAxis);
+	const updateSeriesVisibility = useGraphStore((s) => s.updateSeriesVisibility);
+	const allSeries = useGraphStore((s) => s.series);
+	const setPreviewColor = useGraphStore((s) => s.setPreviewColor);
 
 	const multiDs = datasets.length > 1;
 	const handleUpdate = (updates: Partial<SeriesConfig>) => {

--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -46,11 +46,16 @@ describe("useDataImport hook", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 
-		// Setup store mock
-		vi.mocked(useGraphStore).mockImplementation(() => ({
+		const storeState = {
 			addDataset: mockAddDataset,
 			addSeries: mockAddSeries,
-		}));
+		} as unknown as ReturnType<typeof useGraphStore.getState>;
+		// The hook now reads each field via a per-field selector; replicate that
+		// behaviour so the mock honours the selector function.
+		vi.mocked(useGraphStore).mockImplementation((selector?: unknown) => {
+			if (typeof selector === "function") return (selector as (s: typeof storeState) => unknown)(storeState);
+			return storeState;
+		});
 		vi.mocked(useGraphStore.getState).mockReturnValue({
 			datasets: [],
 			series: [],

--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { persistence } from "../../services/persistence";
 import { useGraphStore } from "../../store/useGraphStore";
 import type { ImportSettings } from "../../types/import";
-import { parseData } from "../../utils/data-parser";
+import { parseDataInWorker } from "../../workers/parserClient";
 import { useDataImport } from "../useDataImport";
 
 // Mock the graph store
@@ -29,9 +29,9 @@ vi.mock("../../services/persistence", () => ({
 	},
 }));
 
-// Mock the parseData function
-vi.mock("../../utils/data-parser", () => ({
-	parseData: vi.fn(),
+// Mock the parser worker client
+vi.mock("../../workers/parserClient", () => ({
+	parseDataInWorker: vi.fn(),
 }));
 
 // Mock URL.createObjectURL since JSDOM might not have it
@@ -218,15 +218,15 @@ describe("useDataImport hook", () => {
 			xAxisId: "axis-1",
 		};
 
-		vi.mocked(parseData).mockResolvedValueOnce([
+		vi.mocked(parseDataInWorker).mockResolvedValueOnce([
 			mockDataset,
-		] as unknown as ReturnType<typeof parseData>);
+		] as unknown as ReturnType<typeof parseDataInWorker>);
 
 		await act(async () => {
 			await result.current.confirmImport(settings);
 		});
 
-		expect(parseData).toHaveBeenCalledWith(file, "csv", settings);
+		expect(parseDataInWorker).toHaveBeenCalledWith(file, "csv", settings);
 		expect(mockAddDataset).toHaveBeenCalled();
 		expect(mockAddDataset.mock.calls[0][0].name).toBe("A - test.csv");
 		expect(mockAddDataset.mock.calls[0][0].columns[0]).toBe("A: Col1");
@@ -268,9 +268,9 @@ describe("useDataImport hook", () => {
 			data: [],
 		};
 
-		vi.mocked(parseData).mockResolvedValueOnce([
+		vi.mocked(parseDataInWorker).mockResolvedValueOnce([
 			mockDataset,
-		] as unknown as ReturnType<typeof parseData>);
+		] as unknown as ReturnType<typeof parseDataInWorker>);
 
 		await act(async () => {
 			await result.current.confirmImport(settings);
@@ -311,7 +311,7 @@ describe("useDataImport hook", () => {
 		};
 
 		const errorMessage = "Failed to parse JSON";
-		vi.mocked(parseData).mockRejectedValueOnce(new Error(errorMessage));
+		vi.mocked(parseDataInWorker).mockRejectedValueOnce(new Error(errorMessage));
 
 		await act(async () => {
 			await result.current.confirmImport(settings);
@@ -393,9 +393,9 @@ describe("useDataImport hook", () => {
 			xAxisId: "axis-1",
 		};
 
-		vi.mocked(parseData).mockResolvedValueOnce([
+		vi.mocked(parseDataInWorker).mockResolvedValueOnce([
 			mockDataset,
-		] as unknown as ReturnType<typeof parseData>);
+		] as unknown as ReturnType<typeof parseDataInWorker>);
 
 		await act(async () => {
 			await result.current.confirmImport(settings);
@@ -443,9 +443,9 @@ describe("useDataImport hook", () => {
 			xAxisId: "axis-1",
 		};
 
-		vi.mocked(parseData).mockResolvedValueOnce([
+		vi.mocked(parseDataInWorker).mockResolvedValueOnce([
 			mockDataset,
-		] as unknown as ReturnType<typeof parseData>);
+		] as unknown as ReturnType<typeof parseDataInWorker>);
 
 		await act(async () => {
 			await result.current.confirmImport(settings);

--- a/src/hooks/useAutoScale.ts
+++ b/src/hooks/useAutoScale.ts
@@ -8,6 +8,7 @@ import type {
 	YAxisConfig,
 } from "../services/persistence";
 import { useGraphStore } from "../store/useGraphStore";
+import { findFirstGE, findLastLE } from "../utils/binarySearch";
 import { getColumnIndex } from "../utils/columns";
 
 /**
@@ -20,26 +21,8 @@ function visibleIndexRange(
 	xMin: number,
 	xMax: number,
 ): { startIdx: number; endIdx: number } | null {
-	let startIdx = -1,
-		endIdx = -1,
-		low = 0,
-		high = xData.length - 1;
-	while (low <= high) {
-		const mid = (low + high) >>> 1;
-		if (xData[mid] + refX >= xMin) {
-			startIdx = mid;
-			high = mid - 1;
-		} else low = mid + 1;
-	}
-	low = 0;
-	high = xData.length - 1;
-	while (low <= high) {
-		const mid = (low + high) >>> 1;
-		if (xData[mid] + refX <= xMax) {
-			endIdx = mid;
-			low = mid + 1;
-		} else high = mid - 1;
-	}
+	const startIdx = findFirstGE(xData, xMin, refX, -1);
+	const endIdx = findLastLE(xData, xMax, refX, -1);
 	if (startIdx === -1 || endIdx === -1 || startIdx > endIdx) return null;
 	return { startIdx, endIdx };
 }

--- a/src/hooks/useDataImport.ts
+++ b/src/hooks/useDataImport.ts
@@ -34,7 +34,8 @@ export const useDataImport = () => {
 		selectedSheet?: string;
 		workbook?: WorkBook;
 	} | null>(null);
-	const { addDataset, addSeries } = useGraphStore();
+	const addDataset = useGraphStore((s) => s.addDataset);
+	const addSeries = useGraphStore((s) => s.addSeries);
 
 	const initiateImport = useCallback(async (file: File) => {
 		setError(null);

--- a/src/hooks/useDataImport.ts
+++ b/src/hooks/useDataImport.ts
@@ -3,8 +3,8 @@ import type { WorkBook } from "xlsx";
 import type { Dataset } from "../services/persistence";
 import { useGraphStore } from "../store/useGraphStore";
 import type { ImportSettings } from "../types/import";
-import { parseData } from "../utils/data-parser";
 import { buildSeriesConfig } from "../utils/series";
+import { parseDataInWorker } from "../workers/parserClient";
 
 const AUTO_ADD_COLUMN_THRESHOLD = 5;
 
@@ -111,11 +111,11 @@ export const useDataImport = () => {
 			}
 
 			try {
-				// To keep UI responsive during parsing of large files, we use a small timeout to allow
-				// the "isImporting" state to render before blocking the main thread.
-				await new Promise((resolve) => setTimeout(resolve, 10));
-
-				const datasets = await parseData(workerFile, workerType, settings);
+				const datasets = await parseDataInWorker(
+					workerFile,
+					workerType,
+					settings,
+				);
 				const incoming = (datasets as Dataset[]) || [];
 				const isSplitImport = incoming.length > 1;
 

--- a/src/store/__tests__/useGraphStore.test.ts
+++ b/src/store/__tests__/useGraphStore.test.ts
@@ -1,17 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Dataset } from "../../services/persistence";
-import { evaluateFormulaSync } from "../../utils/formula";
 import { useGraphStore } from "../useGraphStore";
-
-vi.mock("../../utils/formula", async () => {
-	const actual = (await vi.importActual(
-		"../../utils/formula",
-	)) as typeof import("../../utils/formula");
-	return {
-		...actual,
-		evaluateFormulaSync: vi.fn(actual.evaluateFormulaSync),
-	};
-});
 
 class MockWorker {
 	onmessage: ((ev: MessageEvent) => void) | null = null;

--- a/src/store/__tests__/useGraphStore.test.ts
+++ b/src/store/__tests__/useGraphStore.test.ts
@@ -725,13 +725,16 @@ describe("useGraphStore", () => {
 		expect(result.success).toBe(true);
 		expect(useGraphStore.getState().datasets[0].columns).toContain("NewCol");
 
-		vi.mocked(evaluateFormulaSync).mockReturnValueOnce({
-			type: "error",
-			error: "Sync error",
-		});
+		// "[Val] * 3" triggers MockWorker.onerror — the store must surface that
+		// as a failed result rather than throwing.
 		result = await store.addCalculatedColumn("ds-1", "NewCol2", "[Val] * 3");
 		expect(result.success).toBe(false);
-		expect(result.error).toBe("Sync error");
+		expect(result.error).toBeDefined();
+
+		// "[Val] * 4" returns { type: "error" } via onmessage.
+		result = await store.addCalculatedColumn("ds-1", "NewCol3", "[Val] * 4");
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("Calculation failed");
 	});
 
 	it("should create sparse dataset for sparse results", async () => {

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -605,13 +605,23 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 let viewportTimer: ReturnType<typeof setTimeout> | null = null;
 let configTimer: ReturnType<typeof setTimeout> | null = null;
 
+// Schedule low-priority work via requestIdleCallback so persistence writes
+// don't compete with a render burst. Falls back to setTimeout in non-Chromium
+// browsers and during SSR/tests.
+const requestIdle =
+	typeof globalThis.requestIdleCallback === "function"
+		? globalThis.requestIdleCallback
+		: (cb: () => void) => setTimeout(cb, 0);
+
 function debouncedSaveViewport() {
 	if (viewportTimer) clearTimeout(viewportTimer);
 	viewportTimer = setTimeout(() => {
 		viewportTimer = null;
-		const s = useGraphStore.getState();
-		if (!s.isLoaded) return;
-		persistence.saveViewport({ xAxes: s.xAxes, yAxes: s.yAxes });
+		requestIdle(() => {
+			const s = useGraphStore.getState();
+			if (!s.isLoaded) return;
+			persistence.saveViewport({ xAxes: s.xAxes, yAxes: s.yAxes });
+		});
 	}, 250);
 }
 
@@ -619,13 +629,15 @@ function debouncedSaveConfig() {
 	if (configTimer) clearTimeout(configTimer);
 	configTimer = setTimeout(() => {
 		configTimer = null;
-		const s = useGraphStore.getState();
-		if (!s.isLoaded) return;
-		persistence.saveConfig({
-			series: s.series,
-			axisTitles: s.axisTitles,
-			legendVisible: s.legendVisible,
-			crosshairVisible: s.crosshairVisible,
+		requestIdle(() => {
+			const s = useGraphStore.getState();
+			if (!s.isLoaded) return;
+			persistence.saveConfig({
+				series: s.series,
+				axisTitles: s.axisTitles,
+				legendVisible: s.legendVisible,
+				crosshairVisible: s.crosshairVisible,
+			});
 		});
 	}, 150);
 }

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -8,7 +8,8 @@ import {
 	type YAxisConfig,
 } from "../services/persistence";
 import { getColumnIndex } from "../utils/columns";
-import { compileFormula, evaluateFormulaSync } from "../utils/formula";
+import { compileFormula } from "../utils/formula";
+import { evaluateFormulaInWorker } from "../workers/formulaClient";
 
 interface GraphState {
 	datasets: Dataset[];
@@ -166,14 +167,22 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 			}));
 		}
 
-		const result = evaluateFormulaSync({
-			datasetId,
-			name: trimmedName,
-			formula,
-			columns: dataset.columns,
-			rowCount: dataset.rowCount,
-			columnData,
-		});
+		let result;
+		try {
+			result = await evaluateFormulaInWorker({
+				datasetId,
+				name: trimmedName,
+				formula,
+				columns: dataset.columns,
+				rowCount: dataset.rowCount,
+				columnData,
+			});
+		} catch (err) {
+			return {
+				success: false,
+				error: err instanceof Error ? err.message : String(err),
+			};
+		}
 
 		if (result.type === "success") {
 			const { newColumn, sparseXColumn } = result;

--- a/src/utils/__tests__/binarySearch.test.ts
+++ b/src/utils/__tests__/binarySearch.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { findClosest, findFirstGE, findLastLE } from "../binarySearch";
+
+describe("findLastLE", () => {
+	it("returns last index whose value <= target", () => {
+		const arr = [0, 1, 2, 5, 8];
+		expect(findLastLE(arr, 5)).toBe(3);
+		expect(findLastLE(arr, 6)).toBe(3);
+		expect(findLastLE(arr, 0)).toBe(0);
+	});
+
+	it("respects refOffset", () => {
+		const arr = new Float32Array([0, 1, 2, 5, 8]);
+		// values shifted by 10 -> [10,11,12,15,18]; target 12 -> idx 2
+		expect(findLastLE(arr, 12, 10)).toBe(2);
+	});
+
+	it("returns fallback when no element matches", () => {
+		expect(findLastLE([5, 6, 7], 3, 0, -1)).toBe(-1);
+	});
+});
+
+describe("findFirstGE", () => {
+	it("returns first index whose value >= target", () => {
+		const arr = [0, 1, 2, 5, 8];
+		expect(findFirstGE(arr, 3)).toBe(3);
+		expect(findFirstGE(arr, 0)).toBe(0);
+		expect(findFirstGE(arr, 8)).toBe(4);
+	});
+
+	it("respects refOffset", () => {
+		const arr = new Float32Array([0, 1, 2, 5, 8]);
+		// shifted +10 -> first >= 13 is idx 3 (value 15)
+		expect(findFirstGE(arr, 13, 10)).toBe(3);
+	});
+
+	it("returns fallback when no element matches", () => {
+		expect(findFirstGE([1, 2, 3], 10, 0, -1)).toBe(-1);
+	});
+});
+
+describe("findClosest", () => {
+	it("returns nearest index", () => {
+		const arr = [0, 10, 20, 30];
+		expect(findClosest(arr, 12)).toBe(1);
+		expect(findClosest(arr, 16)).toBe(2);
+		expect(findClosest(arr, -5)).toBe(0);
+		expect(findClosest(arr, 100)).toBe(3);
+	});
+
+	it("respects refOffset", () => {
+		const arr = new Float32Array([0, 10, 20]);
+		// shifted +5 -> [5,15,25]; closest to 14 is idx 1
+		expect(findClosest(arr, 14, 5)).toBe(1);
+	});
+
+	it("returns 0 on empty input", () => {
+		expect(findClosest([], 5)).toBe(0);
+	});
+});

--- a/src/utils/binarySearch.ts
+++ b/src/utils/binarySearch.ts
@@ -1,0 +1,73 @@
+/**
+ * Binary-search helpers over sorted numeric arrays.
+ *
+ * `refOffset` lets callers search arrays stored as deltas from a reference value
+ * (e.g. Float32 columns with a `refPoint`) without materialising the absolute values.
+ */
+
+export function findLastLE(
+	arr: ArrayLike<number>,
+	target: number,
+	refOffset = 0,
+	fallback = 0,
+): number {
+	let lo = 0;
+	let hi = arr.length - 1;
+	let result = fallback;
+	while (lo <= hi) {
+		const mid = (lo + hi) >>> 1;
+		if (arr[mid] + refOffset <= target) {
+			result = mid;
+			lo = mid + 1;
+		} else {
+			hi = mid - 1;
+		}
+	}
+	return result;
+}
+
+export function findFirstGE(
+	arr: ArrayLike<number>,
+	target: number,
+	refOffset = 0,
+	fallback = arr.length - 1,
+): number {
+	let lo = 0;
+	let hi = arr.length - 1;
+	let result = fallback;
+	while (lo <= hi) {
+		const mid = (lo + hi) >>> 1;
+		if (arr[mid] + refOffset >= target) {
+			result = mid;
+			hi = mid - 1;
+		} else {
+			lo = mid + 1;
+		}
+	}
+	return result;
+}
+
+/** Index of the element whose value is closest to `target`. Returns 0 on empty input. */
+export function findClosest(
+	arr: ArrayLike<number>,
+	target: number,
+	refOffset = 0,
+): number {
+	const n = arr.length;
+	if (n === 0) return 0;
+	let lo = 0;
+	let hi = n - 1;
+	while (lo < hi) {
+		const mid = (lo + hi) >>> 1;
+		if (arr[mid] + refOffset < target) lo = mid + 1;
+		else hi = mid;
+	}
+	if (
+		lo > 0 &&
+		Math.abs(arr[lo - 1] + refOffset - target) <
+			Math.abs(arr[lo] + refOffset - target)
+	) {
+		return lo - 1;
+	}
+	return lo;
+}

--- a/src/utils/data-parser.ts
+++ b/src/utils/data-parser.ts
@@ -64,7 +64,9 @@ export async function parseData(
 	}
 	const doSplit = splitColIdxs.length > 0;
 
-	const groups: { name: string; rowIdxs: number[] }[] = [];
+	// rowIdxs === null means "identity mapping" — every row index maps to itself.
+	// Keeps the non-split fast path from allocating a redundant index array.
+	const groups: { name: string; rowIdxs: number[] | null }[] = [];
 	if (doSplit) {
 		const valueToNames = splitColIdxs.map((idx) => {
 			const m = new Map<number, string>();
@@ -99,10 +101,7 @@ export async function parseData(
 		});
 		groups.sort((a, b) => a.name.localeCompare(b.name));
 	} else {
-		groups.push({
-			name: "",
-			rowIdxs: Array.from({ length: totalRows }, (_, i) => i),
-		});
+		groups.push({ name: "", rowIdxs: null });
 	}
 
 	// Output columns exclude the split columns themselves
@@ -115,20 +114,20 @@ export async function parseData(
 	}
 
 	const datasets = groups.map((group) => {
-		// Build per-group, per-column Float64Arrays by gathering selected row indices
 		const rowIdxs = group.rowIdxs;
-		const groupRowCount = rowIdxs.length;
-		const groupData: Float64Array[] = outputColIdxs.map((srcCol) => {
-			const src = allData[srcCol];
-			const dst = new Float64Array(groupRowCount);
-			for (let r = 0; r < groupRowCount; r++) dst[r] = src[rowIdxs[r]];
-			return dst;
-		});
-
-		const colCount = groupData.length;
+		const groupRowCount = rowIdxs === null ? totalRows : rowIdxs.length;
+		const colCount = outputColIdxs.length;
 		const relativeData = new Array(colCount);
 		for (let j = 0; j < colCount; j++) {
-			relativeData[j] = processRawColumn(groupData[j]);
+			const src = allData[outputColIdxs[j]];
+			if (rowIdxs === null) {
+				// Identity mapping — processRawColumn doesn't mutate src.
+				relativeData[j] = processRawColumn(src);
+			} else {
+				const gathered = new Float64Array(groupRowCount);
+				for (let r = 0; r < groupRowCount; r++) gathered[r] = src[rowIdxs[r]];
+				relativeData[j] = processRawColumn(gathered);
+			}
 		}
 
 		const baseName = group.name ? `${file.name} (${group.name})` : file.name;
@@ -571,47 +570,77 @@ function parseValue(
 	return Number.isNaN(p) ? NaN : p;
 }
 
+interface DateFormatIndices {
+	yIdx: number;
+	moIdx: number;
+	dIdx: number;
+	hIdx: number;
+	miIdx: number;
+	sIdx: number;
+}
+
+const dateFormatCache = new Map<string, DateFormatIndices>();
+
+function getDateFormatIndices(format: string): DateFormatIndices {
+	let cached = dateFormatCache.get(format);
+	if (cached) return cached;
+	cached = {
+		yIdx: format.indexOf("YYYY"),
+		moIdx: format.indexOf("MM"),
+		dIdx: format.indexOf("DD"),
+		hIdx: format.indexOf("HH"),
+		miIdx: format.indexOf("mm"),
+		sIdx: format.indexOf("ss"),
+	};
+	dateFormatCache.set(format, cached);
+	return cached;
+}
+
 function parseDate(val: string, format?: string): number {
 	if (!format) {
 		const d = new Date(val);
 		return d.getTime() / 1000;
 	}
 
-	// Basic format parser (YYYY, MM, DD, HH, mm, ss)
-	try {
-		let year = 1970,
-			month = 0,
-			day = 1,
-			hour = 0,
-			min = 0,
-			sec = 0;
+	const idx = getDateFormatIndices(format);
+	let year = 1970;
+	let month = 0;
+	let day = 1;
+	let hour = 0;
+	let min = 0;
+	let sec = 0;
 
-		const parts = {
-			YYYY: { idx: format.indexOf("YYYY"), len: 4 },
-			MM: { idx: format.indexOf("MM"), len: 2 },
-			DD: { idx: format.indexOf("DD"), len: 2 },
-			HH: { idx: format.indexOf("HH"), len: 2 },
-			mm: { idx: format.indexOf("mm"), len: 2 },
-			ss: { idx: format.indexOf("ss"), len: 2 },
-		};
+	if (idx.yIdx !== -1)
+		year = parseInt(val.substring(idx.yIdx, idx.yIdx + 4), 10);
+	if (idx.moIdx !== -1)
+		month = parseInt(val.substring(idx.moIdx, idx.moIdx + 2), 10) - 1;
+	if (idx.dIdx !== -1)
+		day = parseInt(val.substring(idx.dIdx, idx.dIdx + 2), 10);
+	if (idx.hIdx !== -1)
+		hour = parseInt(val.substring(idx.hIdx, idx.hIdx + 2), 10);
+	if (idx.miIdx !== -1)
+		min = parseInt(val.substring(idx.miIdx, idx.miIdx + 2), 10);
+	if (idx.sIdx !== -1)
+		sec = parseInt(val.substring(idx.sIdx, idx.sIdx + 2), 10);
 
-		if (parts.YYYY.idx !== -1)
-			year = parseInt(val.substring(parts.YYYY.idx, parts.YYYY.idx + 4), 10);
-		if (parts.MM.idx !== -1)
-			month = parseInt(val.substring(parts.MM.idx, parts.MM.idx + 2), 10) - 1;
-		if (parts.DD.idx !== -1)
-			day = parseInt(val.substring(parts.DD.idx, parts.DD.idx + 2), 10);
-		if (parts.HH.idx !== -1)
-			hour = parseInt(val.substring(parts.HH.idx, parts.HH.idx + 2), 10);
-		if (parts.mm.idx !== -1)
-			min = parseInt(val.substring(parts.mm.idx, parts.mm.idx + 2), 10);
-		if (parts.ss.idx !== -1)
-			sec = parseInt(val.substring(parts.ss.idx, parts.ss.idx + 2), 10);
-
-		const d = new Date(year, month, day, hour, min, sec);
-		return d.getTime() / 1000;
-	} catch {
-		const d = new Date(val);
-		return d.getTime() / 1000;
+	// Match the previous local-time semantics (new Date(y, m, d, h, mi, s)) while
+	// skipping the per-row Date allocation. Falls back to Date parsing if the
+	// computed fields are out of range (e.g. malformed value).
+	if (
+		Number.isFinite(year) &&
+		Number.isFinite(month) &&
+		Number.isFinite(day) &&
+		Number.isFinite(hour) &&
+		Number.isFinite(min) &&
+		Number.isFinite(sec)
+	) {
+		dateScratch.setFullYear(year, month, day);
+		dateScratch.setHours(hour, min, sec, 0);
+		return dateScratch.getTime() / 1000;
 	}
+
+	const d = new Date(val);
+	return d.getTime() / 1000;
 }
+
+const dateScratch = new Date();

--- a/src/utils/decimation.ts
+++ b/src/utils/decimation.ts
@@ -3,6 +3,8 @@
  * Per bucket: emit (first, last, min, max) — preserves visible extrema for line plots.
  */
 
+import { findFirstGE } from "./binarySearch";
+
 /**
  * Pixel-anchored M4 decimation. Buckets are X-world intervals tied to screen pixels,
  * so bucket boundaries do not shift with slice length — eliminates sample jumping under zoom.
@@ -51,19 +53,7 @@ export function m4ByXFloat32(
 	let outIdx = 0;
 	const bucket = [0, 0, 0, 0];
 
-	let i = 0;
-	let low = 0;
-	let high = n - 1;
-	const target = gridStart - xRef;
-	while (low <= high) {
-		const mid = (low + high) >>> 1;
-		if (xData[mid] < target) {
-			low = mid + 1;
-		} else {
-			high = mid - 1;
-		}
-	}
-	i = low;
+	let i = findFirstGE(xData, gridStart - xRef, 0, n);
 
 	// Continuity anchor: emit last point before xMin (if any, non-NaN) so the line
 	// enters from the left edge instead of starting inside the viewport.

--- a/src/utils/formula.ts
+++ b/src/utils/formula.ts
@@ -987,18 +987,12 @@ export function evaluateFormulaSync(
 			const orderLen = compactX.length;
 			const order = new Uint32Array(orderLen);
 			for (let i = 0; i < orderLen; i++) order[i] = i;
-			const orderSorted = Array.prototype.sort.call(order, (a, b) =>
-				compactX[a] - compactX[b] > 0
-					? 1
-					: compactX[a] - compactX[b] < 0
-						? -1
-						: 0,
-			) as Uint32Array;
+			order.sort((a, b) => compactX[a] - compactX[b]);
 			const sortedX = new Float64Array(orderLen);
 			const sortedY = new Float64Array(orderLen);
 			for (let i = 0; i < orderLen; i++) {
-				sortedX[i] = compactX[orderSorted[i]];
-				sortedY[i] = compactY[orderSorted[i]];
+				sortedX[i] = compactX[order[i]];
+				sortedY[i] = compactY[order[i]];
 			}
 
 			const processedX = processRawColumn(sortedX);

--- a/src/utils/formula.ts
+++ b/src/utils/formula.ts
@@ -179,33 +179,6 @@ function evaluateFuncToken(
 	}
 }
 
-function evaluateOpToken(
-	token: Extract<Token, { type: "OP" }>,
-	stack: number[],
-): number {
-	if (token.unary) {
-		const a = stack.pop() ?? 0;
-		if (token.value === "u-") return -a;
-		return a;
-	}
-	const b = stack.pop() ?? 0;
-	const a = stack.pop() ?? 0;
-	switch (token.value) {
-		case "+":
-			return a + b;
-		case "-":
-			return a - b;
-		case "*":
-			return a * b;
-		case "/":
-			return a / b;
-		case "^":
-			return a ** b;
-		default:
-			return a;
-	}
-}
-
 export function compileFormula(
 	formula: string,
 	availableColumns: string[],
@@ -653,35 +626,66 @@ export function compileFormula(
 			return ctx;
 		};
 
+		// Pre-allocated stack + args scratch — reused across every row evaluation.
+		// The shunting-yard output rarely needs more than a handful of stack slots,
+		// but 64 leaves headroom for deeply nested expressions without bounds checks.
+		const stack = new Float64Array(64);
+		const argsScratch: number[] = [];
+
 		return {
 			usedColumnIndices,
 			createContext,
 			evaluate: (rowValues: number[], ctx?: FormulaContext) => {
-				const stack: number[] = [];
-				for (const token of outputQueue) {
-					if (token.type === "NUMBER") stack.push(token.value);
-					else if (token.type === "CONST") stack.push(token.value);
-					else if (token.type === "VAR") stack.push(rowValues[token.index]);
-					else if (token.type === "FUNC") {
+				let sp = 0;
+				for (let i = 0; i < outputQueue.length; i++) {
+					const token = outputQueue[i];
+					const type = token.type;
+					if (type === "NUMBER" || type === "CONST") {
+						stack[sp++] = token.value;
+					} else if (type === "VAR") {
+						stack[sp++] = rowValues[token.index];
+					} else if (type === "FUNC") {
 						const argCount = token.args !== undefined ? token.args : 1;
-						const args: number[] = [];
-						for (let j = 0; j < argCount; j++) args.push(stack.pop()!);
-						args.reverse();
-
-						stack.push(
-							evaluateFuncToken(
-								token as Extract<Token, { type: "FUNC" }>,
-								args,
-								rowValues,
-								finalDataColumnIndices,
-								timeVarIdx,
-								ctx,
-							),
+						argsScratch.length = argCount;
+						for (let j = argCount - 1; j >= 0; j--) argsScratch[j] = stack[--sp];
+						stack[sp++] = evaluateFuncToken(
+							token,
+							argsScratch,
+							rowValues,
+							finalDataColumnIndices,
+							timeVarIdx,
+							ctx,
 						);
-					} else if (token.type === "OP") {
-						stack.push(
-							evaluateOpToken(token as Extract<Token, { type: "OP" }>, stack),
-						);
+					} else if (type === "OP") {
+						const op = token.value;
+						if (token.unary) {
+							const a = stack[--sp];
+							stack[sp++] = op === "u-" ? -a : a;
+						} else {
+							const b = stack[--sp];
+							const a = stack[--sp];
+							let r: number;
+							switch (op) {
+								case "+":
+									r = a + b;
+									break;
+								case "-":
+									r = a - b;
+									break;
+								case "*":
+									r = a * b;
+									break;
+								case "/":
+									r = a / b;
+									break;
+								case "^":
+									r = a ** b;
+									break;
+								default:
+									r = a;
+							}
+							stack[sp++] = r;
+						}
 					}
 				}
 				return stack[0];
@@ -980,11 +984,22 @@ export function evaluateFormulaSync(
 
 			const compactX = new Float64Array(repXVals);
 			const compactY = new Float64Array(repYVals);
-			const order = Array.from({ length: compactX.length }, (_, i) => i).sort(
-				(a, b) => compactX[a] - compactX[b],
-			);
-			const sortedX = new Float64Array(order.map((i) => compactX[i]));
-			const sortedY = new Float64Array(order.map((i) => compactY[i]));
+			const orderLen = compactX.length;
+			const order = new Uint32Array(orderLen);
+			for (let i = 0; i < orderLen; i++) order[i] = i;
+			const orderSorted = Array.prototype.sort.call(order, (a, b) =>
+				compactX[a] - compactX[b] > 0
+					? 1
+					: compactX[a] - compactX[b] < 0
+						? -1
+						: 0,
+			) as Uint32Array;
+			const sortedX = new Float64Array(orderLen);
+			const sortedY = new Float64Array(orderLen);
+			for (let i = 0; i < orderLen; i++) {
+				sortedX[i] = compactX[orderSorted[i]];
+				sortedY[i] = compactY[orderSorted[i]];
+			}
 
 			const processedX = processRawColumn(sortedX);
 			const processedY = processRawColumn(sortedY);

--- a/src/workers/formula.worker.ts
+++ b/src/workers/formula.worker.ts
@@ -1,0 +1,25 @@
+/// <reference lib="webworker" />
+
+import {
+	evaluateFormulaSync,
+	type FormulaEvaluationResult,
+	type FormulaWorkerParams,
+} from "../utils/formula";
+
+self.onmessage = (ev: MessageEvent<FormulaWorkerParams>) => {
+	const params = ev.data;
+	try {
+		const result = evaluateFormulaSync(params);
+		const transferables: ArrayBuffer[] = [];
+		if (result.newColumn) transferables.push(result.newColumn.data.buffer as ArrayBuffer);
+		if (result.sparseXColumn)
+			transferables.push(result.sparseXColumn.data.buffer as ArrayBuffer);
+		(self as DedicatedWorkerGlobalScope).postMessage(result, transferables);
+	} catch (err) {
+		const response: FormulaEvaluationResult = {
+			type: "error",
+			error: err instanceof Error ? err.message : String(err),
+		};
+		(self as DedicatedWorkerGlobalScope).postMessage(response);
+	}
+};

--- a/src/workers/formulaClient.ts
+++ b/src/workers/formulaClient.ts
@@ -1,0 +1,47 @@
+import type {
+	FormulaEvaluationResult,
+	FormulaWorkerParams,
+} from "../utils/formula";
+
+let worker: Worker | null = null;
+let currentResolver:
+	| {
+			resolve: (value: FormulaEvaluationResult) => void;
+			reject: (reason: unknown) => void;
+	  }
+	| null = null;
+
+function ensureWorker(): Worker {
+	if (worker) return worker;
+	worker = new Worker(new URL("./formula.worker.ts", import.meta.url), {
+		type: "module",
+	});
+	worker.onmessage = (ev: MessageEvent<FormulaEvaluationResult>) => {
+		const r = currentResolver;
+		currentResolver = null;
+		r?.resolve(ev.data);
+	};
+	worker.onerror = (ev) => {
+		const r = currentResolver;
+		currentResolver = null;
+		const err = ev instanceof Error ? ev : new Error(ev.message ?? "Worker error");
+		r?.reject(err);
+	};
+	return worker;
+}
+
+export function evaluateFormulaInWorker(
+	params: FormulaWorkerParams,
+): Promise<FormulaEvaluationResult> {
+	const w = ensureWorker();
+	return new Promise<FormulaEvaluationResult>((resolve, reject) => {
+		// Single-flight semantics — the store awaits each formula before issuing
+		// the next one, so a queue isn't necessary. Reject any in-flight call if
+		// a new one arrives concurrently to surface programmer error early.
+		if (currentResolver) {
+			currentResolver.reject(new Error("Formula worker preempted"));
+		}
+		currentResolver = { resolve, reject };
+		w.postMessage(params);
+	});
+}

--- a/src/workers/parser.worker.ts
+++ b/src/workers/parser.worker.ts
@@ -1,0 +1,45 @@
+/// <reference lib="webworker" />
+
+import type { Dataset } from "../services/persistence";
+import { parseData, type ParseSettings } from "../utils/data-parser";
+
+export interface ParserRequest {
+	id: number;
+	file: File;
+	type: string;
+	settings?: ParseSettings;
+}
+
+export interface ParserResponse {
+	id: number;
+	type: "success" | "error";
+	datasets?: Dataset[];
+	error?: string;
+}
+
+function collectTransferables(datasets: Dataset[]): ArrayBuffer[] {
+	const buffers: ArrayBuffer[] = [];
+	for (const ds of datasets) {
+		for (const col of ds.data) {
+			buffers.push(col.data.buffer as ArrayBuffer);
+		}
+	}
+	return buffers;
+}
+
+self.onmessage = async (ev: MessageEvent<ParserRequest>) => {
+	const { id, file, type, settings } = ev.data;
+	try {
+		const datasets = (await parseData(file, type, settings)) as Dataset[];
+		const transferables = collectTransferables(datasets);
+		const response: ParserResponse = { id, type: "success", datasets };
+		(self as DedicatedWorkerGlobalScope).postMessage(response, transferables);
+	} catch (err) {
+		const response: ParserResponse = {
+			id,
+			type: "error",
+			error: err instanceof Error ? err.message : String(err),
+		};
+		(self as DedicatedWorkerGlobalScope).postMessage(response);
+	}
+};

--- a/src/workers/parserClient.ts
+++ b/src/workers/parserClient.ts
@@ -1,0 +1,45 @@
+import type { Dataset } from "../services/persistence";
+import type { ParseSettings } from "../utils/data-parser";
+import type { ParserRequest, ParserResponse } from "./parser.worker";
+
+let worker: Worker | null = null;
+let nextId = 1;
+const pending = new Map<
+	number,
+	{ resolve: (value: Dataset[]) => void; reject: (reason: unknown) => void }
+>();
+
+function ensureWorker(): Worker {
+	if (worker) return worker;
+	worker = new Worker(new URL("./parser.worker.ts", import.meta.url), {
+		type: "module",
+	});
+	worker.onmessage = (ev: MessageEvent<ParserResponse>) => {
+		const { id, type, datasets, error } = ev.data;
+		const entry = pending.get(id);
+		if (!entry) return;
+		pending.delete(id);
+		if (type === "success" && datasets) entry.resolve(datasets);
+		else entry.reject(new Error(error ?? "Parser worker error"));
+	};
+	worker.onerror = (ev) => {
+		const err = ev instanceof Error ? ev : new Error(ev.message ?? "Worker error");
+		for (const entry of pending.values()) entry.reject(err);
+		pending.clear();
+	};
+	return worker;
+}
+
+export function parseDataInWorker(
+	file: File,
+	type: string,
+	settings?: ParseSettings,
+): Promise<Dataset[]> {
+	const id = nextId++;
+	const w = ensureWorker();
+	return new Promise<Dataset[]>((resolve, reject) => {
+		pending.set(id, { resolve, reject });
+		const req: ParserRequest = { id, file, type, settings };
+		w.postMessage(req);
+	});
+}


### PR DESCRIPTION
Implements items A–J from the audit plan that came out of `/ultraplan`. All 360 existing tests still pass; lint stays at the pre-PR baseline (9 problems, all in files I didn't touch); `npm run build` succeeds.

## Shape

```
File drop / formula apply ──► parserClient / formulaClient
                              └─► parser.worker.ts  / formula.worker.ts
                                  (zero-copy Float32Array buffers back)
                                                    │
                                                    ▼
WebGLRenderer.tsx (~270 lines)                useGraphStore
  ├ GLStateCache         (new)
  ├ drawOverlay          (new, drawSeries.ts)
  ├ drawSeriesLines      (new)
  └ drawSeriesPoints     (new)
                                                    ▲
                          utils/binarySearch.ts  ───┘ (renderer, Crosshair, useAutoScale, decimation)
```

## Items implemented

- **A — Workers**: new `src/workers/{parser,formula}.{worker,Client}.ts`. `parseDataInWorker` and `evaluateFormulaInWorker` post requests with transferable Float32Array buffers. `useDataImport` and `useGraphStore.addCalculatedColumn` await the worker. Vite emits each worker as its own chunk; main bundle shrinks ~12 kB.
- **B — Renderer split**: the 738-line `drawFrame` `useEffect` is now ~230 lines. Helper closures (`setColor`, `setStyle`, `enableAttrib`, …) live in `GLStateCache` and are reused across renders instead of being reallocated. Per-series drawing moved to `drawSeries.ts`.
- **C — M4 dedup**: a single `getOrComputeM4(…, bucketDivisor)` backs both line (`bucketDivisor=3`) and point (`bucketDivisor=1`) decimation caches. Incidentally fixes a sig-keying inconsistency where the line cache mixed `colY.refPoint` into a key that should depend only on `xRef`.
- **D — Binary search util**: new `src/utils/binarySearch.ts` with `findLastLE` / `findFirstGE` / `findClosest`. Replaces ad-hoc binary searches in `WebGLRenderer`, `Crosshair`, `useAutoScale`, and `decimation`.
- **E — `parseDate`**: per-format index struct cached once, scratch `Date` reused, no per-row allocation. Local-time semantics preserved.
- **F — Formula RPN**: `Float64Array` stack with `sp` pointer; OP dispatch inlined; FUNC args reuse a scratch array — no per-row allocations in the hot path.
- **G — Selectors**: `App`, `SeriesConfig`, `CalculatedColumnModal`, and `useDataImport` now read each Zustand action with its own selector, so unrelated store changes no longer trigger re-renders.
- **H — Index sequences**: the redundant `rowIdxs` array on the non-split parser path is gone (identity mapping = `null` sentinel); `formula` sort-order uses `Uint32Array`.
- **I — Persistence via `requestIdleCallback`**: viewport/config saves now run on idle (falling back to `setTimeout`).
- **J — README sync**: the line claiming workers parse data is now true.

## Test plan

- [x] `npm run lint` — same baseline as before (no new errors)
- [x] `npm run test` — 360/360 passing
- [x] `npm run build` — clean; workers emitted as separate chunks
- [ ] Manual: drop a >1M-row CSV, confirm UI stays interactive while parsing
- [ ] Manual: apply `polyreg([y], 8)` on a large dataset, confirm UI stays responsive
- [ ] Manual: pan/zoom in the demo dataset, confirm no visual regressions

https://claude.ai/code/session_01WeyZX8wq5ty88NyEWWLyHt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeyZX8wq5ty88NyEWWLyHt)_