### PR TITLE
chore: collapse repeated useMemo Map builds and pan-state snapshot

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -396,20 +396,14 @@ export default function ChartContainer() {
 		return set;
 	}, [series]);
 
-	const xAxesById = useMemo(() => {
-		const m = new Map<string, XAxisConfig>();
-		xAxes.forEach((a) => {
-			m.set(a.id, a);
-		});
-		return m;
-	}, [xAxes]);
-	const yAxesById = useMemo(() => {
-		const m = new Map<string, YAxisConfig>();
-		yAxes.forEach((a) => {
-			m.set(a.id, a);
-		});
-		return m;
-	}, [yAxes]);
+	const xAxesById = useMemo(
+		() => new Map(xAxes.map((a) => [a.id, a])),
+		[xAxes],
+	);
+	const yAxesById = useMemo(
+		() => new Map(yAxes.map((a) => [a.id, a])),
+		[yAxes],
+	);
 
 	const activeYAxes = useMemo(() => {
 		return yAxes.filter((a) => usedYAxisIdsSet.has(a.id));
@@ -418,10 +412,7 @@ export default function ChartContainer() {
 	// Per-axis categorical labels: only when ALL series on the axis bind to a column
 	// that has categoryLabels, and they all share the same label set.
 	const yAxisCategoryLabels = useMemo(() => {
-		const dsById = new Map<string, Dataset>();
-		datasets.forEach((d) => {
-			dsById.set(d.id, d);
-		});
+		const dsById = new Map(datasets.map((d) => [d.id, d]));
 		const out = new Map<string, string[] | undefined>();
 		const seriesByAxis = new Map<string, typeof series>();
 		series.forEach((s) => {

--- a/src/components/Plot/Crosshair.tsx
+++ b/src/components/Plot/Crosshair.tsx
@@ -82,29 +82,20 @@ const Crosshair = React.memo(
 		const posRef = useRef<{ x: number; y: number } | null>(null);
 		const lastSnapRef = useRef<SnapResult | null>(null);
 
-		const datasetsById = useMemo(() => {
-			const map = new Map<string, Dataset>();
-			datasets.forEach((d) => {
-				map.set(d.id, d);
-			});
-			return map;
-		}, [datasets]);
+		const datasetsById = useMemo(
+			() => new Map(datasets.map((d) => [d.id, d])),
+			[datasets],
+		);
 
-		const yAxesById = useMemo(() => {
-			const map = new Map<string, YAxisConfig>();
-			yAxes.forEach((a) => {
-				map.set(a.id, a);
-			});
-			return map;
-		}, [yAxes]);
+		const yAxesById = useMemo(
+			() => new Map(yAxes.map((a) => [a.id, a])),
+			[yAxes],
+		);
 
-		const xAxesById = useMemo(() => {
-			const map = new Map<string, XAxisConfig>();
-			xAxes.forEach((a) => {
-				map.set(a.id, a);
-			});
-			return map;
-		}, [xAxes]);
+		const xAxesById = useMemo(
+			() => new Map(xAxes.map((a) => [a.id, a])),
+			[xAxes],
+		);
 
 		const seriesMetadata = useMemo(() => {
 			return series

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -462,6 +462,14 @@ export function usePanZoom({
 			clientY: number;
 			shiftKey: boolean;
 		} | null = null;
+		const snapshotAxesToPanState = (ps: typeof panStateRef.current) => {
+			activeXAxes.forEach((a) => {
+				ps.startTargetX[a.id] = { ...targetXAxes.current[a.id] };
+			});
+			activeYAxes.forEach((a) => {
+				ps.startTargetY[a.id] = { ...targetYs.current[a.id] };
+			});
+		};
 		const handleSingleTouchPan = (e: TouchEvent, target: PanTarget) => {
 			if (e.cancelable) e.preventDefault();
 			const t = e.touches[0];
@@ -473,12 +481,7 @@ export function usePanZoom({
 					ps.startY = lastTouchPos.current.y;
 				}
 				ps.target = target;
-				activeXAxes.forEach((a) => {
-					ps.startTargetX[a.id] = { ...targetXAxes.current[a.id] };
-				});
-				activeYAxes.forEach((a) => {
-					ps.startTargetY[a.id] = { ...targetYs.current[a.id] };
-				});
+				snapshotAxesToPanState(ps);
 			}
 			ps.currentX = t.clientX;
 			ps.currentY = t.clientY;
@@ -618,12 +621,7 @@ export function usePanZoom({
 				ps.startX = lastMousePos.current.x;
 				ps.startY = lastMousePos.current.y;
 				ps.target = target;
-				activeXAxes.forEach((a) => {
-					ps.startTargetX[a.id] = { ...targetXAxes.current[a.id] };
-				});
-				activeYAxes.forEach((a) => {
-					ps.startTargetY[a.id] = { ...targetYs.current[a.id] };
-				});
+				snapshotAxesToPanState(ps);
 			}
 			ps.currentX = e.clientX;
 			ps.currentY = e.clientY;

--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -167,6 +167,19 @@ const DATASET_DEBOUNCE_MS = 300;
 const pendingDatasets = new Map<string, Dataset>();
 const datasetTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+async function putAppState(
+	key: string,
+	state: unknown,
+	label: string,
+): Promise<void> {
+	try {
+		const db = await getDB();
+		await db.put(APP_STATE_STORE, state, key);
+	} catch (error) {
+		console.error(`Failed to save ${label}:`, error);
+	}
+}
+
 function flushDataset(id: string) {
 	const ds = pendingDatasets.get(id);
 	datasetTimers.delete(id);
@@ -212,21 +225,11 @@ export const persistence = {
 		const db = await getDB();
 		await db.delete(DATASET_STORE, id);
 	},
-	async saveViewport(state: ViewportState): Promise<void> {
-		try {
-			const db = await getDB();
-			await db.put(APP_STATE_STORE, state, VIEWPORT_KEY);
-		} catch (error) {
-			console.error("Failed to save viewport:", error);
-		}
+	saveViewport(state: ViewportState): Promise<void> {
+		return putAppState(VIEWPORT_KEY, state, "viewport");
 	},
-	async saveConfig(state: ConfigState): Promise<void> {
-		try {
-			const db = await getDB();
-			await db.put(APP_STATE_STORE, state, CONFIG_KEY);
-		} catch (error) {
-			console.error("Failed to save config:", error);
-		}
+	saveConfig(state: ConfigState): Promise<void> {
+		return putAppState(CONFIG_KEY, state, "config");
 	},
 	async saveAppState(state: AppState): Promise<void> {
 		await Promise.all([


### PR DESCRIPTION
## Summary

Third cleanup pass after #420 and #421. Theme this time: collapse repeated `useMemo` Map-build boilerplate, and extract one more snapshot/error-handling helper. No behavior change; 479/479 tests pass.

### `Crosshair.tsx` and `ChartContainer.tsx` — Map builders
Five `useMemo` blocks looked like this:

```ts
useMemo(() => {
  const m = new Map<string, T>();
  arr.forEach((x) => { m.set(x.id, x); });
  return m;
}, [arr]);
```

…while `useAutoScale.ts` already used the idiomatic one-liner. Aligned them:

```ts
useMemo(() => new Map(arr.map((x) => [x.id, x])), [arr]);
```

5 blocks shrunk, ~15 lines removed, no logic change.

### `usePanZoom.ts` — `snapshotAxesToPanState` helper
The 6-line "copy current target X/Y axes into pan state" block was duplicated at the start of touch-pan and mouse-pan handlers. Extracted as a local helper inside the same `useEffect` (it closes over the same refs both call sites used).

### `persistence.ts` — `putAppState` helper
`saveViewport` and `saveConfig` had structurally identical 5-line try/catch blocks differing only by key and error label. Extracted:

```ts
async function putAppState(key, state, label) { ... }
```

`saveViewport` and `saveConfig` are now one line each.

### Skipped (deliberately)
- `export.ts` grouping loops — looked similar but each has its own filter/intermediate-map shape; a generic `groupBy` would not have made the call sites clearer.
- Larger try/catch helper across `loadAppState` / `clearAppState` — those have different structural shapes; collapsing would force-fit them.
- Anything that required a new abstraction file for 2 callsites.

## Test plan
- [x] `pnpm test` — 479/479 passing
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [ ] Manual smoke: pan + zoom both axes (touch + mouse), reload to verify viewport/config persist, hover crosshair across multiple datasets

https://claude.ai/code/session_01WR3MeRdduFCycDmxaSf84Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR3MeRdduFCycDmxaSf84Q)_