### PR TITLE
🔒 Fix unsafe data URL usage in downloadFile

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -542,6 +542,7 @@ describe("downloadFile", () => {
 	});
 
 	it("should handle data URLs correctly", () => {
+		vi.useFakeTimers();
 		const content =
 			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 		downloadFile(content, "test.png", "image/png");
@@ -555,10 +556,16 @@ describe("downloadFile", () => {
 			download: string;
 			click: () => void;
 		};
-		expect(a.href).toBe(content);
+		expect(URL.createObjectURL).toHaveBeenCalled();
+		expect(a.href).toBe("blob:mock-url");
 		expect(a.download).toBe("test.png");
 		expect(mockClick).toHaveBeenCalled();
-		expect(URL.createObjectURL).not.toHaveBeenCalled();
+
+		expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(100);
+		expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+
+		vi.useRealTimers();
 	});
 
 	it("should throw an error for unsafe data URLs", () => {
@@ -576,15 +583,27 @@ describe("downloadFile", () => {
 	});
 
 	it("should throw an error for unsafe MIME types (svg/xml/html)", () => {
-		expect(() => downloadFile("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=", "test.svg", "image/svg+xml")).toThrow(
-			"Unsafe data URL scheme detected",
-		);
-		expect(() => downloadFile("data:application/xhtml+xml;base64,PGh0bWw+PC9odG1sPg==", "test.html", "application/xhtml+xml")).toThrow(
-			"Unsafe data URL scheme detected",
-		);
-		expect(() => downloadFile("data:image/SVG+XML;base64,PHN2Zz48L3N2Zz4=", "test.svg", "image/SVG+XML")).toThrow(
-			"Unsafe data URL scheme detected",
-		);
+		expect(() =>
+			downloadFile(
+				"data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
+				"test.svg",
+				"image/svg+xml",
+			),
+		).toThrow("Unsafe data URL scheme detected");
+		expect(() =>
+			downloadFile(
+				"data:application/xhtml+xml;base64,PGh0bWw+PC9odG1sPg==",
+				"test.html",
+				"application/xhtml+xml",
+			),
+		).toThrow("Unsafe data URL scheme detected");
+		expect(() =>
+			downloadFile(
+				"data:image/SVG+XML;base64,PHN2Zz48L3N2Zz4=",
+				"test.svg",
+				"image/SVG+XML",
+			),
+		).toThrow("Unsafe data URL scheme detected");
 	});
 
 	it("should throw an error for empty data URLs", () => {
@@ -824,15 +843,7 @@ describe("exportToSVG edge cases", () => {
 		const series: SeriesConfig[] = [];
 		const xAxes: XAxisConfig[] = [];
 		const yAxes: YAxisConfig[] = [];
-		const svg = exportToSVG(
-			datasets,
-			series,
-			xAxes,
-			yAxes,
-			0,
-			0,
-			THEMES.light,
-		);
+		const svg = exportToSVG(datasets, series, xAxes, yAxes, 0, 0, THEMES.light);
 		expect(svg).toContain('<svg width="0" height="0"');
 	});
 });

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -517,6 +517,8 @@ export const downloadFile = (
 ) => {
 	const a = document.createElement("a");
 	const isDataUrl = content.startsWith("data:");
+	let urlToDownload = content;
+
 	if (isDataUrl) {
 		// Ensure the data URL has a safe MIME type to prevent XSS
 		try {
@@ -547,18 +549,30 @@ export const downloadFile = (
 			) {
 				throw new Error();
 			}
+
+			const data = url.pathname.slice(commaIndex + 1);
+			const isBase64 = parts.includes("base64");
+
+			const byteString = isBase64 ? atob(data) : decodeURIComponent(data);
+			const arrayBuffer = new Uint8Array(byteString.length);
+			for (let i = 0; i < byteString.length; i++) {
+				arrayBuffer[i] = byteString.charCodeAt(i);
+			}
+
+			const blob = new Blob([arrayBuffer], { type: contentType || mimeType });
+			urlToDownload = URL.createObjectURL(blob);
 		} catch {
 			throw new Error("Unsafe data URL scheme detected");
 		}
-		a.href = content;
 	} else {
 		const file = new Blob([content], { type: contentType });
-		a.href = URL.createObjectURL(file);
+		urlToDownload = URL.createObjectURL(file);
 	}
+
+	a.href = urlToDownload;
 	a.download = fileName;
 	a.click();
-	if (!isDataUrl) {
-		// Security/Memory leak prevention: revoke the object URL after download
-		setTimeout(() => URL.revokeObjectURL(a.href), 100);
-	}
+
+	// Security/Memory leak prevention: revoke the object URL after download
+	setTimeout(() => URL.revokeObjectURL(a.href), 100);
 };


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed an issue in `downloadFile` where user-provided Data URLs were assigned directly to an anchor tag's `href` attribute for downloading, relying on basic substring matching for security.

⚠️ **Risk:** The potential impact if left unfixed
Directly assigning Data URLs to an `a.href` attribute can lead to Cross-Site Scripting (XSS) vulnerabilities if the validation logic is bypassed or incomplete. 

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the direct assignment pattern with a secure implementation that manually parses the Data URL payload (handling both base64 and URI-encoded formats), constructs a `Uint8Array`, and creates a `Blob` using the validated MIME type. The file is then downloaded using `URL.createObjectURL()`, which safely encapsulates the data and prevents execution, eliminating the XSS vector entirely. Test coverage was also updated to verify the new Object URL lifecycle and revocation behavior.

---
*PR created automatically by Jules for task [2209746065709138139](https://jules.google.com/task/2209746065709138139) started by @michaelkrisper*