### PR TITLE
revert: drop premature xAxesMetrics map optimization (#472)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -1223,96 +1223,86 @@ export default function ChartContainer() {
 					fontFamily={themeColors.fontFamily}
 					isInteracting={isInteracting}
 				/>
-				{(() => {
-					const xAxesLayoutById = xAxesLayout.reduce(
-						(acc, a) => {
-							acc[a.id] = a;
-							return acc;
-						},
-						{} as Record<string, (typeof xAxesLayout)[0]>,
-					);
-
-					return xAxesMetrics.map((m) => {
-						const bY = padding.bottom - m.cumulativeOffset - m.height;
-						const title = xAxesLayoutById[m.id]?.title || "";
-						return (
-							<Fragment key={`wheel-x-${m.id}`}>
-								<div
-									role="region"
-									aria-label={`X-Axis ${m.id} interaction area`}
-									onWheel={(e) => {
-										e.stopPropagation();
-										handleWheel(e, { xAxisId: m.id });
+				{xAxesMetrics.map((m) => {
+					const bY = padding.bottom - m.cumulativeOffset - m.height;
+					const title = xAxesLayout.find((a) => a.id === m.id)?.title || "";
+					return (
+						<Fragment key={`wheel-x-${m.id}`}>
+							<div
+								role="region"
+								aria-label={`X-Axis ${m.id} interaction area`}
+								onWheel={(e) => {
+									e.stopPropagation();
+									handleWheel(e, { xAxisId: m.id });
+								}}
+								onMouseDown={(e) => {
+									e.stopPropagation();
+									handleMouseDown(e, { xAxisId: m.id });
+								}}
+								onTouchStart={(e) => {
+									e.stopPropagation();
+									handleTouchStart(e, { xAxisId: m.id });
+								}}
+								onDoubleClick={(e) => {
+									e.stopPropagation();
+									const rect = e.currentTarget.getBoundingClientRect();
+									const yInside = e.clientY - rect.top;
+									// Check if double click is in the title area (roughly bottom 30px)
+									if (yInside >= m.titleBottom - 30) {
+										setEditingXAxisId(m.id);
+									} else {
+										handleAutoScaleX(m.id);
+									}
+								}}
+								style={{
+									position: "absolute",
+									bottom: bY,
+									left: padding.left,
+									right: padding.right,
+									height: m.height,
+									cursor: "ew-resize",
+									zIndex: 20,
+								}}
+							/>
+							{editingXAxisId === m.id && (
+								<input
+									defaultValue={title}
+									onBlur={(e) => {
+										const newName = e.target.value.trim();
+										useGraphStore
+											.getState()
+											.updateXAxis(m.id, { name: newName });
+										setEditingXAxisId(null);
 									}}
-									onMouseDown={(e) => {
-										e.stopPropagation();
-										handleMouseDown(e, { xAxisId: m.id });
-									}}
-									onTouchStart={(e) => {
-										e.stopPropagation();
-										handleTouchStart(e, { xAxisId: m.id });
-									}}
-									onDoubleClick={(e) => {
-										e.stopPropagation();
-										const rect = e.currentTarget.getBoundingClientRect();
-										const yInside = e.clientY - rect.top;
-										// Check if double click is in the title area (roughly bottom 30px)
-										if (yInside >= m.titleBottom - 30) {
-											setEditingXAxisId(m.id);
-										} else {
-											handleAutoScaleX(m.id);
+									onKeyDown={(e) => {
+										if (e.key === "Enter") {
+											e.currentTarget.blur();
+										} else if (e.key === "Escape") {
+											setEditingXAxisId(null);
 										}
 									}}
 									style={{
 										position: "absolute",
-										bottom: bY,
-										left: padding.left,
-										right: padding.right,
-										height: m.height,
-										cursor: "ew-resize",
-										zIndex: 20,
+										bottom: bY + m.height - m.titleBottom + 2,
+										left: "50%",
+										transform: "translateX(-50%)",
+										zIndex: 30,
+										textAlign: "center",
+										font: `bold 12px ${themeColors.fontFamily}`,
+										color: themeColors.labelColor,
+										background: themeColors.plotBg,
+										border: `1px solid ${themeColors.gridColor}`,
+										borderRadius: "4px",
+										padding: "2px 4px",
+										outline: "none",
+										width: "80%",
+										maxWidth: "300px",
 									}}
 								/>
-								{editingXAxisId === m.id && (
-									<input
-										defaultValue={title}
-										onBlur={(e) => {
-											const newName = e.target.value.trim();
-											useGraphStore
-												.getState()
-												.updateXAxis(m.id, { name: newName });
-											setEditingXAxisId(null);
-										}}
-										onKeyDown={(e) => {
-											if (e.key === "Enter") {
-												e.currentTarget.blur();
-											} else if (e.key === "Escape") {
-												setEditingXAxisId(null);
-											}
-										}}
-										style={{
-											position: "absolute",
-											bottom: bY + m.height - m.titleBottom + 2,
-											left: "50%",
-											transform: "translateX(-50%)",
-											zIndex: 30,
-											textAlign: "center",
-											font: `bold 12px ${themeColors.fontFamily}`,
-											color: themeColors.labelColor,
-											background: themeColors.plotBg,
-											border: `1px solid ${themeColors.gridColor}`,
-											borderRadius: "4px",
-											padding: "2px 4px",
-											outline: "none",
-											width: "80%",
-											maxWidth: "300px",
-										}}
-									/>
-								)}
-							</Fragment>
-						);
-					});
-				})()}
+							)}
+						</Fragment>
+					);
+				})}
 				{activeYAxes.map((a) => {
 					const isL = a.position === "left",
 						am = axisLayout[a.id] || { total: 40 };


### PR DESCRIPTION
## Summary
Reverts the `xAxesMetrics` map optimization from #472.

That PR replaced an inline `xAxesLayout.find((a) => a.id === m.id)` with a precomputed `Record` built via `reduce` inside an IIFE wrapping the JSX. The `.find` runs over the set of X-axes — a handful at most in practice — so the O(N²)→O(N) change had no measurable effect (the PR's "10× at 1000 elements" benchmark doesn't reflect realistic axis counts). What it did add: an IIFE, an extra indentation level across ~80 lines of JSX, and a per-render allocation.

This restores the simpler, more readable inline `.find`.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm build` succeeds (tsc + vite — the deploy gate)
- [x] `pnpm test` — 616/616 pass
- [x] Diff is a pure revert of #472's ChartContainer change (no other file touched it since)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGevfWw3cjXDZYMWakKS6H)_