### PR TITLE
🧹 code health: Use explicit SeriesConfig over any in useDataImport

### DIFF
--- a/src/hooks/useDataImport.ts
+++ b/src/hooks/useDataImport.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type { WorkBook } from "xlsx";
-import type { Dataset } from "../services/persistence";
+import type { Dataset, SeriesConfig } from "../services/persistence";
 import { useGraphStore } from "../store/useGraphStore";
 import type { ImportSettings } from "../types/import";
 import { buildSeriesConfig } from "../utils/series";
@@ -78,8 +78,7 @@ const readTextFile = (
 const processImportedDatasets = (
 	incoming: Dataset[],
 	addDataset: (ds: Dataset) => void,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	addSeries: (series: any) => void,
+	addSeries: (series: SeriesConfig) => void,
 ) => {
 	const isSplitImport = incoming.length > 1;
 


### PR DESCRIPTION
🎯 **What:** Replaced explicit `any` in `addSeries` parameter in `src/hooks/useDataImport.ts` with `SeriesConfig` type.
💡 **Why:** To improve type safety and maintainability while resolving an `@typescript-eslint/no-explicit-any` warning without relying on an eslint-disable comment.
✅ **Verification:** Verified changes visually, compiled successfully via `pnpm run build`, linted via `pnpm lint`, and ran 479 tests successfully via `pnpm run test`.
✨ **Result:** Better types, no `any`, no disabled eslint rules, zero functional regressions.

---
*PR created automatically by Jules for task [11988160570840052301](https://jules.google.com/task/11988160570840052301) started by @michaelkrisper*