### PR TITLE
Fix lint in merged Jules PRs (#492/#493/#495)

### DIFF
--- a/src/components/Plot/__tests__/ChartContainer.test.tsx
+++ b/src/components/Plot/__tests__/ChartContainer.test.tsx
@@ -1,4 +1,6 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+// Mock-heavy component test: store/hook mocks use loose `any` shapes on purpose.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import ChartContainer from "../ChartContainer";
 import { useGraphStore } from "../../../store/useGraphStore";

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -515,7 +515,7 @@ export const downloadFile = (
 ) => {
 	const a = document.createElement("a");
 	const isDataUrl = content.startsWith("data:");
-	let urlToDownload = content;
+	let urlToDownload: string;
 
 	if (isDataUrl) {
 		// Ensure the data URL has a safe MIME type to prevent XSS


### PR DESCRIPTION
## Context

PRs #492, #493 and #495 (from Jules) were merged into `master`. They were branched off old `master` and introduced 12 lint errors that `pnpm lint` flags (CI only runs `build`, so they slipped through). This cleans them up so the tree is lint-clean again.

## Changes

- **`export.ts` (#493)**: drop the useless initial `let urlToDownload = content` — both branches reassign before use, so it's declared `let urlToDownload: string` instead (`no-useless-assignment`).
- **`ChartContainer.test.tsx` (#495)**: remove the unused `act` import and add a file-scoped `@typescript-eslint/no-explicit-any` disable (with a justification) for the intentionally loose store/hook mocks.

## Test plan

- [x] `pnpm lint` — clean
- [x] `tsc -b` — clean
- [x] `pnpm test` — 618 passed

https://claude.ai/code/session_01Qds9LamAb9aCgUcA3uNNZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qds9LamAb9aCgUcA3uNNZC)_