### PR TITLE
🧪 [test] add FormulaReference tests

### DIFF
--- a/src/components/Layout/__tests__/FormulaReference.test.tsx
+++ b/src/components/Layout/__tests__/FormulaReference.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom";
+import { FormulaReference } from "../FormulaReference";
+
+describe("FormulaReference", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("renders correctly with initial state", () => {
+		const onInsert = vi.fn();
+		render(<FormulaReference onInsert={onInsert} />);
+
+		expect(screen.getByPlaceholderText(/Search functions/)).toBeInTheDocument();
+		expect(screen.getByRole("combobox")).toHaveValue("all");
+		expect(screen.getByRole("heading", { name: "Math" })).toBeInTheDocument();
+		expect(screen.getByRole("heading", { name: "Constants" })).toBeInTheDocument();
+	});
+
+	it("filters items by a text search query", () => {
+		const onInsert = vi.fn();
+		render(<FormulaReference onInsert={onInsert} />);
+
+		const searchInput = screen.getByPlaceholderText(/Search functions/);
+		fireEvent.change(searchInput, { target: { value: "rolling" } });
+
+		// Checking heading text which is more reliable
+		expect(screen.queryByRole("heading", { name: "Math" })).not.toBeInTheDocument();
+		expect(screen.getByRole("heading", { name: "Rolling / smoothing" })).toBeInTheDocument();
+	});
+
+	it("filters items by category select", () => {
+		const onInsert = vi.fn();
+		render(<FormulaReference onInsert={onInsert} />);
+
+		const select = screen.getByRole("combobox");
+		fireEvent.change(select, { target: { value: "math" } });
+
+		expect(screen.getByRole("heading", { name: "Math" })).toBeInTheDocument();
+		expect(screen.queryByRole("heading", { name: "Logic" })).not.toBeInTheDocument();
+	});
+
+	it("shows an empty state message when a search query yields no results", () => {
+		const onInsert = vi.fn();
+		render(<FormulaReference onInsert={onInsert} />);
+
+		const searchInput = screen.getByPlaceholderText(/Search functions/);
+		fireEvent.change(searchInput, {
+			target: { value: "notafunctionthatshouldeverexist" },
+		});
+
+		expect(screen.getByText(/No functions match/)).toBeInTheDocument();
+	});
+
+	it("calls onInsert prop when a function button is clicked", () => {
+		const onInsert = vi.fn();
+		render(<FormulaReference onInsert={onInsert} />);
+
+		const insertButtons = screen.getAllByRole("button");
+		const mathInsertButton = insertButtons.find((b) =>
+			b.title.includes("abs("),
+		);
+		if (!mathInsertButton)
+			throw new Error("Could not find insert button for abs");
+
+		fireEvent.click(mathInsertButton);
+		expect(onInsert).toHaveBeenCalledWith("abs(", true);
+	});
+
+	it("calls onInsert prop when a constant button is clicked", () => {
+		const onInsert = vi.fn();
+		render(<FormulaReference onInsert={onInsert} />);
+
+		const insertButtons = screen.getAllByRole("button");
+		const constantInsertButton = insertButtons.find((b) =>
+			b.title.includes("Insert pi"),
+		);
+		if (!constantInsertButton)
+			throw new Error("Could not find insert button for pi");
+
+		fireEvent.click(constantInsertButton);
+		expect(onInsert).toHaveBeenCalledWith("pi", false);
+	});
+});


### PR DESCRIPTION
🎯 **What:** The testing gap for the `FormulaReference` component was addressed by creating its missing test file.
📊 **Coverage:** The test suite now covers:
- Rendering the initial state properly, including default categories.
- Filtering listed functions and constants via a text search query.
- Filtering functions via the category dropdown select.
- Displaying the correct empty state text when a search yields zero results.
- Firing the `onInsert` prop with the correct arguments when clicking function or constant insert buttons.
✨ **Result:** Test coverage improved by properly verifying DOM interaction and component logic in `FormulaReference`.

---
*PR created automatically by Jules for task [6598969226726800844](https://jules.google.com/task/6598969226726800844) started by @michaelkrisper*