### PR TITLE
🧹 Refactor nested conditional in resolveBracketedReferences

### DIFF
--- a/src/utils/formula.ts
+++ b/src/utils/formula.ts
@@ -650,24 +650,7 @@ function resolveBracketedReferences(
 			const candidate = formula.substring(start + 1, end);
 			if (map1.has(candidate)) bestEnd = end;
 		}
-		if (bestEnd === -1) {
-			end = formula.indexOf("]", start + 1);
-			if (end === -1) {
-				scanPos = start + 1;
-				continue;
-			}
-			const colName = formula.substring(start + 1, end);
-			const fullMatch = formula.substring(start, end + 1);
-			if (!columnMap.has(fullMatch)) {
-				return {
-					evaluate: () => NaN,
-					usedColumnIndices: [],
-					error: `Column not found: ${colName}`,
-					errorPos: start,
-				};
-			}
-			scanPos = end + 1;
-		} else {
+		if (bestEnd !== -1) {
 			const fullMatch = formula.substring(start, bestEnd + 1);
 			if (!columnMap.has(fullMatch)) {
 				const colName = formula.substring(start + 1, bestEnd);
@@ -676,7 +659,26 @@ function resolveBracketedReferences(
 				usedColumnIndices.push(colIndex);
 			}
 			scanPos = bestEnd + 1;
+			continue;
 		}
+
+		end = formula.indexOf("]", start + 1);
+		if (end === -1) {
+			scanPos = start + 1;
+			continue;
+		}
+
+		const colName = formula.substring(start + 1, end);
+		const fullMatch = formula.substring(start, end + 1);
+		if (!columnMap.has(fullMatch)) {
+			return {
+				evaluate: () => NaN,
+				usedColumnIndices: [],
+				error: `Column not found: ${colName}`,
+				errorPos: start,
+			};
+		}
+		scanPos = end + 1;
 	}
 	return null;
 }


### PR DESCRIPTION
🎯 **What:** Simplified a deeply nested conditional in `resolveBracketedReferences` inside `src/utils/formula.ts`.
💡 **Why:** By converting the nested block into an early return (using `continue`), we flatten the loop's structure and separate the success path from the fallback/error path. This improves code readability and maintainability.
✅ **Verification:** Verified changes locally by successfully running `pnpm run test src/utils/__tests__/formula.test.ts` and the full test suite (`pnpm run test`). Code review marked the implementation as #Correct#.
✨ **Result:** The code block is now linear and easier to trace, with no change in functionality.

---
*PR created automatically by Jules for task [15933110430977432311](https://jules.google.com/task/15933110430977432311) started by @michaelkrisper*