### PR TITLE
Fix code smells: resource leaks, durability, numerics, dedup

### DIFF
--- a/src/components/Layout/CalculatedColumnModal.tsx
+++ b/src/components/Layout/CalculatedColumnModal.tsx
@@ -136,8 +136,7 @@ export const CalculatedColumnModal: React.FC<CalculatedColumnModalProps> = ({
 	};
 
 	const insertColumn = (col: string) => {
-		const colName = col.includes(": ") ? col.split(": ")[1] : col;
-		insertText(`[${colName}]`);
+		insertText(`[${col}]`);
 	};
 
 	const title = (
@@ -279,7 +278,7 @@ export const CalculatedColumnModal: React.FC<CalculatedColumnModalProps> = ({
 								className="calc-col-btn"
 								title={col}
 							>
-								{col.includes(": ") ? col.split(": ")[1] : col}
+								{col}
 							</button>
 						))}
 					</div>

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -977,108 +977,16 @@ export default function ChartContainer() {
 		});
 
 		return activeXAxesUsed.map((axis) => {
-			const r = axis.max - axis.min,
-				isDate = axis.xMode === "date";
 			const catInfo = xAxisCategoryLabels.get(axis.id);
-			const categoryLabels = catInfo?.labels;
-			const categoryTicks = catInfo?.ticks;
 			const dss = dsByX[axis.id] || [];
-			const uniqueColumns = Array.from(
-				dss.reduce(
-					(acc, d: Dataset) => acc.add(d.xAxisColumn),
-					new Set<string>(),
-				),
+			return buildXAxisLayout(
+				axis,
+				chartWidth,
+				themeColors.labelColor,
+				catInfo?.labels,
+				catInfo?.ticks,
+				dss,
 			);
-			const defaultTitle =
-				dss.length > 1 ? uniqueColumns.join(" / ") : uniqueColumns[0];
-			const title = axis.name || defaultTitle || "";
-			const color = themeColors.labelColor;
-			if (r <= 0 || chartWidth <= 0)
-				return {
-					id: axis.id,
-					min: axis.min,
-					max: axis.max,
-					showGrid: axis.showGrid,
-					ticks: { result: [], step: 1, precision: 0, isXDate: false as const },
-					title,
-					color,
-					categoryLabels,
-					categoryTicks,
-				};
-
-			if (categoryLabels) {
-				const result = categoryTicks
-					? categoryTicks.filter((v) => v >= axis.min && v <= axis.max)
-					: calcCategoricalTicks(axis.min, axis.max, categoryLabels.length);
-				return {
-					id: axis.id,
-					min: axis.min,
-					max: axis.max,
-					showGrid: axis.showGrid,
-					ticks: {
-						result,
-						step: 1,
-						precision: 0,
-						isXDate: false as const,
-					},
-					title,
-					color,
-					categoryLabels,
-					categoryTicks,
-				};
-			}
-
-			if (!isDate) {
-				const step = calcNumericStep(
-					r,
-					Math.max(2, Math.floor(chartWidth / 60)),
-				);
-				if (step <= 0)
-					return {
-						id: axis.id,
-						min: axis.min,
-						max: axis.max,
-						showGrid: axis.showGrid,
-						ticks: {
-							result: [],
-							step: 1,
-							precision: 0,
-							isXDate: false as const,
-						},
-						title,
-						color,
-					};
-				const precision = calcNumericPrecision(step);
-				return {
-					id: axis.id,
-					min: axis.min,
-					max: axis.max,
-					showGrid: axis.showGrid,
-					ticks: {
-						result: calcNumericTicks(axis.min, axis.max, step),
-						step,
-						precision,
-						isXDate: false as const,
-					},
-					title,
-					color,
-				};
-			} else {
-				const ts = getTimeStep(r, Math.max(2, Math.floor(chartWidth / 80)));
-				return {
-					id: axis.id,
-					min: axis.min,
-					max: axis.max,
-					showGrid: axis.showGrid,
-					ticks: {
-						result: generateTimeTicks(axis.min, axis.max, ts),
-						isXDate: true as const,
-						secondaryLabels: generateSecondaryLabels(axis.min, axis.max, ts),
-					},
-					title,
-					color,
-				};
-			}
 		});
 	}, [
 		activeXAxesUsed,

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -838,6 +838,17 @@ export const WebGLRenderer = React.memo(
 			if (drawFrameRef.current) {
 				drawFrameRef.current(liveXAxesRef.current, liveYAxesRef.current);
 			}
+
+			return () => {
+				gl.deleteProgram(program);
+				gl.deleteShader(vs);
+				gl.deleteShader(fs);
+				gl.getExtension("WEBGL_lose_context")?.loseContext();
+				glRef.current = null;
+				programRef.current = null;
+				locationsRef.current = null;
+				stateCacheRef.current = null;
+			};
 		}, []);
 
 		const seriesMetadata = useMemo(() => {

--- a/src/components/Plot/__tests__/WebGLRenderer.test.tsx
+++ b/src/components/Plot/__tests__/WebGLRenderer.test.tsx
@@ -38,8 +38,10 @@ describe("hexToRgba", () => {
 	});
 
 	it("handles invalid hex formats gracefully", () => {
-		// too short, parses as zero padded hex
-		expect(hexToRgba("#FF")).toEqual([0, 0, 255 / 255]);
+		// too short (not 3 or 6 hex digits) is invalid
+		expect(hexToRgba("#FF")).toEqual([0, 0, 0]);
+		// CSS shorthand expands #rgb -> #rrggbb
+		expect(hexToRgba("#00f")).toEqual([0, 0, 1]);
 		// nonsense characters still fall back
 		expect(hexToRgba("#zzz")).toEqual([0, 0, 0]);
 		// too long

--- a/src/components/Plot/chartTypes.ts
+++ b/src/components/Plot/chartTypes.ts
@@ -51,3 +51,11 @@ export interface XAxisMetrics {
 }
 
 export type PanTarget = "all" | { xAxisId: string } | { yAxisId: string };
+
+/** The x-axis id a pan target refers to, or undefined for "all"/y-targets. */
+export const panTargetXAxisId = (t: PanTarget): string | undefined =>
+	typeof t === "object" && "xAxisId" in t ? t.xAxisId : undefined;
+
+/** The y-axis id a pan target refers to, or undefined for "all"/x-targets. */
+export const panTargetYAxisId = (t: PanTarget): string | undefined =>
+	typeof t === "object" && "yAxisId" in t ? t.yAxisId : undefined;

--- a/src/components/Sidebar/DataSourcesSection.tsx
+++ b/src/components/Sidebar/DataSourcesSection.tsx
@@ -184,7 +184,7 @@ export const DataSourcesSection: React.FC<DataSourcesSectionProps> = ({
 										}}
 										title={ds.name}
 									>
-										{ds.name.includes(": ") ? ds.name.split(": ")[1] : ds.name}
+										{ds.name}
 									</span>
 									<span className="sb-dataset-meta">
 										{ds.rowCount.toLocaleString()} lines
@@ -271,7 +271,7 @@ export const DataSourcesSection: React.FC<DataSourcesSectionProps> = ({
 											>
 												{ds.columns.map((c) => (
 													<option key={c} value={c}>
-														{c.includes(": ") ? c.split(": ")[1] : c}
+														{c}
 													</option>
 												))}
 											</select>
@@ -324,7 +324,7 @@ export const DataSourcesSection: React.FC<DataSourcesSectionProps> = ({
 										if (isX) return null;
 										const colData = ds.data[colIdx];
 										const isCalc = !!colData?.formula;
-										const label = col.includes(": ") ? col.split(": ")[1] : col;
+										const label = col;
 										const isRenaming =
 											renamingColumn?.datasetId === ds.id &&
 											renamingColumn?.col === col;

--- a/src/components/Sidebar/SeriesConfig.tsx
+++ b/src/components/Sidebar/SeriesConfig.tsx
@@ -340,14 +340,9 @@ export const SeriesConfigUI: React.FC<Props> = ({
 				className="sc-select"
 				title="Y Column"
 			>
-				{datasets.map((ds, dsIdx) => {
-					const letter = String.fromCharCode(65 + dsIdx);
+				{datasets.map((ds) => {
 					return ds.columns.map((c) => {
-						const label = multiDs
-							? `${letter}: ${c.includes(": ") ? c.split(": ")[1] : c}`
-							: c.includes(": ")
-								? c.split(": ")[1]
-								: c;
+						const label = multiDs ? `${ds.name}: ${c}` : c;
 						return (
 							<option key={`${ds.id}::${c}`} value={`${ds.id}::${c}`}>
 								{label}

--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -237,8 +237,8 @@ describe("useDataImport hook", () => {
 
 		expect(parseDataInWorker).toHaveBeenCalledWith(file, "csv", settings);
 		expect(mockAddDataset).toHaveBeenCalled();
-		expect(mockAddDataset.mock.calls[0][0].name).toBe("A - test.csv");
-		expect(mockAddDataset.mock.calls[0][0].columns[0]).toBe("A: Col1");
+		expect(mockAddDataset.mock.calls[0][0].name).toBe("test.csv");
+		expect(mockAddDataset.mock.calls[0][0].columns[0]).toBe("Col1");
 		expect(result.current.isImporting).toBe(false);
 		expect(result.current.pendingFile).toBeNull();
 
@@ -290,7 +290,7 @@ describe("useDataImport hook", () => {
 		expect(result.current.pendingFile).toBeNull();
 		// xAxisColumn is undefined so all columns pass the filter — Col1 gets auto-added as a series
 		expect(mockAddSeries).toHaveBeenCalledTimes(1);
-		expect(mockAddSeries.mock.calls[0][0].yColumn).toBe("A: Col1");
+		expect(mockAddSeries.mock.calls[0][0].yColumn).toBe("Col1");
 
 		global.FileReader = originalFileReader;
 	});
@@ -411,8 +411,8 @@ describe("useDataImport hook", () => {
 		});
 
 		expect(mockAddSeries).toHaveBeenCalledTimes(2);
-		expect(mockAddSeries.mock.calls[0][0].yColumn).toBe("A: Temp");
-		expect(mockAddSeries.mock.calls[1][0].yColumn).toBe("A: Humidity");
+		expect(mockAddSeries.mock.calls[0][0].yColumn).toBe("Temp");
+		expect(mockAddSeries.mock.calls[1][0].yColumn).toBe("Humidity");
 
 		global.FileReader = originalFileReader;
 	});

--- a/src/hooks/__tests__/useFormulaEditor.test.tsx
+++ b/src/hooks/__tests__/useFormulaEditor.test.tsx
@@ -103,7 +103,7 @@ describe("useFormulaEditor", () => {
 		expect(result.current.formula).toBe("a + b");
 	});
 
-	const columns = ["Dataset: Column A", "Column B", "Dataset: Another"];
+	const columns = ["Column A", "Column B", "Another"];
 
 	it("initializes with initialFormula", () => {
 		const { textareaRef } = createMockTextarea();

--- a/src/hooks/useDataImport.ts
+++ b/src/hooks/useDataImport.ts
@@ -8,17 +8,6 @@ import { parseDataInWorker } from "../workers/parserClient";
 
 const AUTO_ADD_COLUMN_THRESHOLD = 5;
 
-const processImportedDataset = (ds: Dataset, currentDatasetsLength: number) => {
-	const letter = String.fromCharCode(65 + currentDatasetsLength);
-	const prefix = `${letter}: `;
-	ds.name = `${letter} - ${ds.name}`;
-	ds.columns = ds.columns.map((c) => `${prefix}${c}`);
-	if (ds.xAxisColumn) {
-		ds.xAxisColumn = `${prefix}${ds.xAxisColumn}`;
-	}
-	return ds;
-};
-
 export type PendingFile = {
 	file: File;
 	preview: string;
@@ -82,10 +71,7 @@ const processImportedDatasets = (
 ) => {
 	const isSplitImport = incoming.length > 1;
 
-	for (const raw of incoming) {
-		const currentState = useGraphStore.getState();
-		const ds = processImportedDataset(raw, currentState.datasets.length);
-
+	for (const ds of incoming) {
 		addDataset(ds);
 
 		if (!isSplitImport && ds.columns.length <= AUTO_ADD_COLUMN_THRESHOLD) {

--- a/src/hooks/useFormulaEditor.ts
+++ b/src/hooks/useFormulaEditor.ts
@@ -131,23 +131,14 @@ export function useFormulaEditor({
 			if (bracketMatch) {
 				const partial = bracketMatch[1].toLowerCase();
 				return columns
-					.filter((c) => {
-						const short = c.includes(": ") ? c.split(": ")[1] : c;
-						return (
-							short.toLowerCase().startsWith(partial) ||
-							c.toLowerCase().startsWith(partial)
-						);
-					})
+					.filter((c) => c.toLowerCase().startsWith(partial))
 					.slice(0, 8)
-					.map((c) => {
-						const short = c.includes(": ") ? c.split(": ")[1] : c;
-						return {
-							kind: "column" as const,
-							label: short,
-							insert: `${short}]`,
-							detail: c !== short ? `from ${c.split(": ")[0]}` : "column",
-						};
-					});
+					.map((c) => ({
+						kind: "column" as const,
+						label: c,
+						insert: `${c}]`,
+						detail: "column",
+					}));
 			}
 
 			// Otherwise — function or constant name.

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -1,6 +1,10 @@
 // src/hooks/usePanZoom.ts
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { PanTarget } from "../components/Plot/chartTypes";
+import {
+	type PanTarget,
+	panTargetXAxisId,
+	panTargetYAxisId,
+} from "../components/Plot/chartTypes";
 import type { XAxisConfig, YAxisConfig } from "../services/persistence";
 import { getAxisById } from "../utils/axisCalculations";
 import { screenToWorld } from "../utils/coords";
@@ -123,13 +127,13 @@ export function usePanZoom({
 		let changed = false;
 
 		// X-Axis Panning
-		if (ps.target === "all" || (ps.target as { xAxisId?: string }).xAxisId) {
+		if (ps.target === "all" || panTargetXAxisId(ps.target)) {
 			for (let i = 0; i < activeXAxes.length; i++) {
 				const axis = activeXAxes[i];
 				if (
 					ps.target !== "all" &&
 					!shiftDownRef.current &&
-					(ps.target as { xAxisId?: string }).xAxisId !== axis.id
+					panTargetXAxisId(ps.target) !== axis.id
 				)
 					continue;
 				const startConf = ps.startTargetX[axis.id];
@@ -148,8 +152,8 @@ export function usePanZoom({
 		}
 
 		// Y-Axis Panning
-		if (ps.target === "all" || (ps.target as { yAxisId?: string }).yAxisId) {
-			const targetYId = (ps.target as { yAxisId?: string }).yAxisId;
+		if (ps.target === "all" || panTargetYAxisId(ps.target)) {
+			const targetYId = panTargetYAxisId(ps.target);
 			const syncSideAxes =
 				shiftDownRef.current && targetYId
 					? leftAxes.some((a) => a.id === targetYId)
@@ -300,7 +304,7 @@ export function usePanZoom({
 			) {
 				const axesToZoom = (() => {
 					if (target === "all") return activeYAxes;
-					const yId = (target as { yAxisId: string }).yAxisId;
+					const yId = panTargetYAxisId(target) as string;
 					if (shiftKey) {
 						return leftAxes.some((a) => a.id === yId) ? leftAxes : rightAxes;
 					}

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -455,6 +455,13 @@ export function usePanZoom({
 		shiftDownRef.current = isShiftPressed;
 	}, [panTarget, isShiftPressed]);
 
+	useEffect(
+		() => () => {
+			if (wheelTimeoutRef.current) clearTimeout(wheelTimeoutRef.current);
+		},
+		[],
+	);
+
 	// eslint-disable-next-line react-hooks/immutability
 	useEffect(() => {
 		let mouseMoveRaf = 0;

--- a/src/services/__tests__/demoData.test.ts
+++ b/src/services/__tests__/demoData.test.ts
@@ -27,12 +27,12 @@ describe("demoData", () => {
 			expect(dataset.name).toBe("Weather Demo");
 			expect(dataset.rowCount).toBe(100);
 			expect(dataset.columns).toHaveLength(5);
-			expect(dataset.columns).toContain("Demo: Timestamp");
-			expect(dataset.columns).toContain("Demo: Temperature (°C)");
-			expect(dataset.columns).toContain("Demo: Humidity (%)");
-			expect(dataset.columns).toContain("Demo: Solar Irradiance (W/m²)");
-			expect(dataset.columns).toContain("Demo: Wind Speed (m/s)");
-			expect(dataset.xAxisColumn).toBe("Demo: Timestamp");
+			expect(dataset.columns).toContain("Timestamp");
+			expect(dataset.columns).toContain("Temperature (°C)");
+			expect(dataset.columns).toContain("Humidity (%)");
+			expect(dataset.columns).toContain("Solar Irradiance (W/m²)");
+			expect(dataset.columns).toContain("Wind Speed (m/s)");
+			expect(dataset.xAxisColumn).toBe("Timestamp");
 			expect(dataset.xAxisId).toBe("axis-1");
 		});
 
@@ -46,7 +46,7 @@ describe("demoData", () => {
 				expect(column.bounds).toBeDefined();
 				expect(column.bounds.min).toBeLessThanOrEqual(column.bounds.max);
 
-				if (dataset.columns[index] === "Demo: Timestamp") {
+				if (dataset.columns[index] === "Timestamp") {
 					expect(column.isFloat64).toBe(true);
 				} else {
 					expect(column.isFloat64).toBe(false);

--- a/src/services/demoData.ts
+++ b/src/services/demoData.ts
@@ -73,14 +73,13 @@ export function generateDemoDataset(rowCount = 10000): Dataset {
 		}
 	}
 
-	const prefix = "Demo: ";
 	return {
 		id: datasetId,
 		name: "Weather Demo",
-		columns: columns.map((c) => `${prefix}${c}`),
+		columns,
 		data,
 		rowCount,
-		xAxisColumn: `${prefix}${columns[0]}`,
+		xAxisColumn: columns[0],
 		xAxisId: "axis-1",
 	};
 }

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -571,6 +571,8 @@ export const downloadFile = (
 	a.download = fileName;
 	a.click();
 
-	// Security/Memory leak prevention: revoke the object URL after download
-	setTimeout(() => URL.revokeObjectURL(a.href), 100);
+	// Security/Memory leak prevention: revoke the object URL after download.
+	// Capture the URL directly rather than re-reading a.href, which can be
+	// detached/GC'd by the time the timeout fires.
+	setTimeout(() => URL.revokeObjectURL(urlToDownload), 100);
 };

--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -180,14 +180,17 @@ async function putAppState(
 	}
 }
 
-function flushDataset(id: string) {
+async function flushDataset(id: string): Promise<void> {
 	const ds = pendingDatasets.get(id);
 	datasetTimers.delete(id);
 	pendingDatasets.delete(id);
 	if (!ds) return;
-	getDB()
-		.then((db) => db.put(DATASET_STORE, ds))
-		.catch((e) => console.error("saveDataset failed:", e));
+	try {
+		const db = await getDB();
+		await db.put(DATASET_STORE, ds);
+	} catch (e) {
+		console.error("saveDataset failed:", e);
+	}
 }
 
 export const persistence = {
@@ -201,11 +204,12 @@ export const persistence = {
 		);
 	},
 	async flushAll(): Promise<void> {
-		for (const id of [...datasetTimers.keys()]) {
+		const ids = [...datasetTimers.keys()];
+		for (const id of ids) {
 			const t = datasetTimers.get(id);
 			if (t) clearTimeout(t);
-			flushDataset(id);
 		}
+		await Promise.all(ids.map((id) => flushDataset(id)));
 	},
 	async loadDataset(id: string): Promise<Dataset | undefined> {
 		const db = await getDB();
@@ -292,6 +296,11 @@ export const persistence = {
 };
 
 if (typeof window !== "undefined") {
+	// "hidden" fires before unload and still allows async IndexedDB writes to
+	// run, which beforeunload does not reliably guarantee.
+	document.addEventListener("visibilitychange", () => {
+		if (document.visibilityState === "hidden") persistence.flushAll();
+	});
 	window.addEventListener("beforeunload", () => {
 		persistence.flushAll();
 	});

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -195,17 +195,13 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 				// Sparse result (avgDay/avgHour etc.) — create a compact sub-dataset
 				const xColName = dataset.xAxisColumn;
 				const sparseRowCount = sparseXColumn.data.length;
-				const letter = String.fromCharCode(65 + get().datasets.length);
 				const sparseDataset: Dataset = {
 					id: `${datasetId}-sparse-${trimmedName}-${Date.now()}`,
-					name: `${letter} - ${trimmedName}`,
-					columns: [
-						`${letter}: ${xColName.includes(": ") ? xColName.split(": ")[1] : xColName}`,
-						`${letter}: ${trimmedName}`,
-					],
+					name: trimmedName,
+					columns: [xColName, trimmedName],
 					data: [{ ...sparseXColumn }, { ...newColumn, formula }],
 					rowCount: sparseRowCount,
-					xAxisColumn: `${letter}: ${xColName.includes(": ") ? xColName.split(": ")[1] : xColName}`,
+					xAxisColumn: xColName,
 					xAxisId: dataset.xAxisId,
 				};
 				get().addDataset(sparseDataset);

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -255,50 +255,45 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 	},
 
 	addDataset: (dataset) => {
-		set((state) => {
-			if (!dataset.xAxisColumn) {
-				const potentialX =
-					dataset.columns.find(
-						(c) =>
-							c.toLowerCase().includes("time") ||
-							c.toLowerCase().includes("date"),
-					) || dataset.columns[0];
-				dataset.xAxisColumn = potentialX;
-			}
+		const state = get();
 
-			if (!dataset.xAxisId) {
-				const usedXAxisIds = state.datasets.reduce(
-					(acc, d) => (d.xAxisId ? acc.add(d.xAxisId) : acc),
-					new Set<string>(),
-				);
-				const unusedAxis =
-					state.xAxes.find((a) => !usedXAxisIds.has(a.id)) || state.xAxes[0];
-				dataset.xAxisId = unusedAxis.id;
-			}
+		const xAxisColumn =
+			dataset.xAxisColumn ||
+			dataset.columns.find(
+				(c) =>
+					c.toLowerCase().includes("time") ||
+					c.toLowerCase().includes("date"),
+			) ||
+			dataset.columns[0];
 
-			const xColIdx = getColumnIndex(dataset, dataset.xAxisColumn);
-			const col = dataset.data[xColIdx];
-			const bounds = col?.bounds || { min: 0, max: 100 };
-			const xMode = xModeFor(col);
-
-			const nextXAxes = state.xAxes.map((a) =>
-				a.id === dataset.xAxisId
-					? {
-							...a,
-							min: bounds.min,
-							max: bounds.max,
-							xMode,
-						}
-					: a,
+		let xAxisId = dataset.xAxisId;
+		if (!xAxisId) {
+			const usedXAxisIds = state.datasets.reduce(
+				(acc, d) => (d.xAxisId ? acc.add(d.xAxisId) : acc),
+				new Set<string>(),
 			);
+			const unusedAxis =
+				state.xAxes.find((a) => !usedXAxisIds.has(a.id)) || state.xAxes[0];
+			xAxisId = unusedAxis.id;
+		}
 
-			persistence.saveDataset(dataset);
+		const newDataset: Dataset = { ...dataset, xAxisColumn, xAxisId };
 
-			return {
-				datasets: [...state.datasets, dataset],
-				xAxes: nextXAxes,
-			};
-		});
+		const xColIdx = getColumnIndex(newDataset, xAxisColumn);
+		const col = newDataset.data[xColIdx];
+		const bounds = col?.bounds || { min: 0, max: 100 };
+		const xMode = xModeFor(col);
+
+		set((s) => ({
+			datasets: [...s.datasets, newDataset],
+			xAxes: s.xAxes.map((a) =>
+				a.id === xAxisId
+					? { ...a, min: bounds.min, max: bounds.max, xMode }
+					: a,
+			),
+		}));
+
+		persistence.saveDataset(newDataset);
 		if (get().isLoaded) debouncedSaveState();
 	},
 

--- a/src/utils/__tests__/colors.test.ts
+++ b/src/utils/__tests__/colors.test.ts
@@ -74,9 +74,11 @@ describe("colors", () => {
 			expect(hexToRgb("#zzxxxx")).toEqual({ r: 0, g: 0, b: 0 });
 		});
 
-		it("should handle zero padded hex color", () => {
-			expect(hexToRgb("#fff")).toEqual({ r: 0, g: 15, b: 255 });
-			expect(hexToRgb("#1")).toEqual({ r: 0, g: 0, b: 1 });
+		it("should expand CSS shorthand hex colors", () => {
+			expect(hexToRgb("#fff")).toEqual({ r: 255, g: 255, b: 255 });
+			expect(hexToRgb("#abc")).toEqual({ r: 170, g: 187, b: 204 });
+			// Lengths other than 3 or 6 hex digits are invalid.
+			expect(hexToRgb("#1")).toEqual({ r: 0, g: 0, b: 0 });
 			expect(hexToRgb("#0f0a05")).toEqual({ r: 15, g: 10, b: 5 });
 			expect(hexToRgb("#000102")).toEqual({ r: 0, g: 1, b: 2 });
 		});

--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { compileFormula, evaluateFormulaSync } from "../formula";
 
 describe("compileFormula", () => {
-	const columns = ["Timestamp", "A: Temp", "A: Hum", "A: Press"];
+	const columns = ["Timestamp", "Temp", "Hum", "Press"];
 
 	it("should handle averaging functions", () => {
 		const cols = ["Timestamp", "Temp"];
@@ -317,10 +317,9 @@ describe("compileFormula", () => {
 		const resSumDay = compileFormula("sumday([Temp])", columns);
 		expect(resSumDay.evaluate([20, 1000])).toBe(20);
 
-		// Test column not found via bestEnd fallback
-		// e.g. "[A: Unknown]" where "A:" exists but not "A: Unknown"
-		const resUnknown = compileFormula("[A: Unknown]", columns);
-		expect(resUnknown.error).toContain("Column not found: A: Unknown");
+		// Unknown column reference reports a clear error.
+		const resUnknown = compileFormula("[Unknown]", columns);
+		expect(resUnknown.error).toContain("Column not found: Unknown");
 
 		// Defensive fallback testing - providing unknown functions triggers an error
 		// earlier in the lexer as checked in 'should return error for invalid characters'
@@ -330,7 +329,7 @@ describe("compileFormula", () => {
 });
 
 describe("compileFormula — new language features", () => {
-	const columns = ["Timestamp", "A: Temp", "A: Hum", "A: Press"];
+	const columns = ["Timestamp", "Temp", "Hum", "Press"];
 
 	it("parses scientific-notation numeric literals", () => {
 		expect(compileFormula("1e3", columns).evaluate([])).toBe(1000);
@@ -456,7 +455,7 @@ describe("compileFormula — new language features", () => {
 	});
 
 	it("rolling rejects non-constant window argument", () => {
-		const { error } = compileFormula("rolling([A: Temp], [A: Hum])", columns);
+		const { error } = compileFormula("rolling([Temp], [Hum])", columns);
 		expect(error).toContain("constant number");
 	});
 

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -8,12 +8,10 @@ function parseHexChannels(
 	if (typeof hex !== "string") return null;
 
 	let normalizedHex = hex;
-	if (
-		normalizedHex.startsWith("#") &&
-		normalizedHex.length > 1 &&
-		normalizedHex.length < 7
-	) {
-		normalizedHex = "#" + normalizedHex.slice(1).padStart(6, "0");
+	// Expand CSS shorthand #rgb -> #rrggbb
+	if (/^#[0-9a-f]{3}$/i.test(normalizedHex)) {
+		const [, r, g, b] = normalizedHex;
+		normalizedHex = `#${r}${r}${g}${g}${b}${b}`;
 	}
 
 	const m = HEX_RE.exec(normalizedHex);

--- a/src/utils/coords.test.ts
+++ b/src/utils/coords.test.ts
@@ -51,8 +51,8 @@ describe("Coordinate Conversions", () => {
 
 			const result = worldToScreen(100, 50, view);
 
-			expect(Number.isNaN(result.x)).toBe(true);
-			expect(Number.isNaN(result.y)).toBe(true);
+			// Degenerate (zero-width) range centers the point instead of NaN.
+			expect(result).toEqual({ x: 500, y: 250 });
 		});
 
 		it("handles negative coordinates correctly", () => {
@@ -197,8 +197,8 @@ describe("Coordinate Conversions", () => {
 			};
 
 			const result = worldToScreen(50, 50, view);
-			expect(Number.isNaN(result.x)).toBe(true);
-			expect(Number.isNaN(result.y)).toBe(true);
+			// Degenerate (zero-width) range centers the point instead of NaN.
+			expect(result).toEqual({ x: 500, y: 250 });
 		});
 
 		it("handles extreme padding (collapsed chart area)", () => {

--- a/src/utils/coords.ts
+++ b/src/utils/coords.ts
@@ -20,11 +20,14 @@ export const worldToScreen = (x: number, y: number, view: Viewport) => {
 	const chartWidth = view.width - p.left - p.right;
 	const chartHeight = view.height - p.top - p.bottom;
 
-	const sx = p.left + ((x - view.xMin) / (view.xMax - view.xMin)) * chartWidth;
-	const sy =
-		view.height -
-		p.bottom -
-		((y - view.yMin) / (view.yMax - view.yMin)) * chartHeight;
+	const xRange = view.xMax - view.xMin;
+	const yRange = view.yMax - view.yMin;
+	// A zero-width range (e.g. a single data point) would divide by zero; center
+	// the degenerate axis instead of emitting NaN/Infinity screen coords.
+	const fx = xRange !== 0 ? (x - view.xMin) / xRange : 0.5;
+	const fy = yRange !== 0 ? (y - view.yMin) / yRange : 0.5;
+	const sx = p.left + fx * chartWidth;
+	const sy = view.height - p.bottom - fy * chartHeight;
 	return { x: sx, y: sy };
 };
 

--- a/src/utils/data-parser.ts
+++ b/src/utils/data-parser.ts
@@ -490,7 +490,7 @@ async function parseCSV(file: File, settings?: ParseSettings) {
 
 	let isFirstLine = true;
 
-	for await (const { lines } of readCSVChunks(file)) {
+	for await (const { lines, done } of readCSVChunks(file)) {
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i].trim();
 
@@ -500,8 +500,11 @@ async function parseCSV(file: File, settings?: ParseSettings) {
 			}
 
 			if (!line) {
-				// Only increment lineCount if it's an actual empty line in the middle of the file
-				if (i < lines.length - 1) {
+				// Count every blank line except the artifact left by a trailing
+				// newline, which only appears as the last entry of the final chunk.
+				// (Per-chunk position is unreliable: readCSVChunks holds back the
+				// last partial line, so chunk boundaries are arbitrary.)
+				if (!(done && i === lines.length - 1)) {
 					lineCount++;
 				}
 				continue;

--- a/src/utils/formula.ts
+++ b/src/utils/formula.ts
@@ -1151,7 +1151,10 @@ export function compileFormula(
 			filterState: {},
 		});
 
-		const stack = new Float64Array(64);
+		// Each token pushes at most one value, so the RPN stack can never grow
+		// deeper than the queue length — size it accordingly to avoid silent
+		// out-of-range writes on deeply nested expressions.
+		const stack = new Float64Array(outputQueue.length + 1);
 		const argsScratch: number[] = [];
 
 		return {

--- a/src/utils/formula.ts
+++ b/src/utils/formula.ts
@@ -1066,13 +1066,6 @@ export function compileFormula(
 					if (!availableColumnsMap.has(col)) {
 						availableColumnsMap.set(col, i);
 					}
-					const colonIdx = col.indexOf(": ");
-					if (colonIdx !== -1) {
-						const suffix = col.substring(colonIdx + 2);
-						if (!availableColumnsMap.has(suffix)) {
-							availableColumnsMap.set(suffix, i);
-						}
-					}
 				}
 			}
 			return availableColumnsMap;

--- a/src/utils/regression.ts
+++ b/src/utils/regression.ts
@@ -36,9 +36,24 @@ export function polynomialRegression(
 ): Float64Array {
 	const n = x.length;
 	const d = Math.min(degree, Math.min(n - 1, 10)); // Cap at 10 for stability
-
-	// Build Vandermonde matrix and solve via normal equations
 	const m = d + 1;
+
+	// Center and scale x before building the normal equations. Raw values such
+	// as epoch timestamps raised to high powers wreck the conditioning of X^T X;
+	// fitting in normalized space and evaluating at the same points leaves the
+	// fitted y values unchanged but keeps the solve numerically stable.
+	let meanX = 0;
+	for (let i = 0; i < n; i++) meanX += x[i];
+	meanX /= n;
+	let varX = 0;
+	for (let i = 0; i < n; i++) {
+		const dxv = x[i] - meanX;
+		varX += dxv * dxv;
+	}
+	const scaleX = Math.sqrt(varX / n) || 1;
+	const xs = new Float64Array(n);
+	for (let i = 0; i < n; i++) xs[i] = (x[i] - meanX) / scaleX;
+
 	// Compute X^T * X and X^T * y
 	const XtX = new Float64Array(m * m);
 	const Xty = new Float64Array(m);
@@ -50,9 +65,9 @@ export function polynomialRegression(
 			let xpow2 = 1;
 			for (let k = 0; k < m; k++) {
 				XtX[j * m + k] += xpow * xpow2;
-				xpow2 *= x[i];
+				xpow2 *= xs[i];
 			}
-			xpow *= x[i];
+			xpow *= xs[i];
 		}
 	}
 
@@ -65,7 +80,7 @@ export function polynomialRegression(
 			xpow = 1;
 		for (let j = 0; j < m; j++) {
 			val += coeffs[j] * xpow;
-			xpow *= x[i];
+			xpow *= xs[i];
 		}
 		result[i] = val;
 	}
@@ -172,7 +187,7 @@ export function logisticRegression(
 		if (y[i] < yMin) yMin = y[i];
 		if (y[i] > yMax) yMax = y[i];
 	}
-	const L = yMax * 1.05; // Upper asymptote
+	const L = yMax + 0.05 * (yMax - yMin); // Upper asymptote, 5% above the range
 	const yRange = L - yMin;
 	if (yRange < 1e-10) return new Float64Array(n);
 

--- a/src/workers/__tests__/parserClient.test.ts
+++ b/src/workers/__tests__/parserClient.test.ts
@@ -4,6 +4,7 @@ class MockWorker {
   onmessage: ((ev: MessageEvent) => void) | null = null;
   onerror: ((ev: ErrorEvent | Event) => void) | null = null;
   postMessage = vi.fn();
+  terminate = vi.fn();
 
   simulateMessage(data: unknown) {
     if (this.onmessage) {

--- a/src/workers/formulaClient.ts
+++ b/src/workers/formulaClient.ts
@@ -31,6 +31,8 @@ function ensureWorker(): Worker {
 			ev instanceof Error ? ev : new Error(ev.message ?? "Worker error");
 		for (const entry of pending.values()) entry.reject(err);
 		pending.clear();
+		worker?.terminate();
+		worker = null;
 	};
 	return worker;
 }

--- a/src/workers/parserClient.ts
+++ b/src/workers/parserClient.ts
@@ -27,6 +27,8 @@ function ensureWorker(): Worker {
 			ev instanceof Error ? ev : new Error(ev.message ?? "Worker error");
 		for (const entry of pending.values()) entry.reject(err);
 		pending.clear();
+		worker?.terminate();
+		worker = null;
 	};
 	return worker;
 }


### PR DESCRIPTION
## Summary

Addresses the code-smell review. Each fix is a small, isolated commit; all 618 tests, `tsc -b`, and `eslint` pass.

### Bug fixes
- **Durability:** `flushAll` now awaits IndexedDB writes and flushes on `visibilitychange`, so dataset edits aren't lost on tab close. Fixes #497
- **WebGL leak:** delete shaders/program and lose the GL context on unmount — stops leaking a context + GPU buffers on every theme change. Fixes #498
- **Formula stack:** size the RPN stack to the queue length instead of a fixed 64 slots, preventing silent out-of-range writes on deep expressions. Fixes #499
- **usePanZoom:** clear the wheel-end timeout on unmount. Fixes #500
- **Worker clients:** terminate and recreate the worker after an error instead of reusing a dead one. Fixes #501
- **Store:** `addDataset` builds a new dataset instead of mutating its argument; side effects moved out of the `set` updater. Fixes #503
- **Regressions:** center+scale x for `polyreg` (stable on timestamps); sign-independent logistic asymptote. Fixes #506
- **CSV parser:** blank-line counting no longer depends on stream chunk boundaries. Fixes #507
- **Export:** revoke the object URL via a captured reference instead of re-reading `a.href`. Fixes #508
- **Colors:** expand CSS shorthand `#rgb` → `#rrggbb` instead of zero-padding (`#fff` is now white). Fixes #513

### Refactors
- Remove the dataset/column name prefix system (`A - `/`A: `/`Demo: `) and the ~10 duplicated strip sites + formula suffix-alias; fixes the >26-dataset letter bug. Fixes #502
- Dedupe X-axis layout: the memo now calls `buildXAxisLayout`. Fixes #504
- Replace `PanTarget` shape casts with `panTargetXAxisId`/`panTargetYAxisId` accessors. Fixes #505

### Included but intentionally left open for browser verification
- **coords:** zero-width viewport now centers the point instead of emitting NaN. Change is in this PR, but #512 stays open per maintainer request to verify degenerate-axis rendering in the browser before closing.

### Deferred (tracked, not in this PR)
- God-component decomposition #509, magic-number constants #510, blanket eslint-disable #511 — large/architectural; best done with browser verification.
- Low-impact type/edge items: `buildDatasets` xAxisId type hole #514, `findFirstGE` empty-array `-1` #515.

### Verification notes
- Verified with `tsc -b`, `eslint .`, and `vitest run` (618 passing). UI/WebGL behavior was **not** verified in a browser in this environment.
- Several originally-suspected issues were checked and found **not** to be bugs (formula hot-loop column indexing, `dateScratch` stale state, subarray buffer over-transfer) and were left unchanged.

https://claude.ai/code/session_012F1qpofis2XzZ637YTHYRF