### PR TITLE
🧪 Add unit tests for Modal component

### DIFF
--- a/src/components/Layout/__tests__/Modal.test.tsx
+++ b/src/components/Layout/__tests__/Modal.test.tsx
@@ -1,0 +1,141 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Modal } from "../Modal";
+
+describe("Modal", () => {
+	it("renders title as string and children", () => {
+		const onClose = vi.fn();
+		render(
+			<Modal onClose={onClose} title="Test Title">
+				<div>Test Content</div>
+			</Modal>,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: "Test Title" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Test Content")).toBeInTheDocument();
+	});
+
+	it("renders title as ReactNode", () => {
+		const onClose = vi.fn();
+		render(
+			<Modal
+				onClose={onClose}
+				title={<div data-testid="custom-title">Custom Node Title</div>}
+			>
+				<div>Test Content</div>
+			</Modal>,
+		);
+
+		expect(screen.getByTestId("custom-title")).toBeInTheDocument();
+		expect(screen.getByText("Custom Node Title")).toBeInTheDocument();
+	});
+
+	it("renders footer when provided", () => {
+		const onClose = vi.fn();
+		render(
+			<Modal
+				onClose={onClose}
+				title="Test Title"
+				footer={<div data-testid="modal-footer">Footer Content</div>}
+			>
+				<div>Test Content</div>
+			</Modal>,
+		);
+
+		expect(screen.getByTestId("modal-footer")).toBeInTheDocument();
+		expect(screen.getByText("Footer Content")).toBeInTheDocument();
+	});
+
+	it("renders headerActions when provided", () => {
+		const onClose = vi.fn();
+		render(
+			<Modal
+				onClose={onClose}
+				title="Test Title"
+				headerActions={<button type="button">Extra Action</button>}
+			>
+				<div>Test Content</div>
+			</Modal>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Extra Action" }),
+		).toBeInTheDocument();
+	});
+
+	it("calls onClose when the close button is clicked", () => {
+		const onClose = vi.fn();
+		render(
+			<Modal onClose={onClose} title="Test Title">
+				<div>Test Content</div>
+			</Modal>,
+		);
+
+		const closeButton = screen.getByRole("button", { name: "Close dialog" });
+		fireEvent.click(closeButton);
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses custom ariaLabel for close button", () => {
+		const onClose = vi.fn();
+		render(
+			<Modal onClose={onClose} title="Test Title" ariaLabel="Custom Close">
+				<div>Test Content</div>
+			</Modal>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Custom Close" }),
+		).toBeInTheDocument();
+	});
+
+	it("hides header when hideHeader is true", () => {
+		const onClose = vi.fn();
+		render(
+			<Modal onClose={onClose} title="Test Title" hideHeader={true}>
+				<div>Test Content</div>
+			</Modal>,
+		);
+
+		expect(
+			screen.queryByRole("heading", { name: "Test Title" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Close dialog" }),
+		).not.toBeInTheDocument();
+		// Content should still render
+		expect(screen.getByText("Test Content")).toBeInTheDocument();
+	});
+
+	it("applies custom styles to the modal card", () => {
+		const onClose = vi.fn();
+		const { container } = render(
+			<Modal
+				onClose={onClose}
+				title="Test Title"
+				padding="10px"
+				borderRadius="5px"
+				maxWidth="500px"
+				width="80%"
+				height="400px"
+				maxHeight="80vh"
+			>
+				<div>Test Content</div>
+			</Modal>,
+		);
+
+		const modalCard = container.querySelector(".modal-card");
+		expect(modalCard).toHaveStyle({
+			padding: "10px",
+			borderRadius: "5px",
+			maxWidth: "500px",
+			width: "80%",
+			height: "400px",
+			maxHeight: "80vh",
+		});
+	});
+});

--- a/src/workers/__tests__/parserClient.test.ts
+++ b/src/workers/__tests__/parserClient.test.ts
@@ -5,13 +5,13 @@ class MockWorker {
   onerror: ((ev: ErrorEvent | Event) => void) | null = null;
   postMessage = vi.fn();
 
-  simulateMessage(data: any) {
+  simulateMessage(data: unknown) {
     if (this.onmessage) {
       this.onmessage({ data } as MessageEvent);
     }
   }
 
-  simulateError(error: any) {
+  simulateError(error: ErrorEvent | Event) {
     if (this.onerror) {
       this.onerror(error);
     }


### PR DESCRIPTION
🎯 **What:** The `Modal` layout component in `src/components/Layout/Modal.tsx` lacked a test file, leaving standard rendering and callback behaviors unverified.
📊 **Coverage:** A new test suite was created in `src/components/Layout/__tests__/Modal.test.tsx`. The tests comprehensively cover:
- Standard rendering of `children`, `title` (both `string` and `ReactNode`), `footer`, and `headerActions`.
- Interaction verification for the `onClose` callback when the close button is clicked.
- Conditional rendering behavior when `hideHeader` is set to `true`.
- Correct application of custom style properties (`maxWidth`, `width`, `height`, `maxHeight`, `borderRadius`, `padding`).
- Correct rendering of custom `ariaLabel` on the close button.
✨ **Result:** Test coverage for the core `Modal` component has been established, ensuring future refactoring won't silently break its rendering logic or close handlers. Additionally, two preexisting minor type safety lint errors (`any` types) in `parserClient.test.ts` were corrected.

---
*PR created automatically by Jules for task [10313913793369500151](https://jules.google.com/task/10313913793369500151) started by @michaelkrisper*