### PR TITLE
🧹 chore: remove dead comment in regression tests

### DIFF
--- a/src/utils/__tests__/regression.test.ts
+++ b/src/utils/__tests__/regression.test.ts
@@ -77,7 +77,6 @@ describe("Regression Utilities", () => {
 			const y = new Float64Array([1, 2, 3]);
 			const result = polynomialRegression(x, y, 2);
 			expect(result.length).toBe(3);
-			// Since it's singular, it will fall back to 0s for undefined terms
 		});
 
 		it("should cap degree at n-1", () => {


### PR DESCRIPTION
🎯 **What:** Removed a dead code comment (`// Since it's singular, it will fall back to 0s for undefined terms`) from the `polynomialRegression` test in `src/utils/__tests__/regression.test.ts`.

💡 **Why:** To improve code maintainability by eliminating redundant or leftover comments that are no longer useful.

✅ **Verification:** 
- Used a Python replacement script to correctly target and remove the specific comment line.
- Visually inspected the file via `cat`.
- Formatted the file using Biome.
- Ran the specific test file `pnpm run test src/utils/__tests__/regression.test.ts` (passed).
- Ran the full test suite `pnpm run test` (all 573 tests passed).

✨ **Result:** The code is cleaner without the dead code comment, with no behavior changes.

---
*PR created automatically by Jules for task [8078864254207902867](https://jules.google.com/task/8078864254207902867) started by @michaelkrisper*