### PR TITLE
🔒 fix: Prevent Template Literal Injection by Escaping Backticks

### DIFF
--- a/src/utils/__tests__/dom.test.ts
+++ b/src/utils/__tests__/dom.test.ts
@@ -15,6 +15,12 @@ describe("escapeHTML", () => {
 		expect(escapeHTML(input)).toBe(expected);
 	});
 
+	it("should escape backticks", () => {
+		const input = "Template `literal` injection";
+		const expected = "Template &#x60;literal&#x60; injection";
+		expect(escapeHTML(input)).toBe(expected);
+	});
+
 	it("should handle strings without special characters", () => {
 		const input = "Normal string 123";
 		expect(escapeHTML(input)).toBe(input);

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -10,5 +10,6 @@ export function escapeHTML(str: string | undefined | null): string {
 		.replace(/>/g, "&gt;")
 		.replace(/"/g, "&quot;")
 		.replace(/'/g, "&#039;")
-		.replace(/=/g, "&#061;");
+		.replace(/=/g, "&#061;")
+		.replace(/`/g, "&#x60;");
 }


### PR DESCRIPTION
🎯 **What:** Added backtick (`` ` ``) escaping to the `escapeHTML` function in `src/utils/dom.ts`.
⚠️ **Risk:** Output generated by `escapeHTML` used within JavaScript template literals could be vulnerable to Template Literal Injection (XSS), potentially allowing an attacker to execute arbitrary code.
🛡️ **Solution:** Added `.replace(/`/g, "&#x60;")` to safely encode backticks, completely mitigating template literal injection risks while preserving existing escaping. Added a unit test.

---
*PR created automatically by Jules for task [15099256667537276001](https://jules.google.com/task/15099256667537276001) started by @michaelkrisper*