### PR TITLE
🧪 Add edge case tests for hexToRgba and hexToRgb

### DIFF
--- a/src/components/Plot/__tests__/WebGLRenderer.test.tsx
+++ b/src/components/Plot/__tests__/WebGLRenderer.test.tsx
@@ -23,6 +23,7 @@ describe("hexToRgba", () => {
 	it("handles invalid inputs gracefully", () => {
 		// missing #
 		expect(hexToRgba("FFFFFF")).toEqual([0, 0, 0]);
+		expect(hexToRgba("invalid")).toEqual([0, 0, 0]);
 		// undefined
 		// @ts-expect-error testing invalid input
 		expect(hexToRgba(undefined)).toEqual([0, 0, 0]);
@@ -39,6 +40,7 @@ describe("hexToRgba", () => {
 	it("handles invalid hex formats gracefully", () => {
 		// too short, parses NaN
 		expect(hexToRgba("#FF")).toEqual([0, 0, 0]);
+		expect(hexToRgba("#zzz")).toEqual([0, 0, 0]);
 		// too long
 		expect(hexToRgba("#FFFFFFFF")).toEqual([0, 0, 0]);
 		// nonsense characters

--- a/src/utils/__tests__/colors.test.ts
+++ b/src/utils/__tests__/colors.test.ts
@@ -41,10 +41,12 @@ describe("colors", () => {
 		it("should handle invalid hex strings safely", () => {
 			// Missing #
 			expect(hexToRgb("ffffff")).toEqual({ r: 0, g: 0, b: 0 });
+			expect(hexToRgb("invalid")).toEqual({ r: 0, g: 0, b: 0 });
 
 			// Incorrect length
 			expect(hexToRgb("#fff")).toEqual({ r: 0, g: 0, b: 0 });
 			expect(hexToRgb("#ffffffff")).toEqual({ r: 0, g: 0, b: 0 });
+			expect(hexToRgb("#zzz")).toEqual({ r: 0, g: 0, b: 0 });
 
 			// Invalid characters resulting in NaN
 			expect(hexToRgb("#zzxxxx")).toEqual({ r: 0, g: 0, b: 0 });
@@ -89,10 +91,12 @@ describe("colors", () => {
 		it("should handle invalid hex strings safely", () => {
 			// Missing #
 			expect(hexToRgba("ffffff")).toEqual([0, 0, 0]);
+			expect(hexToRgba("invalid")).toEqual([0, 0, 0]);
 
 			// Incorrect length
 			expect(hexToRgba("#fff")).toEqual([0, 0, 0]);
 			expect(hexToRgba("#ffffffff")).toEqual([0, 0, 0]);
+			expect(hexToRgba("#zzz")).toEqual([0, 0, 0]);
 
 			// Invalid characters resulting in NaN
 			expect(hexToRgba("#zzxxxx")).toEqual([0, 0, 0]);


### PR DESCRIPTION
🎯 **What:** Added explicit tests to cover edge cases (`'invalid'` string and `'#zzz'`) in `hexToRgba` and `hexToRgb` functions within `src/utils/colors.ts`.
📊 **Coverage:** The test suite now explicitly covers malformed hex strings of incorrect length without # prefix (`'invalid'`) and incorrect length with # prefix but nonsense characters (`'#zzz'`).
✨ **Result:** Improved test coverage and explicitly documented the safe fallback behavior (`[0, 0, 0]` and `{ r: 0, g: 0, b: 0 }`) of the utility functions on invalid inputs.

---
*PR created automatically by Jules for task [15049614207431183824](https://jules.google.com/task/15049614207431183824) started by @michaelkrisper*