### PR TITLE
fix: Correctly parse CSV delimiters within double quotes

### DIFF
--- a/src/components/Layout/ImportSettingsDialog.tsx
+++ b/src/components/Layout/ImportSettingsDialog.tsx
@@ -7,6 +7,7 @@ import type {
 	ImportSettings,
 } from "../../types/import";
 import { secureJSONParse } from "../../utils/json";
+import { splitCSVLine } from "../../utils/data-parser";
 import { Modal } from "./Modal";
 
 interface ImportSettingsDialogProps {
@@ -199,14 +200,12 @@ export const ImportSettingsDialog: React.FC<ImportSettingsDialogProps> = ({
 		const headerRowIndex = Math.max(0, deferredStartRow - 1);
 		const skippedLines = lines.slice(0, headerRowIndex);
 		const headerLine = lines[headerRowIndex] || "";
-		const headers = headerLine
-			.split(deferredDelimiter)
+		const headers = splitCSVLine(headerLine, deferredDelimiter)
 			.map((h) => h.trim().replace(/^"|"$/g, ""));
 		const rows = lines
 			.slice(headerRowIndex + 1, headerRowIndex + 51)
 			.map((line) =>
-				line
-					.split(deferredDelimiter)
+				splitCSVLine(line, deferredDelimiter)
 					.map((v) => v.trim().replace(/^"|"$/g, "")),
 			);
 		return { headers, rows, skippedLines };

--- a/src/utils/data-parser.ts
+++ b/src/utils/data-parser.ts
@@ -169,14 +169,37 @@ export async function parseData(
 	return datasets;
 }
 
+export function splitCSVLine(line: string, delimiter: string): string[] {
+	if (delimiter.length === 1) {
+		const delimChar = delimiter.charCodeAt(0);
+		const vals: string[] = [];
+		let start = 0;
+		const lineLen = line.length;
+		let inQuote = false;
+
+		for (let i = 0; i < lineLen; i++) {
+			const c = line.charCodeAt(i);
+			if (c === 34) {
+				inQuote = !inQuote;
+			} else if (c === delimChar && !inQuote) {
+				vals.push(line.substring(start, i));
+				start = i + 1;
+			}
+		}
+		vals.push(line.substring(start));
+		return vals;
+	}
+
+	return line.split(delimiter);
+}
+
 function processCSVHeader(
 	line: string,
 	delimiter: string,
 	columnConfigs: ColumnConfigEntry[],
 	capacity: number,
 ) {
-	const headers = line
-		.split(delimiter)
+	const headers = splitCSVLine(line, delimiter)
 		.map((h) => h.trim().replace(/^"|"$/g, ""));
 
 	const configMap = new Map<number, ColumnConfigEntry>();
@@ -246,7 +269,14 @@ function processCSVRow(
 
 			// Fast forward to target column
 			while (currentCol < targetCol && start < lineLen) {
-				while (start < lineLen && line.charCodeAt(start) !== delimChar) {
+				let inQuote = false;
+				while (start < lineLen) {
+					const c = line.charCodeAt(start);
+					if (c === 34) {
+						inQuote = !inQuote;
+					} else if (c === delimChar && !inQuote) {
+						break;
+					}
 					start++;
 				}
 				if (start < lineLen) {
@@ -258,7 +288,14 @@ function processCSVRow(
 			let val = "";
 			if (start < lineLen) {
 				let end = start;
-				while (end < lineLen && line.charCodeAt(end) !== delimChar) {
+				let inQuote = false;
+				while (end < lineLen) {
+					const c = line.charCodeAt(end);
+					if (c === 34) {
+						inQuote = !inQuote;
+					} else if (c === delimChar && !inQuote) {
+						break;
+					}
 					end++;
 				}
 


### PR DESCRIPTION
Fixes an issue where CSV delimiters inside double quotes were incorrectly parsed as column separators. Excel files imported natively wrap comma-containing cells in double quotes under the hood before CSV processing, which resulted in data shift or corruption.

- Extracted quote-aware split logic to a `splitCSVLine` helper utility in `data-parser.ts`
- Applied `splitCSVLine` to `processCSVHeader` and the `ImportSettingsDialog.tsx` data preview table
- Updated the optimized inline `charCodeAt` scanning logic in `processCSVRow` to track quote states and safely skip delimiters enclosed in double quotes.

---
*PR created automatically by Jules for task [22915750577179519](https://jules.google.com/task/22915750577179519) started by @michaelkrisper*