### PR TITLE
🧪 [test] add error test for initiateImport in useDataImport

### DIFF
--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -456,4 +456,27 @@ describe("useDataImport hook", () => {
 
 		global.FileReader = originalFileReader;
 	});
+
+	it("should handle file reading errors in initiateImport", async () => {
+		const { result } = renderHook(() => useDataImport());
+
+		const file = new File([""], "test.csv", { type: "text/csv" });
+
+		const originalFileReader = global.FileReader;
+		class MockFileReader {
+			onerror: ((event: any) => void) | null = null;
+			readAsText() {
+				this.onerror?.(new Event("error"));
+			}
+		}
+		global.FileReader = MockFileReader as unknown as typeof FileReader;
+
+		await act(async () => {
+			await result.current.importFile(file);
+		});
+
+		expect(result.current.error).toBe("Failed to read file.");
+
+		global.FileReader = originalFileReader;
+	});
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The error handling catch block in the `initiateImport` function of `useDataImport` was missing test coverage. This is triggered when the underlying `FileReader` fails (e.g. `onerror` is called).

📊 **Coverage:** What scenarios are now tested
A new test `should handle file reading errors in initiateImport` was added. This test mocks `FileReader` such that `onerror` is triggered when `readAsText` is called. It asserts that the `result.current.error` state correctly reflects the error message.

✨ **Result:** The improvement in test coverage
The error condition in `initiateImport` is fully covered, ensuring that file reading failures are caught and surfaced to the UI correctly. Coverage of `src/hooks/useDataImport.ts` is improved.

---
*PR created automatically by Jules for task [13080797312735221768](https://jules.google.com/task/13080797312735221768) started by @michaelkrisper*