### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "webgraphy",
 	"private": true,
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"packageManager": "pnpm@11.0.9",
 	"author": "Michael Krisper",
 	"type": "module",


### PR DESCRIPTION
## Summary

Patch version bump to 1.1.1 — covers the three internal cleanup PRs that just landed (#420, #421, #422). No user-facing changes.

## Test plan
- [x] No code changes; existing CI still applies

https://claude.ai/code/session_01WR3MeRdduFCycDmxaSf84Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR3MeRdduFCycDmxaSf84Q)_