### PR TITLE
🧪 test(usePanZoom): add tests for panning and zooming behavior

### DIFF
--- a/src/hooks/__tests__/usePanZoom.test.tsx
+++ b/src/hooks/__tests__/usePanZoom.test.tsx
@@ -1,0 +1,203 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { usePanZoom } from "../usePanZoom";
+
+describe("usePanZoom", () => {
+	const mockSyncViewport = vi.fn();
+	const mockHandleAutoScaleX = vi.fn();
+	const mockHandleAutoScaleY = vi.fn();
+	const mockOnPanEnd = vi.fn();
+
+	let baseOptions: any;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.stubGlobal("requestAnimationFrame", (cb: Function) => setTimeout(cb, 0));
+		vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
+
+		const containerRef = {
+			current: {
+				getBoundingClientRect: () => ({
+					left: 0,
+					top: 0,
+					width: 800,
+					height: 600,
+				}),
+			},
+		};
+
+		const activeXAxes = [{ id: "x1", min: 0, max: 100 }];
+		const activeYAxes = [{ id: "y1", min: 0, max: 100 }];
+
+		baseOptions = {
+			containerRef,
+			width: 800,
+			height: 600,
+			padding: { top: 10, right: 10, bottom: 10, left: 10 },
+			chartWidth: 780,
+			chartHeight: 580,
+			activeXAxes,
+			activeYAxes,
+			xAxesById: new Map([["x1", activeXAxes[0]]]),
+			yAxesById: new Map([["y1", activeYAxes[0]]]),
+			targetXAxes: { current: { x1: { min: 0, max: 100 } } },
+			targetYs: { current: { y1: { min: 0, max: 100 } } },
+			syncViewport: mockSyncViewport,
+			xAxesMetrics: [],
+			axisLayout: {},
+			leftAxes: [],
+			rightAxes: [],
+			handleAutoScaleX: mockHandleAutoScaleX,
+			handleAutoScaleY: mockHandleAutoScaleY,
+			pressedKeys: { current: new Set() },
+			onPanEnd: mockOnPanEnd,
+			panStateRef: {
+				current: {
+					active: false,
+					startX: 0,
+					startY: 0,
+					currentX: 0,
+					currentY: 0,
+					target: null,
+					startTargetX: {},
+					startTargetY: {},
+				},
+			},
+		};
+	});
+
+	afterEach(() => {
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it("initializes correctly", () => {
+		const { result } = renderHook(() => usePanZoom(baseOptions));
+
+		expect(result.current.panTarget).toBeNull();
+		expect(result.current.isInteracting).toBe(false);
+		expect(result.current.isZooming).toBe(false);
+	});
+
+	it("handles mouse down and start panning", () => {
+		const { result } = renderHook(() => usePanZoom(baseOptions));
+
+		act(() => {
+			result.current.handleMouseDown(
+				{ clientX: 100, clientY: 100, button: 0 } as any,
+				"all"
+			);
+		});
+
+		expect(result.current.panTarget).toBe("all");
+		expect(result.current.isInteracting).toBe(true);
+	});
+
+	it("handles mouse panning correctly", () => {
+		const { result } = renderHook(() => usePanZoom(baseOptions));
+
+		act(() => {
+			result.current.handleMouseDown(
+				{ clientX: 100, clientY: 100, button: 0 } as any,
+				"all"
+			);
+		});
+
+		// Simulate global mousemove
+		act(() => {
+			const moveEvent = new MouseEvent("mousemove", {
+				clientX: 150,
+				clientY: 120,
+			});
+			window.dispatchEvent(moveEvent);
+			vi.advanceTimersByTime(16); // advance rAF
+		});
+
+		// Mouse moved dx=50, dy=20
+		// shiftWorld = -dx / (chartWidth / range) = -50 / (780 / 100) = -50 / 7.8 = -6.41
+		const newXMin = baseOptions.targetXAxes.current["x1"].min;
+		expect(newXMin).toBeLessThan(0); // Should have panned left
+	});
+
+	it("handles mouse up and ends panning", () => {
+		const { result } = renderHook(() => usePanZoom(baseOptions));
+
+		act(() => {
+			result.current.handleMouseDown(
+				{ clientX: 100, clientY: 100, button: 0 } as any,
+				"all"
+			);
+		});
+
+		act(() => {
+			const upEvent = new MouseEvent("mouseup");
+			window.dispatchEvent(upEvent);
+		});
+
+		expect(result.current.panTarget).toBeNull();
+		expect(mockOnPanEnd).toHaveBeenCalled();
+	});
+
+	it("handles wheel zoom correctly", () => {
+		const { result } = renderHook(() => usePanZoom(baseOptions));
+
+		act(() => {
+			const preventDefault = vi.fn();
+			result.current.handleWheel(
+				{
+					clientX: 400,
+					clientY: 300,
+					deltaY: 100,
+					preventDefault,
+				} as any,
+				"all"
+			);
+		});
+
+		// Wheel logic synchronously updates targetAxes
+		expect(baseOptions.targetXAxes.current["x1"].min).toBeLessThan(0);
+		expect(baseOptions.targetXAxes.current["x1"].max).toBeGreaterThan(100);
+		expect(mockSyncViewport).toHaveBeenCalled();
+
+		act(() => {
+			vi.runAllTimers();
+		});
+	});
+
+	it("handles single touch down", () => {
+		const { result } = renderHook(() => usePanZoom(baseOptions));
+
+		act(() => {
+			result.current.handleTouchStart(
+				{ touches: [{ clientX: 100, clientY: 100 }] } as any,
+				"all"
+			);
+		});
+
+		expect(result.current.panTarget).toBe("all");
+	});
+
+	it("handles double tap to auto scale", () => {
+		const { result } = renderHook(() => usePanZoom(baseOptions));
+
+		act(() => {
+			result.current.handleTouchStart(
+				{ touches: [{ clientX: 100, clientY: 100 }] } as any,
+				"all"
+			);
+		});
+
+		// Trigger another touch immediately
+		act(() => {
+			result.current.handleTouchStart(
+				{ touches: [{ clientX: 100, clientY: 100 }] } as any,
+				"all"
+			);
+		});
+
+		expect(mockHandleAutoScaleX).toHaveBeenCalled();
+		expect(mockHandleAutoScaleY).toHaveBeenCalledWith("y1");
+	});
+});


### PR DESCRIPTION
🎯 **What:** The `usePanZoom` hook was completely untested, leaving complex pan, zoom, and touch event tracking logic vulnerable to regressions.

📊 **Coverage:** This PR introduces `usePanZoom.test.tsx` testing the following scenarios:
- Proper state initialization
- Mouse panning gestures (combining mousedown, global mousemove, and mouseup) with `requestAnimationFrame` handling.
- Wheel zoom events altering axis boundaries
- Single-touch pan setup
- Double-tap auto-scaling functionality.

✨ **Result:** Solidifies regression protection for core interaction routines by fully covering happy paths and core edge cases of the `usePanZoom` hook using vitest and fake timers.

---
*PR created automatically by Jules for task [10732434217092234352](https://jules.google.com/task/10732434217092234352) started by @michaelkrisper*