### PR TITLE
🧪 Test mathematical inverse of rgbToLch via lchToRgb

### DIFF
--- a/src/utils/__tests__/colors.test.ts
+++ b/src/utils/__tests__/colors.test.ts
@@ -164,6 +164,20 @@ describe("colors", () => {
 			}
 		});
 
+		it("should be the inverse of rgbToLch for a wide color spectrum", () => {
+			for (let r = 0; r <= 255; r += 15) {
+				for (let g = 0; g <= 255; g += 15) {
+					for (let b = 0; b <= 255; b += 15) {
+						const lch = rgbToLch(r, g, b);
+						const rgb = lchToRgb(lch.L, lch.C, lch.h);
+						expect(Math.abs(rgb.r - r)).toBeLessThanOrEqual(1);
+						expect(Math.abs(rgb.g - g)).toBeLessThanOrEqual(1);
+						expect(Math.abs(rgb.b - b)).toBeLessThanOrEqual(1);
+					}
+				}
+			}
+		});
+
 		it("should clamp output to valid RGB ranges (0-255)", () => {
 			// Super high lightness/chroma
 			const overblown = lchToRgb(150, 200, 180);


### PR DESCRIPTION
🎯 **What:** The testing gap for `lchToRgb` addressed by testing its mathematical reverse against `rgbToLch`.
📊 **Coverage:** A wide color spectrum is now tested by looping R, G, B values from 0 to 255 with a step of 15 (~4900 test points) to ensure the conversion back to RGB correctly matches the original input.
✨ **Result:** Improved test coverage and reliability for color conversions without introducing flaky floating point assertions.

---
*PR created automatically by Jules for task [4688050613253367428](https://jules.google.com/task/4688050613253367428) started by @michaelkrisper*