### PR TITLE
🧹 Refactor statefulSumGroup and statefulAvgGroup to use early returns

### DIFF
--- a/src/utils/formula.ts
+++ b/src/utils/formula.ts
@@ -424,14 +424,16 @@ function statefulAvgGroup(
 	val: number,
 	key: string | number,
 ): number {
-	if (ctx.groupLastKey[id] !== key) {
-		ctx.groupSums[id] = 0;
-		ctx.groupCounts[id] = 0;
-		ctx.groupLastKey[id] = key;
+	if (ctx.groupLastKey[id] === key) {
+		ctx.groupSums[id] += val;
+		ctx.groupCounts[id] += 1;
+		return ctx.groupSums[id] / ctx.groupCounts[id];
 	}
-	ctx.groupSums[id] = (ctx.groupSums[id] || 0) + val;
-	ctx.groupCounts[id] = (ctx.groupCounts[id] || 0) + 1;
-	return ctx.groupSums[id] / ctx.groupCounts[id];
+
+	ctx.groupSums[id] = val;
+	ctx.groupCounts[id] = 1;
+	ctx.groupLastKey[id] = key;
+	return val;
 }
 
 function statefulSumGroup(
@@ -440,12 +442,14 @@ function statefulSumGroup(
 	val: number,
 	key: string | number,
 ): number {
-	if (ctx.groupLastKey[id] !== key) {
-		ctx.groupSums[id] = 0;
-		ctx.groupLastKey[id] = key;
+	if (ctx.groupLastKey[id] === key) {
+		ctx.groupSums[id] += val;
+		return ctx.groupSums[id];
 	}
-	ctx.groupSums[id] = (ctx.groupSums[id] || 0) + val;
-	return ctx.groupSums[id];
+
+	ctx.groupSums[id] = val;
+	ctx.groupLastKey[id] = key;
+	return val;
 }
 
 function pushBoundedQueue(


### PR DESCRIPTION
🎯 **What:** Refactored `statefulSumGroup` and `statefulAvgGroup` in `src/utils/formula.ts` to utilize early returns.
💡 **Why:** This reduces cognitive complexity by eliminating the `|| 0` fallbacks and splitting the updates into distinct execution paths (updating an existing group vs. initializing a new group).
✅ **Verification:** Verified the code changes visually, confirmed the localized test `src/utils/__tests__/formula.test.ts` passed, and ran the full test suite (`pnpm run test`), which passed with zero regressions.
✨ **Result:** Cleaner and more readable code with preserved functionality.

---
*PR created automatically by Jules for task [10145373924216210317](https://jules.google.com/task/10145373924216210317) started by @michaelkrisper*