### PR TITLE
🧪 [testing improvement: test m4ByXFloat32 threshold preservation]

### DIFF
--- a/src/utils/__tests__/decimation.test.ts
+++ b/src/utils/__tests__/decimation.test.ts
@@ -180,6 +180,22 @@ describe("m4Float32", () => {
 });
 
 describe("m4ByXFloat32", () => {
+	it("preserves min, max, first, and last values when points exceed threshold", () => {
+		// All points fall into a single bucket [0, 10).
+		const x = new Float32Array([1, 2, 3, 4, 5, 6, 7]);
+		const y = new Float32Array([10, 5, 100, 20, -50, 15, 30]);
+
+		// First: y=10 (idx 0)
+		// Max: y=100 (idx 2)
+		// Min: y=-50 (idx 4)
+		// Last: y=30 (idx 6)
+		const r = m4ByXFloat32(x, y, 0, 0, 10, 10);
+
+		// Output indices should be sorted: 0, 2, 4, 6
+		expect(Array.from(r.x)).toEqual([1, 3, 5, 7]);
+		expect(Array.from(r.y)).toEqual([10, 100, -50, 30]);
+	});
+
 	it("returns empty for empty input", () => {
 		const x = new Float32Array([]);
 		const y = new Float32Array([]);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: `m4ByXFloat32` was missing a test to ensure it extracts `min`, `max`, `first`, and `last` values when points exceed the bucket threshold.
📊 **Coverage:** Covered the scenario where multiple points map to a single bucket, asserting that extrema points are faithfully retained and properly ordered.
✨ **Result:** Improved test reliability and ensured line plots visually preserve extremities correctly.

---
*PR created automatically by Jules for task [4013016578225396223](https://jules.google.com/task/4013016578225396223) started by @michaelkrisper*