### PR TITLE
🧹 fix: Remove unused export from ConfigState

### DIFF
--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -65,7 +65,7 @@ export interface ViewportState {
 	yAxes: YAxisConfig[];
 }
 
-export interface ConfigState {
+interface ConfigState {
 	series: SeriesConfig[];
 	axisTitles: { x: string; y: string };
 	legendVisible: boolean;


### PR DESCRIPTION
🎯 **What:** Removed the `export` keyword from the `ConfigState` interface in `src/services/persistence.ts`.
💡 **Why:** `ConfigState` is an internal interface not used outside this module. Removing the export improves code encapsulation.
✅ **Verification:** Verified by running the linter and unit tests, and checking that the change introduces no TypeScript compilation errors.
✨ **Result:** The codebase is cleaner and follows better module encapsulation practices.

---
*PR created automatically by Jules for task [9171534169851162332](https://jules.google.com/task/9171534169851162332) started by @michaelkrisper*