### PR TITLE
docs: refresh README, in-app help, and agent notes

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,64 +1,84 @@
-# Webgraphy: High-Performance Data Visualization
+# Webgraphy — Agent Notes
 
-`webgraphy` is a precision-focused, high-performance data visualization application designed to handle extremely large datasets (millions of points) with smooth interaction and visual integrity. It leverages custom WebGL rendering and advanced data management strategies to provide a responsive charting experience.
+High-performance, precision-focused data visualization. Custom WebGL renderer,
+worker-based ingestion, IndexedDB persistence. Designed for datasets in the
+millions of points.
 
-## Core Technologies
+## Stack
 
-- **Frontend:** React 19, TypeScript, Vite 8.
-- **Rendering:** Raw WebGL with custom shaders for ultra-precision and high-throughput drawing.
-- **State Management:** Zustand for application state (series configuration, viewport, axes).
-- **Persistence:** 
-    - **IndexedDB (`idb`):** Stores large datasets for fast retrieval across sessions.
-    - **LocalStorage:** Stores UI state and application configuration.
-- **Optimization:** Direct raw data rendering path optimized for massive datasets.
+- **Frontend:** React 19, TypeScript, Vite 8 (Node ≥ 24, pnpm).
+- **Rendering:** Raw WebGL with custom precision shaders. Per-frame updates
+  bypass React and Zustand for responsiveness.
+- **State:** Zustand (`src/store/`) for series, viewport, axes, themes.
+- **Persistence:** `idb` for datasets, LocalStorage for UI state and config.
+- **Concurrency:** Web Workers (`src/workers/`) for CSV/JSON parsing and
+  formula evaluation.
+- **PWA:** `vite-plugin-pwa` (auto-update, installable).
 
-## Architecture & Data Flow
+## Data Flow
 
-1.  **Data Import:** Files (CSV/JSON) are read and parsed by `src/utils/data-parser.ts`.
-2.  **Processing:** The parser calculates bounds, and transforms values to relative offsets (`refPoint`) for high-precision rendering.
-3.  **Persistence:** The processed dataset is stored in IndexedDB.
-4.  **State Sync:** `useGraphStore` (Zustand) manages the active datasets and series configurations.
-5.  **Rendering:** `WebGLRenderer` consumes datasets and series configs and renders raw data to a canvas using specialized shaders. To ensure high responsiveness during interaction, the renderer bypasses the global store and React render cycle for per-frame updates.
+1. `useDataImport` accepts CSV / JSON / XLSX (sheet selection for Excel).
+2. `src/utils/data-parser.ts` parses and computes bounds; values are stored as
+   relative offsets to a `refPoint` to keep WebGL coords inside f32 precision.
+3. Processed datasets land in IndexedDB; series and viewport config in
+   LocalStorage.
+4. `useGraphStore` (Zustand) is the single source of truth for active datasets
+   and series configuration.
+5. `WebGLRenderer` consumes datasets + series configs and draws via custom
+   shaders. Pan/zoom mutate the viewport directly and re-render without going
+   through React.
 
 ## Key Directories
 
-- `src/components/Plot/`: Core rendering components, including `WebGLRenderer` and `ChartContainer`.
-- `src/store/`: Zustand stores for application state.
-- `src/services/`: Persistence logic and data interfaces.
-- `src/utils/`: Helper functions for coordinates and data algorithms.
+- `src/components/Plot/` — `WebGLRenderer`, `ChartContainer`, crosshair,
+  legend, axis interactions.
+- `src/components/Layout/` — Sidebar shell, modals (Help, Calculated Column,
+  Import Settings, Export).
+- `src/components/Sidebar/` — Data sources, series config, color picker.
+- `src/store/` — Zustand stores.
+- `src/services/` — Persistence (`idb`), export (SVG + PNG).
+- `src/utils/` — Data parser, formula compiler/evaluator, coordinate math.
+- `src/workers/` — Off-main-thread parsing and formula workers.
 
-## Building and Running
+## Scripts
 
-### Development
 ```bash
-pnpm run dev
+pnpm install
+pnpm run dev       # Vite dev server
+pnpm run build     # tsc -b && vite build
+pnpm run preview   # serve dist/
+pnpm run lint      # ESLint
+pnpm run test      # Vitest
 ```
 
-### Build
-```bash
-pnpm run build
-```
+Deployment is automatic via `.github/workflows/deploy.yml` on push to `master`.
 
-### Linting
-```bash
-pnpm run lint
-```
+## Conventions
 
-### Deployment
-The project is configured for deployment to GitHub Pages.
-```bash
-pnpm run deploy
-```
+- **Performance first.** WebGL is the only data-rendering path. Avoid
+  full-store updates on per-frame interactions.
+- **Precision.** Use `refPoint` offsets in shaders; never feed raw absolute
+  timestamps or large coords directly into f32 attributes.
+- **Type safety.** Strict TypeScript; no `any` unless unavoidable at FFI
+  boundaries.
+- **Persistence awareness.** Any `GraphState` change that should survive a
+  refresh must flow through the `persistence` service.
+- **Package manager.** Use `pnpm`. After any `package.json` change (deps,
+  overrides) run `pnpm install` and commit `pnpm-lock.yaml`.
 
-## Development Conventions
+## Formula Engine (`src/utils/formula.ts`)
 
-- **Performance First:** WebGL is the primary rendering path for data.
-- **Precision:** Shaders are designed for ultra-precision, using relative offsets (`refPoint`) to handle large coordinate values without floating-point artifacts.
-- **Type Safety:** Strict TypeScript usage is encouraged across the codebase.
-- **Persistence Awareness:** Any changes to the `GraphState` that should survive a refresh must be persisted via the `persistence` service.
-- **Package Manager:** This project uses `pnpm`. Whenever you modify `package.json` (e.g., adding/updating dependencies or overrides), you MUST run `pnpm install` and ensure `pnpm-lock.yaml` is staged and committed alongside `package.json`.
+Reference columns as `[Column Name]`. Operators `+ - * / ^`; constants `pi`,
+`e`.
 
-## Agent Optimization & Efficiency
-- **Caveman Mode:** Adopt extreme token efficiency ("Why use many token when few do trick"). Eliminate all conversational filler, preambles, and postambles. Prioritize direct action, maximum brevity, and high-signal output.
-- **Conductor Orchestration:** Use `conductor` for complex, multi-agent task orchestration when kanban-style management or sub-agent delegation is required.
-- **Ripgrep & System Tools:** Utilize `rg` (Ripgrep), `fd`, and `bat` in shell commands for lightning-fast codebase navigation and exploration instead of standard slow fallbacks.
+- Math: `sqrt`, `abs`, `exp`, `log` (base 10), `ln`, `round`, `floor`, `ceil`.
+- Trig: `sin`, `cos`, `tan`, `asin`, `acos`, `atan` (radians).
+- Aggregations: `min`, `max`, `sum`, `avg` (no args ⇒ across all numeric
+  columns in the row).
+- Rolling: `avgN` over rows; `avgNs|m|h|d` over time windows. Alignment
+  suffix `c` (central, default) / `l` / `r`.
+- Time-bucketed cumulative: `avgDay`, `avgHour`, `avgMinute`, `avgSecond` and
+  the `sum…` variants.
+- Smoothing: `filter` (adaptive Kalman).
+- Regression fits: `linreg`, `polyreg([col], degree)`, `expreg`, `logreg`,
+  `kde([col], bandwidth?)`.

--- a/README.md
+++ b/README.md
@@ -1,110 +1,125 @@
 # Webgraphy
 
 [![Live Demo](https://img.shields.io/badge/Live-Demo-brightgreen)](https://michaelkrisper.github.io/webgraphy/)
+[![Deploy](https://github.com/michaelkrisper/webgraphy/actions/workflows/deploy.yml/badge.svg)](https://github.com/michaelkrisper/webgraphy/actions/workflows/deploy.yml)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Webgraphy is a precision-focused, high-performance data visualization application designed to handle extremely large datasets (millions of points) with smooth interaction and visual integrity. It leverages custom WebGL rendering and advanced data management strategies to provide a responsive charting experience.
+A precision-focused, high-performance data visualization application that handles datasets with millions of points while keeping interaction smooth. Webgraphy uses custom WebGL shaders and off-main-thread processing to render and explore data at scale, directly in the browser.
 
-**Live Demo:** [https://michaelkrisper.github.io/webgraphy/](https://michaelkrisper.github.io/webgraphy/)
+**Live demo:** <https://michaelkrisper.github.io/webgraphy/>
 
-## Key Features
+## Highlights
 
-- **Ultra High Performance:** Render millions of data points smoothly using raw WebGL with custom high-precision shaders.
-- **Advanced Data Handling:** CSV/JSON parsing and formula evaluation run in dedicated Web Workers, keeping the UI responsive even with very large datasets.
-- **Precision Rendering:** Raw data rendering using custom WebGL shaders for maximum visual integrity and accuracy, utilizing relative offsets (`refPoint`) to avoid floating-point artifacts.
-- **Rich Interaction:**
-  - **Interactive Axes:** Pan and zoom directly on individual X or Y axes.
-  - **Box Zoom:** `Ctrl + Drag` to precisely zoom into a specific region.
-  - **Smart Snapping:** Y-axis zero-lines automatically snap to each other during dragging for easy alignment.
-  - **Precision Crosshair:** High-performance data-snapping crosshair for accurate value inspection.
-  - **Quick Scaling:** Double-click axes to auto-scale; smart Y-scaling based on click position.
-- **Complex Visualizations:**
-  - Support for up to 9 independent X and Y axes.
-  - Flexible X-Axis modes (Numeric, Date/Time).
-  - View Snapshots to save and recall specific zoom/pan states.
-- **Formula Support:** Add calculated columns using a powerful formula engine. Supports math operations, moving averages (`avgN`, `avgTime`, `avgGroup`, `avgDay`), and Kalman filters.
-- **Regression Analysis:** Add linear, polynomial, exponential, logarithmic, or KDE fits to your data.
-- **Robust Persistence:** Automatic state recovery across browser sessions using IndexedDB for large datasets and LocalStorage for UI configurations.
-- **Professional Export:** High-quality export of charts to PNG or SVG formats.
+- **Millions of points, fluid interaction.** Custom WebGL shaders draw raw data with high-precision relative offsets (`refPoint`) to avoid floating-point artifacts at large coordinate values.
+- **Background data processing.** Import, parse, and formula evaluation run in Web Workers, so the UI stays responsive on multi-GB files.
+- **Rich interaction model.** Pan/zoom per axis, `Ctrl + Drag` box zoom, smart Y-axis zero-line snapping, a data-snapping crosshair, and double-click auto-scaling.
+- **Multi-axis charts.** Up to 9 independent X and Y axes, per-axis position and color, numeric or date/time X-axis modes.
+- **Formula engine.** Add calculated columns with math, trigonometry, rolling/time/group averages, Kalman filtering, and regression fits (linear, polynomial, exponential, logistic, KDE).
+- **PWA & offline.** Installable Progressive Web App with auto-update; opens previously imported data instantly via IndexedDB.
+- **Robust persistence.** Datasets live in IndexedDB; UI state, series configuration, and theme in LocalStorage — all restored on next visit.
+- **High-quality export.** SVG and PNG export of the current view, theme-aware.
 
-## Interactions & Shortcuts
+## Supported Inputs
 
-### Plot Area
-- **Mouse Wheel:** Zoom in and out.
-- **Click & Drag:** Pan the chart.
-- **Shift + Interaction:** Synchronize all X-axes (zoom/pan/keys).
-- **CTRL + Drag:** Draw a zoom selection box.
-- **CTRL + C:** Copy current tooltip data to clipboard.
-- **Hover:** Show tooltips for nearest data points.
-- **Double Click:** Auto-scale to fit all data.
-- **Drag & Drop:** Drop a CSV/JSON file onto the chart to import.
+Drag-and-drop or pick a file: **CSV**, **JSON**, **XLSX / XLS** (with sheet selection). Large files are streamed to a worker; skipped rows are reported in a preview panel.
+
+## Quick Start
+
+Webgraphy uses **pnpm** and requires **Node.js ≥ 24**.
+
+```bash
+pnpm install
+pnpm run dev      # start the dev server (http://localhost:5173)
+pnpm run build    # type-check and produce a production build in dist/
+pnpm run preview  # serve the production build locally
+pnpm run lint     # run ESLint
+pnpm run test     # run the Vitest suite
+```
+
+## Deployment
+
+Pushes to `master` are automatically built and published to GitHub Pages by the workflow in `.github/workflows/deploy.yml`. The production site is served from `https://michaelkrisper.github.io/webgraphy/`.
+
+## Interaction Reference
+
+### Plot area
+| Action | Effect |
+| --- | --- |
+| Mouse wheel | Zoom both axes |
+| Drag | Pan |
+| Shift + drag/wheel/keys | Synchronize all X-axes |
+| Ctrl + drag | Box zoom into a region |
+| Hover | Snap crosshair + tooltip to nearest point |
+| Ctrl + C | Copy tooltip values to clipboard |
+| Double-click | Auto-scale to fit |
+| Drop file | Import CSV / JSON / XLSX |
 
 ### Axes (X & Y)
-- **Mouse Wheel:** Zoom only this axis.
-- **Drag:** Pan only this axis.
-- **Double Click:** Auto-scale this axis.
-- **CTRL + Double Click (Y):** Auto-scale to top or bottom half.
-- **Click on Title:** Rename the axis.
+| Action | Effect |
+| --- | --- |
+| Wheel on axis | Zoom only that axis |
+| Drag on axis | Pan only that axis |
+| Double-click on axis | Auto-scale that axis |
+| Ctrl + double-click (Y) | Auto-scale to upper or lower half (based on click position) |
+| Click on title | Rename the axis |
 
 ### Keyboard
-- **← →:** Pan X axis (animated).
-- **↑ ↓:** Pan Y axis (hovered axis, or all).
-- **+ / =:** Zoom in (X and Y).
-- **- / _:** Zoom out (X and Y).
-- **Shift + ← →:** Pan all X-axes together.
-- **CTRL + + / -:** Zoom only X axis.
+| Key | Effect |
+| --- | --- |
+| ← → | Pan X axis (animated) |
+| ↑ ↓ | Pan Y axis (hovered, or all) |
+| `+` / `=` | Zoom in |
+| `-` / `_` | Zoom out |
+| Shift + ← → | Pan all X-axes together |
+| Ctrl + `+` / `-` | Zoom only the X axis |
 
-## Core Technologies
+## Formula Engine
 
-- **Frontend:** React 19, TypeScript, Vite 8
-- **Rendering:** Raw WebGL (Custom Shaders)
-- **State Management:** Zustand
-- **Persistence:** IndexedDB (`idb`), LocalStorage
-- **Concurrency:** Web Workers for data processing and formula calculation.
+Reference other columns with `[Column Name]`. Math operators: `+ - * / ^` with parentheses. Constants `pi`, `e`.
 
-## Development
+| Function | Purpose |
+| --- | --- |
+| `sqrt`, `abs`, `exp`, `log` (base 10), `ln`, `round`, `floor`, `ceil` | Math basics |
+| `sin`, `cos`, `tan`, `asin`, `acos`, `atan` | Trigonometry (radians) |
+| `min(...)`, `max(...)`, `sum(...)`, `avg(...)` | Aggregations (no args = across all numeric columns in the row) |
+| `avgN([col])` | Rolling average over N rows. Suffix: `avgNc` central (default), `avgNl` left/trailing, `avgNr` right/leading |
+| `avgNs / avgNm / avgNh / avgNd([col])` | Rolling average over N seconds/minutes/hours/days, with the same `c`/`l`/`r` alignment suffix |
+| `avgDay`, `avgHour`, `avgMinute`, `avgSecond([col])` | Per-bucket cumulative average (resets per calendar bucket) |
+| `sumDay`, `sumHour`, `sumMinute`, `sumSecond([col])` | Per-bucket cumulative sum |
+| `filter([col])` | Adaptive Kalman filter (noise smoothing) |
+| `linreg([col])` | Linear regression fit |
+| `polyreg([col], degree)` | Polynomial regression (default degree 3) |
+| `expreg([col])` | Exponential regression fit |
+| `logreg([col])` | Logistic regression fit |
+| `kde([col])` or `kde([col], bandwidth)` | KDE-smoothed fit |
 
-First, ensure you have Node.js installed. Clone the repository and install dependencies:
+## Architecture
 
-```bash
-npm install
+- **Frontend:** React 19 + TypeScript, bundled with Vite 8.
+- **Rendering:** Raw WebGL with custom precision shaders. Per-frame updates bypass the React render cycle and the global store for responsiveness.
+- **State:** [Zustand](https://github.com/pmndrs/zustand) stores in `src/store/`.
+- **Persistence:** [`idb`](https://github.com/jakearchibald/idb) for datasets (IndexedDB); LocalStorage for UI config and theme.
+- **Concurrency:** Parsing (CSV/JSON/Excel) and formula evaluation run in Web Workers (`src/workers/`).
+- **PWA:** Service worker via `vite-plugin-pwa` (auto-update).
+
+### Key directories
+
+```
+src/
+├── components/Plot/      # WebGL renderer, chart container, interactions
+├── components/Layout/    # Sidebar, modals, header/footer
+├── components/Sidebar/   # Data sources, series, color picker
+├── store/                # Zustand stores
+├── services/             # Persistence, export (SVG/PNG)
+├── utils/                # Data parser, formula engine, coordinate math
+├── workers/              # CSV/JSON parsing, formula workers
+└── themes.ts             # Light, Dark, Matrix, Winnie, Unicorn
 ```
 
-### Running Locally
+## Contributing
 
-```bash
-npm run dev
-```
-
-### Build
-
-```bash
-npm run build
-```
-
-### Linting
-
-```bash
-npm run lint
-```
-
-### Testing
-
-```bash
-npm run test
-```
-
-### Deploy to GitHub Pages
-
-The application is configured for automatic deployment to GitHub Pages via GitHub Actions on every push to the `master` branch.
-
-To manually deploy from your local machine:
-```bash
-npm run deploy
-```
-
-The application will be available at `https://michaelkrisper.github.io/webgraphy/`.
+This project uses `pnpm`. When you modify `package.json` (dependencies, overrides), run `pnpm install` and commit the updated `pnpm-lock.yaml` alongside it. Run `pnpm run lint` and `pnpm run test` before opening a pull request.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+[MIT](LICENSE) © Michael Krisper

--- a/src/components/Layout/HelpModal.tsx
+++ b/src/components/Layout/HelpModal.tsx
@@ -46,15 +46,15 @@ export const HelpModal: React.FC<HelpModalProps> = ({ onClose }) => {
 					<strong>CTRL + C:</strong> Copy current tooltip data to clipboard
 				</li>
 				<li>
-					<strong>Hover:</strong> Show tooltips for nearest data points
-					(decimal-aligned)
+					<strong>Hover:</strong> Snap crosshair and tooltip to the nearest data
+					point
 				</li>
 				<li>
 					<strong>Double Click:</strong> Auto-scale to fit all data
 				</li>
 				<li>
-					<strong>Drag & Drop file:</strong> Drop a CSV/JSON onto the chart to
-					import
+					<strong>Drag & Drop file:</strong> Drop a CSV, JSON, or XLSX file onto
+					the chart to import
 				</li>
 			</Section>
 
@@ -69,8 +69,8 @@ export const HelpModal: React.FC<HelpModalProps> = ({ onClose }) => {
 					<strong>Double Click:</strong> Auto-scale this axis
 				</li>
 				<li>
-					<strong>CTRL + Dbl Click (Y):</strong> Auto-scale to top or bottom
-					half
+					<strong>CTRL + Dbl Click (Y):</strong> Auto-scale to the upper or
+					lower half (based on click position)
 				</li>
 				<li>
 					<strong>Click on title:</strong> Rename the axis
@@ -100,18 +100,24 @@ export const HelpModal: React.FC<HelpModalProps> = ({ onClose }) => {
 
 			<Section title="Sidebar — Data">
 				<li>
-					<strong>Import:</strong> Load CSV or JSON files (large files handled
-					in a worker)
+					<strong>Import:</strong> Load CSV, JSON, or Excel (XLSX/XLS) files.
+					Large files stream through a worker; pick a sheet for Excel
 				</li>
 				<li>
 					<strong>Skipped Rows Preview:</strong> Inspect rows skipped during
 					import
 				</li>
 				<li>
-					<strong>Calculated Columns:</strong> Add, edit, or delete formula
-					columns; reference other columns via <code>[Column Name]</code>.
-					Supports math, <code>avgN</code>, <code>avgTime</code>,{" "}
-					<code>avgGroup</code>, <code>avgDay</code>, Kalman <code>filter</code>
+					<strong>Calculated Columns:</strong> Reference columns with{" "}
+					<code>[Column Name]</code>. Supports math/trig, rolling averages{" "}
+					<code>avgN</code> / <code>avgNs|m|h|d</code> with{" "}
+					<code>c</code>/<code>l</code>/<code>r</code> alignment,
+					per-bucket{" "}
+					<code>avgDay</code>/<code>avgHour</code>/<code>avgMinute</code>/
+					<code>avgSecond</code> (and <code>sum…</code> variants), Kalman{" "}
+					<code>filter</code>, and regressions <code>linreg</code>,{" "}
+					<code>polyreg</code>, <code>expreg</code>, <code>logreg</code>,{" "}
+					<code>kde</code>
 				</li>
 				<li>
 					<strong>X-Axis per Dataset:</strong> Cycle the dataset's X-axis (1–9)
@@ -126,29 +132,30 @@ export const HelpModal: React.FC<HelpModalProps> = ({ onClose }) => {
 				</li>
 				<li>
 					<strong>Multiple Y-Axes:</strong> Up to 9 Y-axes, each with
-					independent scale, position (L/R), and color
+					independent scale, position (left/right), and color
 				</li>
 				<li>
 					<strong>Style:</strong> Line style (solid/dashed/dotted), point
 					markers (circle/square/cross), color
 				</li>
 				<li>
-					<strong>Regression:</strong> Add linear, polynomial, exponential, log,
-					or KDE fits
+					<strong>Regression:</strong> Add linear, polynomial, exponential,
+					logistic, or KDE fits
 				</li>
 				<li>
-					<strong>Visibility:</strong> Toggle per-series visibility; hover row
-					to highlight on chart
+					<strong>Visibility:</strong> Toggle per-series visibility; hover a row
+					to highlight it on the chart
 				</li>
 			</Section>
 
 			<Section title="Export">
 				<li>
-					<strong>Export Chart:</strong> Save current view as SVG or PNG
+					<strong>Export Chart:</strong> Save the current view as SVG or PNG
+					(theme-aware, device-pixel scaled)
 				</li>
 				<li>
-					<strong>Auto-Save:</strong> State persists to IndexedDB/localStorage
-					between visits
+					<strong>Auto-Save:</strong> Datasets persist in IndexedDB; UI and
+					series state in LocalStorage — restored on next visit
 				</li>
 			</Section>
 
@@ -158,14 +165,15 @@ export const HelpModal: React.FC<HelpModalProps> = ({ onClose }) => {
 					via the theme button
 				</li>
 				<li>
-					<strong>Sidebar Collapse:</strong> Click the logo to collapse/expand
-					the sidebar
+					<strong>Sidebar Collapse:</strong> Click the logo to collapse or
+					expand the sidebar
 				</li>
 				<li>
 					<strong>Legend:</strong> Toggle the top-right legend overlay
 				</li>
 				<li>
-					<strong>Views:</strong> Save and restore zoom/pan snapshots
+					<strong>Install as App:</strong> Webgraphy is a PWA — install it from
+					the browser for offline access
 				</li>
 			</Section>
 		</Modal>


### PR DESCRIPTION
## Summary

Brings the project documentation back in sync with the current implementation, and tightens it for a professional, useful, concise read.

### README.md
- Switched all command examples from `npm` to **pnpm** (matches `packageManager` field, `engines.node >= 24`, and the deploy workflow).
- Removed the fictional `npm run deploy` step — deployment is automatic via `.github/workflows/deploy.yml` on push to `master`.
- Documented full file-format support: **CSV, JSON, XLSX/XLS** (with sheet selection), not just CSV/JSON.
- Replaced the stale formula bullet (`avgN`, `avgTime`, `avgGroup`, `avgDay`) with a full reference table that matches `src/utils/formula.ts`: math/trig, aggregations, rolling row + time windows with `c`/`l`/`r` alignment, per-bucket cumulative `avg…`/`sum…`, Kalman `filter`, and all regression fits (`linreg`, `polyreg`, `expreg`, `logreg`, `kde`).
- Added a PWA / offline note (`vite-plugin-pwa`) and a CI badge for the deploy workflow.
- Restructured into Highlights / Inputs / Quick Start / Deployment / Interaction Reference / Formulas / Architecture / Contributing for a clearer scan-path.

### `src/components/Layout/HelpModal.tsx`
- Dropped the **Views** bullet — the feature has no UI surface (only orphan CSS in `components.css`).
- Mentioned **XLSX** in import + drag-and-drop.
- Expanded the calculated-columns description to match the formula engine: alignment suffixes, `avgDay/Hour/Minute/Second` plus `sum…` variants, and the full regression list (logistic was missing).
- Added a **PWA install** entry under UI.
- Preserved every string that the existing `HelpModal.test.tsx` asserts on.

### GEMINI.md
- Replaced the agent prelude with a focused architecture overview (data flow, key directories, conventions).
- Documented the actual formula API the agent will run into.
- Removed Gemini-specific "Caveman Mode" / Conductor instructions that don't apply to this codebase.

## Verification
- `pnpm run test` — 41 files, 457 tests pass (HelpModal test included).
- `pnpm run lint` — clean.

## Test plan
- [ ] Render the help modal in the app and confirm the new sections read well.
- [ ] Skim the README on GitHub to confirm formatting and tables render correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R4VrUdTXLvy88i9WyD7Y5J)_