### PR TITLE
🔒 Fix potential XSS via loose MIME type validation for Data URLs

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -588,6 +588,18 @@ describe("downloadFile", () => {
 		);
 	});
 
+	it("should throw an error for unsafe MIME types (svg/xml/html)", () => {
+		expect(() => downloadFile("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=", "test.svg", "image/svg+xml")).toThrow(
+			"Unsafe data URL scheme detected",
+		);
+		expect(() => downloadFile("data:application/xhtml+xml;base64,PGh0bWw+PC9odG1sPg==", "test.html", "application/xhtml+xml")).toThrow(
+			"Unsafe data URL scheme detected",
+		);
+		expect(() => downloadFile("data:image/SVG+XML;base64,PHN2Zz48L3N2Zz4=", "test.svg", "image/SVG+XML")).toThrow(
+			"Unsafe data URL scheme detected",
+		);
+	});
+
 	it("should throw an error for empty data URLs", () => {
 		expect(() => downloadFile("data:", "test.html", "text/html")).toThrow(
 			"Unsafe data URL scheme detected",

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -544,6 +544,14 @@ export const downloadFile = (
 			) {
 				throw new Error();
 			}
+			const lowerMimeType = mimeType.toLowerCase();
+			if (
+				lowerMimeType.includes("svg") ||
+				lowerMimeType.includes("xml") ||
+				lowerMimeType.includes("html")
+			) {
+				throw new Error();
+			}
 		} catch {
 			throw new Error("Unsafe data URL scheme detected");
 		}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The application previously validated Data URLs solely by checking if the MIME type started with `image/` or `application/`. This inadvertently permitted unsafe types like `image/svg+xml`, `application/xhtml+xml`, or `application/xml`, which can execute JavaScript if opened directly in a browser context (e.g. via "Open in new tab").

⚠️ **Risk:** The potential impact if left unfixed
An attacker could craft a malicious dataset or configuration that generates a data URL containing embedded JavaScript payloads (e.g., inside an SVG `<script>` tag). If a user clicked "export" and opened the exported file in a new tab, the payload could execute in the context of the browser, leading to a Cross-Site Scripting (XSS) vulnerability.

🛡️ **Solution:** How the fix addresses the vulnerability
This patch updates the `downloadFile` utility in `src/services/export.ts`. It introduces a stricter validation mechanism that checks the normalized (lowercased) MIME type. If the MIME type includes `"svg"`, `"xml"`, or `"html"`, an exception is thrown, blocking the download. This ensures only safe, non-executable data URLs (like `image/png`) are processed via the `a.href = content` path. Legitimate SVG files exported via blobs continue to use the secure `Blob` URL path, preserving application functionality. Tests have been added to verify that `downloadFile` correctly rejects these unsafe Data URLs.

---
*PR created automatically by Jules for task [5027886248316557720](https://jules.google.com/task/5027886248316557720) started by @michaelkrisper*