### PR TITLE
🧹 Remove unused export from ViewportState interface

### DIFF
--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -60,7 +60,7 @@ export interface SeriesConfig {
 	hidden?: boolean;
 }
 
-export interface ViewportState {
+interface ViewportState {
 	xAxes: XAxisConfig[];
 	yAxes: YAxisConfig[];
 }


### PR DESCRIPTION
🎯 **What:** Removed the `export` keyword from the `ViewportState` interface in `src/services/persistence.ts`.
💡 **Why:** This interface is only used internally within `persistence.ts` and isn't imported anywhere else in the codebase. Removing the `export` encapsulates it correctly and improves codebase cleanliness.
✅ **Verification:** Verified by checking references, running `pnpm run build` to ensure TypeScript compilation passes, and `pnpm run test` to confirm no regressions.
✨ **Result:** Improved maintainability by accurately scoping the interface without changing any functionality.

---
*PR created automatically by Jules for task [1487377033238442088](https://jules.google.com/task/1487377033238442088) started by @michaelkrisper*