### PR TITLE
🔒 fix(export): mitigate SVG XSS vulnerability by escaping axis labels

### DIFF
--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -350,7 +350,7 @@ export const exportToSVG = (
 				axis.xMode === "date"
 					? formatDate(t, xStep)
 					: formatAxisLabel(t, xPrecision);
-			svg += `<text x="${x}" y="${baseY + 24}" text-anchor="middle" font-size="12" fill="${theme.labelColor}">${label}</text>`;
+			svg += `<text x="${x}" y="${baseY + 24}" text-anchor="middle" font-size="12" fill="${theme.labelColor}">${escapeHTML(label)}</text>`;
 		}
 
 		const datasetsForThisAxis = datasetsByXAxisId[axis.id] || [];
@@ -402,7 +402,7 @@ export const exportToSVG = (
 			});
 			svg += `<line x1="${lineX - (isLeft ? 5 : 0)}" y1="${y}" x2="${lineX + (isLeft ? 0 : 5)}" y2="${y}" stroke="${theme.axisColor}" stroke-width="1" />`;
 			const labelX = xPos + axisWidth - 8;
-			svg += `<text x="${labelX}" y="${y + 4}" text-anchor="end" font-size="12" fill="${theme.labelColor}">${formatAxisLabel(t, precision)}</text>`;
+			svg += `<text x="${labelX}" y="${y + 4}" text-anchor="end" font-size="12" fill="${theme.labelColor}">${escapeHTML(formatAxisLabel(t, precision))}</text>`;
 		}
 
 		const axisSeries = seriesByYAxisId[axis.id] || [];


### PR DESCRIPTION
🎯 **What:** An XSS vulnerability existed where unescaped axis labels were injected directly into SVG `<text>` elements.
⚠️ **Risk:** An attacker could craft a malicious label that executes arbitrary JavaScript or corrupts the document when the SVG is rendered or downloaded, impacting any user exporting or viewing the charts.
🛡️ **Solution:** The fix wraps the dynamically generated labels (both `label` for X-axis and `formatAxisLabel` output for Y-axis) in `escapeHTML()` before interpolating them into the SVG strings. This sanitizes the input and prevents malicious script execution while preserving identical functionality.

---
*PR created automatically by Jules for task [16912577997293801515](https://jules.google.com/task/16912577997293801515) started by @michaelkrisper*