### PR TITLE
🧹 Refactor `applyTheme` in `useTheme.ts` to improve maintainability

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -49,14 +49,21 @@ function subscribe(cb: () => void) {
 	return () => listeners.delete(cb);
 }
 
-function applyTheme(t: ThemeName) {
-	loadFont(t);
-	if (typeof localStorage !== "undefined") localStorage.setItem(STORAGE_KEY, t);
+function persistTheme(t: ThemeName) {
+	if (typeof localStorage !== "undefined") {
+		localStorage.setItem(STORAGE_KEY, t);
+	}
+}
+
+function updateThemeDOM(t: ThemeName) {
 	document.documentElement.dataset.theme = t;
 	document.documentElement.classList.toggle(
 		"dark",
 		t === "dark" || t === "matrix",
 	);
+}
+
+function updateThemeVariables(t: ThemeName) {
 	const theme = THEMES[t];
 	const s = document.documentElement.style;
 	s.setProperty("--font-family", theme.fontFamily);
@@ -89,16 +96,23 @@ function applyTheme(t: ThemeName) {
 	s.setProperty("--tooltip-divider-color", theme.tooltipDividerColor);
 	s.setProperty("--tooltip-sub-color", theme.tooltipSubColor);
 	s.setProperty("--no-data-color", theme.noDataColor);
+}
+
+function notifyListeners() {
 	listeners.forEach((cb) => {
 		cb();
 	});
 }
 
-export function useTheme(): [
-	ThemeName,
-	() => void,
-	(t: ThemeName) => void,
-] {
+function applyTheme(t: ThemeName) {
+	loadFont(t);
+	persistTheme(t);
+	updateThemeDOM(t);
+	updateThemeVariables(t);
+	notifyListeners();
+}
+
+export function useTheme(): [ThemeName, () => void, (t: ThemeName) => void] {
 	const theme = useSyncExternalStore(subscribe, getSnapshot);
 	const cycle = () =>
 		applyTheme(


### PR DESCRIPTION
🎯 **What:** The monolithic `applyTheme` function in `src/hooks/useTheme.ts` was around 40 lines long and has been broken down into multiple focused helper functions (`persistTheme`, `updateThemeDOM`, `updateThemeVariables`, `notifyListeners`).
💡 **Why:** Smaller functions adhere to better coding standards, separating concerns such as local storage persistence, DOM mutations, CSS variable updates, and listener execution, which enhances maintainability.
✅ **Verification:** A Python script was used to safely perform exact code replacement, ensuring logic remained exactly as before. Biome was run to format the changes. `pnpm run test` confirmed no tests regressed, and `pnpm lint` passed cleanly (also fixing a minor TypeScript any issue in a worker test file).
✨ **Result:** `applyTheme` is now a 6-line readable orchestrator function instead of 40 lines, while preserving identical logic and passing all checks.

---
*PR created automatically by Jules for task [1846709031665700114](https://jules.google.com/task/1846709031665700114) started by @michaelkrisper*