### PR TITLE
🧪 Add test suite for parser.worker.ts

### DIFF
--- a/src/workers/__tests__/parser.worker.test.ts
+++ b/src/workers/__tests__/parser.worker.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Dataset } from "../../services/persistence";
+import { parseData } from "../../utils/data-parser";
+
+vi.mock("../../utils/data-parser", () => ({
+	parseData: vi.fn(),
+}));
+
+describe("parser.worker", () => {
+	let postMessageMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		postMessageMock = vi.fn();
+
+		// Stub the global self properties required by the worker
+		vi.stubGlobal("postMessage", postMessageMock);
+
+		// Import the worker so it registers `self.onmessage`
+		await import("../parser.worker");
+	});
+
+	it("should process a file successfully and post transferables", async () => {
+		const mockFile = new File(["dummy"], "test.csv", { type: "text/csv" });
+		const mockArrayBuffer = new ArrayBuffer(8);
+		const mockDataset = [
+			{
+				id: "123",
+				name: "test.csv",
+				columns: ["col1"],
+				rowCount: 1,
+				data: [
+					{
+						isFloat64: true,
+						refPoint: 0,
+						bounds: { min: 0, max: 0 },
+						data: new Float64Array(mockArrayBuffer),
+					},
+				],
+			},
+		];
+
+		vi.mocked(parseData).mockResolvedValue(mockDataset as any);
+
+		const event = new MessageEvent("message", {
+			data: {
+				id: 1,
+				file: mockFile,
+				type: "csv",
+			},
+		});
+
+		// call self.onmessage
+		await (self as any).onmessage(event);
+
+		expect(parseData).toHaveBeenCalledWith(mockFile, "csv", undefined);
+		expect(postMessageMock).toHaveBeenCalledWith(
+			{ id: 1, type: "success", datasets: mockDataset },
+			[mockArrayBuffer],
+		);
+	});
+
+	it("should handle Error object from parseData", async () => {
+		const mockFile = new File(["dummy"], "test.csv", { type: "text/csv" });
+		vi.mocked(parseData).mockRejectedValue(new Error("Parse failed"));
+
+		const event = new MessageEvent("message", {
+			data: {
+				id: 2,
+				file: mockFile,
+				type: "csv",
+			},
+		});
+
+		await (self as any).onmessage(event);
+
+		expect(postMessageMock).toHaveBeenCalledWith({
+			id: 2,
+			type: "error",
+			error: "Parse failed",
+		});
+	});
+
+	it("should handle string error from parseData", async () => {
+		const mockFile = new File(["dummy"], "test.csv", { type: "text/csv" });
+		vi.mocked(parseData).mockRejectedValue("String error");
+
+		const event = new MessageEvent("message", {
+			data: {
+				id: 3,
+				file: mockFile,
+				type: "csv",
+			},
+		});
+
+		await (self as any).onmessage(event);
+
+		expect(postMessageMock).toHaveBeenCalledWith({
+			id: 3,
+			type: "error",
+			error: "String error",
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `src/workers/parser.worker.ts`.
📊 **Coverage:** Tests verify the success case (ensuring proper transferables collection and correct `self.postMessage` response) and both error paths (when `parseData` throws an Error object or a primitive/string).
✨ **Result:** Increased code reliability and coverage for the main parser web worker.

---
*PR created automatically by Jules for task [15669885773220560454](https://jules.google.com/task/15669885773220560454) started by @michaelkrisper*