### PR TITLE
chore: fix 26 lint errors in test files

### DIFF
--- a/src/components/Layout/__tests__/CalculatedColumnModal.test.tsx
+++ b/src/components/Layout/__tests__/CalculatedColumnModal.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
 import { CalculatedColumnModal } from "../CalculatedColumnModal";
 import { useGraphStore } from "../../../store/useGraphStore";
+import type { Dataset } from "../../../services/persistence";
 
 // Mock the graph store
 vi.mock("../../../store/useGraphStore", () => ({
@@ -19,7 +21,7 @@ describe("CalculatedColumnModal", () => {
 		name: "Test Dataset",
 		columns: ["A", "B"],
 		data: [[1, 2]],
-	};
+	} as unknown as Dataset;
 
 	const mockOnClose = vi.fn();
 	const mockAddCalculatedColumn = vi.fn();
@@ -29,18 +31,24 @@ describe("CalculatedColumnModal", () => {
 		vi.clearAllMocks();
 
 		// Setup useGraphStore mock implementation
-		(useGraphStore as any).mockImplementation((selector: any) => {
-			const state = {
-				addCalculatedColumn: mockAddCalculatedColumn,
-				removeCalculatedColumn: mockRemoveCalculatedColumn,
-			};
-			return selector(state);
-		});
+		type StoreState = {
+			addCalculatedColumn: typeof mockAddCalculatedColumn;
+			removeCalculatedColumn: typeof mockRemoveCalculatedColumn;
+		};
+		(useGraphStore as unknown as Mock).mockImplementation(
+			(selector: (state: StoreState) => unknown) => {
+				const state: StoreState = {
+					addCalculatedColumn: mockAddCalculatedColumn,
+					removeCalculatedColumn: mockRemoveCalculatedColumn,
+				};
+				return selector(state);
+			},
+		);
 	});
 
 	it("renders correctly for adding a new column", () => {
 		render(
-			<CalculatedColumnModal dataset={mockDataset as any} onClose={mockOnClose} />
+			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
 		);
 
 		expect(screen.getByText("Add Calculated Series")).toBeDefined();
@@ -51,7 +59,7 @@ describe("CalculatedColumnModal", () => {
 	it("renders correctly for editing an existing column", () => {
 		render(
 			<CalculatedColumnModal
-				dataset={mockDataset as any}
+				dataset={mockDataset}
 				onClose={mockOnClose}
 				initialName="Calc A"
 				initialFormula="[A] * 2"
@@ -70,7 +78,7 @@ describe("CalculatedColumnModal", () => {
 		});
 
 		render(
-			<CalculatedColumnModal dataset={mockDataset as any} onClose={mockOnClose} />
+			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
 		);
 
 		// Fill inputs
@@ -101,7 +109,7 @@ describe("CalculatedColumnModal", () => {
 		mockAddCalculatedColumn.mockRejectedValueOnce(new Error("Network Error"));
 
 		render(
-			<CalculatedColumnModal dataset={mockDataset as any} onClose={mockOnClose} />
+			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
 		);
 
 		// Fill inputs
@@ -132,7 +140,7 @@ describe("CalculatedColumnModal", () => {
         mockAddCalculatedColumn.mockRejectedValueOnce("String error throw");
 
 		render(
-			<CalculatedColumnModal dataset={mockDataset as any} onClose={mockOnClose} />
+			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
 		);
 
 		// Fill inputs
@@ -163,7 +171,7 @@ describe("CalculatedColumnModal", () => {
 		mockAddCalculatedColumn.mockResolvedValueOnce({ success: true });
 
 		render(
-			<CalculatedColumnModal dataset={mockDataset as any} onClose={mockOnClose} />
+			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
 		);
 
 		// Fill inputs

--- a/src/components/Sidebar/__tests__/DataSourcesSection.test.tsx
+++ b/src/components/Sidebar/__tests__/DataSourcesSection.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import type { ReactNode } from "react";
 import type { Mock } from "vitest";
 import { DataSourcesSection } from "../DataSourcesSection";
 import { useGraphStore } from "../../../store/useGraphStore";
@@ -21,7 +22,15 @@ vi.mock("../../ErrorBoundary", () => ({
 
 // Mock PopupPicker
 vi.mock("../PopupPicker", () => ({
-	PopupPicker: ({ renderTrigger }: any) => renderTrigger({ onClick: vi.fn(), ref: null })
+	PopupPicker: ({
+		renderTrigger,
+	}: {
+		renderTrigger: (args: {
+			onClick: () => void;
+			ref: null;
+			isOpen: boolean;
+		}) => ReactNode;
+	}) => renderTrigger({ onClick: vi.fn(), ref: null, isOpen: false }),
 }));
 
 // Mock hooks

--- a/src/components/Sidebar/__tests__/PopupPicker.test.tsx
+++ b/src/components/Sidebar/__tests__/PopupPicker.test.tsx
@@ -39,7 +39,7 @@ describe("PopupPicker", () => {
 				options={mockOptions}
 				current="opt1"
 				onChange={vi.fn()}
-				renderTrigger={({ onClick, ref, isOpen }) => (
+				renderTrigger={({ onClick, ref }) => (
 					<button ref={ref} onClick={onClick} data-testid="trigger">
 						Trigger
 					</button>

--- a/src/hooks/__tests__/useFormulaEditor.test.tsx
+++ b/src/hooks/__tests__/useFormulaEditor.test.tsx
@@ -98,7 +98,7 @@ describe("useFormulaEditor", () => {
 	});
 
 	it("updates formula and suggestions on change for functions", () => {
-		const { mockTextarea, textareaRef } = createMockTextarea();
+		const { textareaRef } = createMockTextarea();
 		const { result } = renderHook(() =>
 			useFormulaEditor({ columns, textareaRef }),
 		);
@@ -122,7 +122,7 @@ describe("useFormulaEditor", () => {
 
 
 	it("updates formula and suggestions on change for columns", () => {
-		const { mockTextarea, textareaRef } = createMockTextarea();
+		const { textareaRef } = createMockTextarea();
 		const { result } = renderHook(() =>
 			useFormulaEditor({ columns, textareaRef }),
 		);
@@ -146,7 +146,7 @@ describe("useFormulaEditor", () => {
 
 
 	it("returns empty suggestions if function partial is less than 2 characters", () => {
-		const { mockTextarea, textareaRef } = createMockTextarea();
+		const { textareaRef } = createMockTextarea();
 		const { result } = renderHook(() =>
 			useFormulaEditor({ columns, textareaRef }),
 		);
@@ -206,7 +206,7 @@ describe("useFormulaEditor", () => {
 
 
 	it("handles auto-pairing brackets on keydown", () => {
-		const { mockTextarea, textareaRef } = createMockTextarea();
+		const { textareaRef } = createMockTextarea();
 		const { result } = renderHook(() =>
 			useFormulaEditor({ columns, textareaRef }),
 		);
@@ -233,7 +233,7 @@ describe("useFormulaEditor", () => {
 
 
 	it("skips closing bracket if it already exists", () => {
-		const { mockTextarea, textareaRef } = createMockTextarea();
+		const { textareaRef } = createMockTextarea();
 		const { result } = renderHook(() =>
 			useFormulaEditor({ initialFormula: "sin()", columns, textareaRef }),
 		);
@@ -259,7 +259,7 @@ describe("useFormulaEditor", () => {
 
 
 	it("navigates suggestions via arrow keys and escape", () => {
-		const { mockTextarea, textareaRef } = createMockTextarea();
+		const { textareaRef } = createMockTextarea();
 		const { result } = renderHook(() =>
 			useFormulaEditor({ columns, textareaRef }),
 		);
@@ -334,7 +334,7 @@ describe("useFormulaEditor", () => {
 
 
 	it("applies suggestion via enter/tab key", () => {
-		const { mockTextarea, textareaRef } = createMockTextarea();
+		const { textareaRef } = createMockTextarea();
 		const { result } = renderHook(() =>
 			useFormulaEditor({ columns, textareaRef }),
 		);

--- a/src/hooks/__tests__/usePanZoom.test.tsx
+++ b/src/hooks/__tests__/usePanZoom.test.tsx
@@ -1,6 +1,9 @@
+import type React from "react";
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { usePanZoom } from "../usePanZoom";
+
+type PanZoomOptions = Parameters<typeof usePanZoom>[0];
 
 describe("usePanZoom", () => {
 	const mockSyncViewport = vi.fn();
@@ -8,11 +11,14 @@ describe("usePanZoom", () => {
 	const mockHandleAutoScaleY = vi.fn();
 	const mockOnPanEnd = vi.fn();
 
-	let baseOptions: any;
+	let baseOptions: PanZoomOptions;
 
 	beforeEach(() => {
 		vi.useFakeTimers();
-		vi.stubGlobal("requestAnimationFrame", (cb: Function) => setTimeout(cb, 0));
+		vi.stubGlobal(
+			"requestAnimationFrame",
+			(cb: FrameRequestCallback) => setTimeout(() => cb(performance.now()), 0),
+		);
 		vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
 
 		const containerRef = {
@@ -63,7 +69,7 @@ describe("usePanZoom", () => {
 					startTargetY: {},
 				},
 			},
-		};
+		} as unknown as PanZoomOptions;
 	});
 
 	afterEach(() => {
@@ -86,7 +92,7 @@ describe("usePanZoom", () => {
 
 		act(() => {
 			result.current.handleMouseDown(
-				{ clientX: 100, clientY: 100, button: 0 } as any,
+				{ clientX: 100, clientY: 100, button: 0 } as unknown as React.MouseEvent,
 				"all"
 			);
 		});
@@ -100,7 +106,7 @@ describe("usePanZoom", () => {
 
 		act(() => {
 			result.current.handleMouseDown(
-				{ clientX: 100, clientY: 100, button: 0 } as any,
+				{ clientX: 100, clientY: 100, button: 0 } as unknown as React.MouseEvent,
 				"all"
 			);
 		});
@@ -126,7 +132,7 @@ describe("usePanZoom", () => {
 
 		act(() => {
 			result.current.handleMouseDown(
-				{ clientX: 100, clientY: 100, button: 0 } as any,
+				{ clientX: 100, clientY: 100, button: 0 } as unknown as React.MouseEvent,
 				"all"
 			);
 		});
@@ -151,7 +157,7 @@ describe("usePanZoom", () => {
 					clientY: 300,
 					deltaY: 100,
 					preventDefault,
-				} as any,
+				} as unknown as React.WheelEvent,
 				"all"
 			);
 		});
@@ -171,7 +177,7 @@ describe("usePanZoom", () => {
 
 		act(() => {
 			result.current.handleTouchStart(
-				{ touches: [{ clientX: 100, clientY: 100 }] } as any,
+				{ touches: [{ clientX: 100, clientY: 100 }] } as unknown as React.TouchEvent,
 				"all"
 			);
 		});
@@ -184,7 +190,7 @@ describe("usePanZoom", () => {
 
 		act(() => {
 			result.current.handleTouchStart(
-				{ touches: [{ clientX: 100, clientY: 100 }] } as any,
+				{ touches: [{ clientX: 100, clientY: 100 }] } as unknown as React.TouchEvent,
 				"all"
 			);
 		});
@@ -192,7 +198,7 @@ describe("usePanZoom", () => {
 		// Trigger another touch immediately
 		act(() => {
 			result.current.handleTouchStart(
-				{ touches: [{ clientX: 100, clientY: 100 }] } as any,
+				{ touches: [{ clientX: 100, clientY: 100 }] } as unknown as React.TouchEvent,
 				"all"
 			);
 		});


### PR DESCRIPTION
## Summary

Resolves all 26 pre-existing ESLint errors across 5 test files. Behavior unchanged — only types and unused variables.

### Changes per file

- **`CalculatedColumnModal.test.tsx`** — replace `(useGraphStore as any).mockImplementation((selector: any) => ...)` with a properly typed `Mock` cast and explicit `selector: (state: StoreState) => unknown` signature; cast `mockDataset` once to `Dataset` at its definition so the 6 inline `as any` casts in render calls are no longer needed.
- **`DataSourcesSection.test.tsx`** — replace `({ renderTrigger }: any)` mock factory with a properly typed `renderTrigger` prop returning `ReactNode`. Also pass the required `isOpen` arg.
- **`PopupPicker.test.tsx`** — drop unused `isOpen` from the `renderTrigger` destructure.
- **`useFormulaEditor.test.tsx`** — drop unused `mockTextarea` from 7 destructures where the test body never references it (4 destructures that DO use it remain intact).
- **`usePanZoom.test.tsx`** — derive options type via `Parameters<typeof usePanZoom>[0]` instead of `any`; type the `requestAnimationFrame` stub callback as `FrameRequestCallback` (was `Function`); cast 6 inline event mocks via `as unknown as React.{Mouse,Wheel,Touch}Event`.

## Test plan

- [x] `pnpm run lint` → 0 errors (was 26)
- [x] `pnpm run build` → clean
- [x] `pnpm test` → 448/448 passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgmL1uBNxKEQz1ap77izVc)_