### PR TITLE
Code-smell follow-up: eslint scope, parser typing, named caps, layout extraction

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -185,6 +185,9 @@ type DatasetsByAxisId = Record<string, Dataset[]>;
 
 const BASE_PADDING_DESKTOP = { top: 20, right: 20, bottom: 60, left: 20 };
 
+/** Cap on x-values sampled when deriving categorical labels for a forced axis. */
+const MAX_DERIVED_CATEGORY_LABELS = 1000;
+
 const getXAxisMetrics = (
 	xMode: "date" | "numeric" | "categorical",
 ): Omit<XAxisMetrics, "id" | "cumulativeOffset"> => {
@@ -401,7 +404,7 @@ export default function ChartContainer() {
 					const arr = col.data;
 					for (let i = 0; i < arr.length; i++) {
 						uniq.add(arr[i] + ref);
-						if (uniq.size > 1000) break outer;
+						if (uniq.size > MAX_DERIVED_CATEGORY_LABELS) break outer;
 					}
 				}
 				const sorted = Array.from(uniq).sort((a, b) => a - b);

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -25,24 +25,18 @@ import {
 	AXIS_EPSILON,
 	type AxesFrame,
 	DEFAULT_X_AXIS_ID,
-	calcCategoricalTicks,
 	calcNumericPrecision,
 	calcNumericStep,
-	calcNumericTicks,
 	calcYAxisTicks,
 	formatAxisLabel,
 	getAxisById,
 	syncAxesWithTargets,
 } from "../../utils/axisCalculations";
 import { applyKeyboardPan, applyKeyboardZoom } from "../../utils/keyboard";
-import {
-	generateSecondaryLabels,
-	generateTimeTicks,
-	getTimeStep,
-} from "../../utils/time";
 import ErrorBoundary from "../ErrorBoundary";
 import { ImportSettingsDialog } from "../Layout/ImportSettingsDialog";
 import { AxesLayer, type AxesLayerHandle } from "./AxesLayer";
+import { buildXAxisLayout } from "./buildXAxisLayout";
 import { ChartLegend } from "./ChartLegend";
 import { Crosshair } from "./Crosshair";
 import type { XAxisLayout, XAxisMetrics, YAxisLayout } from "./chartTypes";
@@ -190,114 +184,6 @@ function syncStoreUpdates(
 type DatasetsByAxisId = Record<string, Dataset[]>;
 
 const BASE_PADDING_DESKTOP = { top: 20, right: 20, bottom: 60, left: 20 };
-
-function buildXAxisLayout(
-	axis: XAxisConfig,
-	chartWidth: number,
-	labelColor: string,
-	categoryLabels: string[] | undefined,
-	categoryTicks: number[] | undefined,
-	datasets: Dataset[],
-): XAxisLayout {
-	const r = axis.max - axis.min;
-	const isDate = axis.xMode === "date";
-	const uniqueColumns = Array.from(
-		datasets.reduce(
-			(acc, d: Dataset) => acc.add(d.xAxisColumn),
-			new Set<string>(),
-		),
-	);
-	const defaultTitle =
-		datasets.length > 1 ? uniqueColumns.join(" / ") : uniqueColumns[0];
-	const title = axis.name || defaultTitle || "";
-	const color = labelColor;
-	if (r <= 0 || chartWidth <= 0)
-		return {
-			id: axis.id,
-			min: axis.min,
-			max: axis.max,
-			showGrid: axis.showGrid,
-			ticks: {
-				result: [],
-				step: 1,
-				precision: 0,
-				isXDate: false as const,
-			},
-			title,
-			color,
-			categoryLabels,
-			categoryTicks,
-		};
-	if (categoryLabels) {
-		const result = categoryTicks
-			? categoryTicks.filter((v) => v >= axis.min && v <= axis.max)
-			: calcCategoricalTicks(axis.min, axis.max, categoryLabels.length);
-		return {
-			id: axis.id,
-			min: axis.min,
-			max: axis.max,
-			showGrid: axis.showGrid,
-			ticks: {
-				result,
-				step: 1,
-				precision: 0,
-				isXDate: false as const,
-			},
-			title,
-			color,
-			categoryLabels,
-			categoryTicks,
-		};
-	}
-	if (!isDate) {
-		const step = calcNumericStep(r, Math.max(2, Math.floor(chartWidth / 60)));
-		if (step <= 0)
-			return {
-				id: axis.id,
-				min: axis.min,
-				max: axis.max,
-				showGrid: axis.showGrid,
-				ticks: {
-					result: [],
-					step: 1,
-					precision: 0,
-					isXDate: false as const,
-				},
-				title,
-				color,
-			};
-		const precision = calcNumericPrecision(step);
-		return {
-			id: axis.id,
-			min: axis.min,
-			max: axis.max,
-			showGrid: axis.showGrid,
-			ticks: {
-				result: calcNumericTicks(axis.min, axis.max, step),
-				step,
-				precision,
-				isXDate: false as const,
-			},
-			title,
-			color,
-		};
-	} else {
-		const ts = getTimeStep(r, Math.max(2, Math.floor(chartWidth / 80)));
-		return {
-			id: axis.id,
-			min: axis.min,
-			max: axis.max,
-			showGrid: axis.showGrid,
-			ticks: {
-				result: generateTimeTicks(axis.min, axis.max, ts),
-				isXDate: true as const,
-				secondaryLabels: generateSecondaryLabels(axis.min, axis.max, ts),
-			},
-			title,
-			color,
-		};
-	}
-}
 
 const getXAxisMetrics = (
 	xMode: "date" | "numeric" | "categorical",

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/refs */
 // src/components/Plot/ChartContainer.tsx
 
 import { ChartGantt, Expand } from "lucide-react";
@@ -929,6 +928,10 @@ export default function ChartContainer() {
 		],
 	);
 
+	// Latest-callback ref: keep syncViewportRef pointing at the current
+	// syncViewport so the stable imperative handle and RAF closures call the
+	// up-to-date version. The write is intentional during render.
+	// eslint-disable-next-line react-hooks/refs
 	syncViewportRef.current = syncViewport;
 
 	// 6. Effects

--- a/src/components/Plot/Crosshair.tsx
+++ b/src/components/Plot/Crosshair.tsx
@@ -12,6 +12,11 @@ import { getColumnIndex } from "../../utils/columns";
 import { screenToWorld, worldToScreen } from "../../utils/coords";
 import { formatFullDate } from "../../utils/time";
 
+// Highlighted-point marker glyph sizes (px): a white "halo" drawn behind the
+// smaller colored glyph. Square side = half * 2; circle radius = half.
+const MARKER_OUTER_HALF = 6.5;
+const MARKER_INNER_HALF = 5.5;
+
 interface SeriesMetadata {
 	series: SeriesConfig;
 	ds: Dataset;
@@ -288,38 +293,53 @@ const Crosshair = React.memo(
 
 						if (style === "square") {
 							ctx.fillStyle = "rgba(255, 255, 255, 0.9)";
-							ctx.fillRect(xs - 6.5, ys - 6.5, 13, 13);
+							ctx.fillRect(
+								xs - MARKER_OUTER_HALF,
+								ys - MARKER_OUTER_HALF,
+								MARKER_OUTER_HALF * 2,
+								MARKER_OUTER_HALF * 2,
+							);
 							ctx.fillStyle = color;
-							ctx.fillRect(xs - 5.5, ys - 5.5, 11, 11);
+							ctx.fillRect(
+								xs - MARKER_INNER_HALF,
+								ys - MARKER_INNER_HALF,
+								MARKER_INNER_HALF * 2,
+								MARKER_INNER_HALF * 2,
+							);
 							ctx.strokeStyle = plotBg;
 							ctx.lineWidth = 2.5;
-							ctx.strokeRect(xs - 5.5, ys - 5.5, 11, 11);
+							ctx.strokeRect(
+								xs - MARKER_INNER_HALF,
+								ys - MARKER_INNER_HALF,
+								MARKER_INNER_HALF * 2,
+								MARKER_INNER_HALF * 2,
+							);
 						} else if (style === "cross") {
 							ctx.strokeStyle = "rgba(255, 255, 255, 0.9)";
 							ctx.lineWidth = 5.0;
 							ctx.beginPath();
-							ctx.moveTo(xs - 5.5, ys - 5.5);
-							ctx.lineTo(xs + 5.5, ys + 5.5);
-							ctx.moveTo(xs + 5.5, ys - 5.5);
-							ctx.lineTo(xs - 5.5, ys + 5.5);
+							ctx.moveTo(xs - MARKER_INNER_HALF, ys - MARKER_INNER_HALF);
+							ctx.lineTo(xs + MARKER_INNER_HALF, ys + MARKER_INNER_HALF);
+							ctx.moveTo(xs + MARKER_INNER_HALF, ys - MARKER_INNER_HALF);
+							ctx.lineTo(xs - MARKER_INNER_HALF, ys + MARKER_INNER_HALF);
 							ctx.stroke();
 
 							ctx.strokeStyle = color;
 							ctx.lineWidth = 2.5;
 							ctx.beginPath();
-							ctx.moveTo(xs - 5.5, ys - 5.5);
-							ctx.lineTo(xs + 5.5, ys + 5.5);
-							ctx.moveTo(xs + 5.5, ys - 5.5);
-							ctx.lineTo(xs - 5.5, ys + 5.5);
+							ctx.moveTo(xs - MARKER_INNER_HALF, ys - MARKER_INNER_HALF);
+							ctx.lineTo(xs + MARKER_INNER_HALF, ys + MARKER_INNER_HALF);
+							ctx.moveTo(xs + MARKER_INNER_HALF, ys - MARKER_INNER_HALF);
+							ctx.lineTo(xs - MARKER_INNER_HALF, ys + MARKER_INNER_HALF);
 							ctx.stroke();
 						} else {
 							ctx.beginPath();
-							ctx.arc(xs, ys, 6.5, 0, Math.PI * 2);
+							ctx.arc(xs, ys, MARKER_OUTER_HALF, 0, Math.PI * 2);
 							ctx.fillStyle = "rgba(255, 255, 255, 0.9)";
 							ctx.fill();
 
 							ctx.beginPath();
-							ctx.arc(xs, ys, 5.5, 0, Math.PI * 2);
+							ctx.arc(xs, ys, MARKER_INNER_HALF, 0, Math.PI * 2);
 							ctx.fillStyle = color;
 							ctx.fill();
 

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -655,6 +655,11 @@ function computeDrawRanges(
 	drawRangesScratch.length = drCount;
 }
 
+// The renderer adapts its decimation pixel budget between these bounds based on
+// measured frame time to keep pan/zoom responsive.
+const MIN_PIXEL_BUDGET_MULT = 32;
+const MAX_PIXEL_BUDGET_MULT = 64;
+
 function updatePixelBudget(
 	frameTime: number,
 	now: number,
@@ -667,12 +672,12 @@ function updatePixelBudget(
 		lastBudgetUpdateRef.current = now;
 		if (frameTime > TARGET_MS) {
 			pixelBudgetMultRef.current = Math.max(
-				32,
+				MIN_PIXEL_BUDGET_MULT,
 				pixelBudgetMultRef.current * 0.8,
 			);
 		} else if (frameTime < TARGET_MS * 0.5) {
 			pixelBudgetMultRef.current = Math.min(
-				64,
+				MAX_PIXEL_BUDGET_MULT,
 				pixelBudgetMultRef.current * 1.2,
 			);
 		}
@@ -740,7 +745,7 @@ export const WebGLRenderer = React.memo(
 		useEffect(() => {
 			plotBgRgbaRef.current = hexToRgba(plotBg ?? "#ffffff");
 		}, [plotBg]);
-		const pixelBudgetMultRef = useRef<number>(64);
+		const pixelBudgetMultRef = useRef<number>(MAX_PIXEL_BUDGET_MULT);
 		const frameTimeRef = useRef<number>(0);
 		const lastBudgetUpdateRef = useRef<number>(0);
 		const liveXAxesRef = useRef<XAxisConfig[]>(xAxes);
@@ -1124,7 +1129,7 @@ export const WebGLRenderer = React.memo(
 		useEffect(() => {
 			if (isInteracting) return;
 			const id = setTimeout(() => {
-				pixelBudgetMultRef.current = 64;
+				pixelBudgetMultRef.current = MAX_PIXEL_BUDGET_MULT;
 				drawFrameRef.current?.(liveXAxesRef.current, liveYAxesRef.current);
 			}, 0);
 			return () => clearTimeout(id);

--- a/src/components/Plot/buildXAxisLayout.ts
+++ b/src/components/Plot/buildXAxisLayout.ts
@@ -1,0 +1,121 @@
+import type { Dataset, XAxisConfig } from "../../services/persistence";
+import {
+	calcCategoricalTicks,
+	calcNumericPrecision,
+	calcNumericStep,
+	calcNumericTicks,
+} from "../../utils/axisCalculations";
+import {
+	generateSecondaryLabels,
+	generateTimeTicks,
+	getTimeStep,
+} from "../../utils/time";
+import type { XAxisLayout } from "./chartTypes";
+
+export function buildXAxisLayout(
+	axis: XAxisConfig,
+	chartWidth: number,
+	labelColor: string,
+	categoryLabels: string[] | undefined,
+	categoryTicks: number[] | undefined,
+	datasets: Dataset[],
+): XAxisLayout {
+	const r = axis.max - axis.min;
+	const isDate = axis.xMode === "date";
+	const uniqueColumns = Array.from(
+		datasets.reduce(
+			(acc, d: Dataset) => acc.add(d.xAxisColumn),
+			new Set<string>(),
+		),
+	);
+	const defaultTitle =
+		datasets.length > 1 ? uniqueColumns.join(" / ") : uniqueColumns[0];
+	const title = axis.name || defaultTitle || "";
+	const color = labelColor;
+	if (r <= 0 || chartWidth <= 0)
+		return {
+			id: axis.id,
+			min: axis.min,
+			max: axis.max,
+			showGrid: axis.showGrid,
+			ticks: {
+				result: [],
+				step: 1,
+				precision: 0,
+				isXDate: false as const,
+			},
+			title,
+			color,
+			categoryLabels,
+			categoryTicks,
+		};
+	if (categoryLabels) {
+		const result = categoryTicks
+			? categoryTicks.filter((v) => v >= axis.min && v <= axis.max)
+			: calcCategoricalTicks(axis.min, axis.max, categoryLabels.length);
+		return {
+			id: axis.id,
+			min: axis.min,
+			max: axis.max,
+			showGrid: axis.showGrid,
+			ticks: {
+				result,
+				step: 1,
+				precision: 0,
+				isXDate: false as const,
+			},
+			title,
+			color,
+			categoryLabels,
+			categoryTicks,
+		};
+	}
+	if (!isDate) {
+		const step = calcNumericStep(r, Math.max(2, Math.floor(chartWidth / 60)));
+		if (step <= 0)
+			return {
+				id: axis.id,
+				min: axis.min,
+				max: axis.max,
+				showGrid: axis.showGrid,
+				ticks: {
+					result: [],
+					step: 1,
+					precision: 0,
+					isXDate: false as const,
+				},
+				title,
+				color,
+			};
+		const precision = calcNumericPrecision(step);
+		return {
+			id: axis.id,
+			min: axis.min,
+			max: axis.max,
+			showGrid: axis.showGrid,
+			ticks: {
+				result: calcNumericTicks(axis.min, axis.max, step),
+				step,
+				precision,
+				isXDate: false as const,
+			},
+			title,
+			color,
+		};
+	} else {
+		const ts = getTimeStep(r, Math.max(2, Math.floor(chartWidth / 80)));
+		return {
+			id: axis.id,
+			min: axis.min,
+			max: axis.max,
+			showGrid: axis.showGrid,
+			ticks: {
+				result: generateTimeTicks(axis.min, axis.max, ts),
+				isXDate: true as const,
+				secondaryLabels: generateSecondaryLabels(axis.min, axis.max, ts),
+			},
+			title,
+			color,
+		};
+	}
+}

--- a/src/hooks/useDataImport.ts
+++ b/src/hooks/useDataImport.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type { WorkBook } from "xlsx";
-import type { Dataset, SeriesConfig } from "../services/persistence";
+import type { ParsedDataset, SeriesConfig } from "../services/persistence";
 import { useGraphStore } from "../store/useGraphStore";
 import type { ImportSettings } from "../types/import";
 import { buildSeriesConfig } from "../utils/series";
@@ -65,8 +65,8 @@ const readTextFile = (
 };
 
 const processImportedDatasets = (
-	incoming: Dataset[],
-	addDataset: (ds: Dataset) => void,
+	incoming: ParsedDataset[],
+	addDataset: (ds: ParsedDataset) => void,
 	addSeries: (series: SeriesConfig) => void,
 ) => {
 	const isSplitImport = incoming.length > 1;
@@ -155,7 +155,7 @@ export const useDataImport = () => {
 					workerType,
 					settings,
 				);
-				const incoming = (datasets as Dataset[]) || [];
+				const incoming = datasets ?? [];
 
 				processImportedDatasets(incoming, addDataset, addSeries);
 

--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -28,6 +28,14 @@ export interface Dataset {
 	xAxisId: string;
 }
 
+/**
+ * Dataset shape as emitted by the parser: the x-axis column and axis slot are
+ * resolved later by the store (`addDataset`), so both are absent/optional here.
+ */
+export type ParsedDataset = Omit<Dataset, "xAxisId" | "xAxisColumn"> & {
+	xAxisColumn?: string;
+};
+
 export interface XAxisConfig {
 	id: string;
 	name: string;

--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -3,6 +3,7 @@ import { generateDemoDataset, getDemoAppState } from "../services/demoData";
 import {
 	type DataColumn,
 	type Dataset,
+	type ParsedDataset,
 	persistence,
 	type SeriesConfig,
 	type XAxisConfig,
@@ -31,7 +32,7 @@ interface GraphState {
 	) => void;
 
 	// Actions
-	addDataset: (dataset: Dataset) => void;
+	addDataset: (dataset: ParsedDataset & { xAxisId?: string }) => void;
 	addCalculatedColumn: (
 		datasetId: string,
 		name: string,

--- a/src/utils/axisCalculations.ts
+++ b/src/utils/axisCalculations.ts
@@ -58,7 +58,10 @@ export function calcCategoricalTicks(
 	return ticks;
 }
 
-/** Generate tick values from min to max for a given step (capped at 200). */
+/** Hard cap on generated numeric ticks, guarding against pathological steps. */
+const MAX_NUMERIC_TICKS = 200;
+
+/** Generate tick values from min to max for a given step. */
 export function calcNumericTicks(
 	min: number,
 	max: number,
@@ -67,7 +70,7 @@ export function calcNumericTicks(
 	const first = Math.ceil((min - step) / step) * step;
 	const ticks: number[] = [];
 	for (let t = first; t <= max + step; t += step) {
-		if (ticks.length > 200) break;
+		if (ticks.length > MAX_NUMERIC_TICKS) break;
 		ticks.push(t);
 	}
 	return ticks;

--- a/src/utils/data-parser.ts
+++ b/src/utils/data-parser.ts
@@ -1,6 +1,6 @@
 // Data Parser (v0.5.0 - Main Thread)
 
-import type { DataColumn } from "../services/persistence";
+import type { DataColumn, ParsedDataset } from "../services/persistence";
 import { processRawColumn } from "./data-processing";
 import { secureJSONParse } from "./json";
 
@@ -109,7 +109,7 @@ function buildDatasets(
 	configByName: Map<string, ColumnConfigEntry>,
 	splitColIdxSet: Set<number>,
 	settings?: ParseSettings,
-) {
+): ParsedDataset[] {
 	const doSplit = splitColIdxSet.size > 0;
 	// Output columns exclude the split columns themselves
 	const outputColIdxs: number[] = [];
@@ -180,7 +180,7 @@ export async function parseData(
 	file: File,
 	type: string,
 	settings?: ParseSettings,
-) {
+): Promise<ParsedDataset[]> {
 	let result: Awaited<ReturnType<typeof parseCSV>>;
 	if (type === "csv") result = await parseCSV(file, settings);
 	else if (type === "json") result = await parseJSON(file, settings);

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -17,6 +17,10 @@ export interface TimeTick {
 	label: string;
 }
 
+/** Hard caps guarding the tick/label loops against pathological time ranges. */
+const MAX_TIME_TICKS = 500;
+const MAX_SECONDARY_LABELS = 100;
+
 const UNIT_SECONDS = {
 	second: 1,
 	minute: 60,
@@ -147,7 +151,7 @@ export function generateTimeTicks(
 		else if (unit === "year") d.setFullYear(d.getFullYear() + value);
 
 		current = d.getTime() / 1000;
-		if (ticks.length > 500) break;
+		if (ticks.length > MAX_TIME_TICKS) break;
 	}
 
 	return ticks;
@@ -207,7 +211,7 @@ export function generateSecondaryLabels(
 			});
 			d.setDate(d.getDate() + 1);
 			current = d.getTime() / 1000;
-			if (labels.length > 100) break;
+			if (labels.length > MAX_SECONDARY_LABELS) break;
 		}
 	} else {
 		// day, week, month, year
@@ -223,7 +227,7 @@ export function generateSecondaryLabels(
 			});
 			d.setFullYear(d.getFullYear() + 1);
 			current = d.getTime() / 1000;
-			if (labels.length > 100) break;
+			if (labels.length > MAX_SECONDARY_LABELS) break;
 		}
 	}
 

--- a/src/workers/parser.worker.ts
+++ b/src/workers/parser.worker.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
 
-import type { Dataset } from "../services/persistence";
+import type { ParsedDataset } from "../services/persistence";
 import { type ParseSettings, parseData } from "../utils/data-parser";
 
 export interface ParserRequest {
@@ -13,11 +13,11 @@ export interface ParserRequest {
 export interface ParserResponse {
 	id: number;
 	type: "success" | "error";
-	datasets?: Dataset[];
+	datasets?: ParsedDataset[];
 	error?: string;
 }
 
-function collectTransferables(datasets: Dataset[]): ArrayBuffer[] {
+function collectTransferables(datasets: ParsedDataset[]): ArrayBuffer[] {
 	const buffers: ArrayBuffer[] = [];
 	for (const ds of datasets) {
 		for (const col of ds.data) {
@@ -30,7 +30,7 @@ function collectTransferables(datasets: Dataset[]): ArrayBuffer[] {
 self.onmessage = async (ev: MessageEvent<ParserRequest>) => {
 	const { id, file, type, settings } = ev.data;
 	try {
-		const datasets = (await parseData(file, type, settings)) as Dataset[];
+		const datasets = await parseData(file, type, settings);
 		const transferables = collectTransferables(datasets);
 		const response: ParserResponse = { id, type: "success", datasets };
 		(self as DedicatedWorkerGlobalScope).postMessage(response, transferables);

--- a/src/workers/parserClient.ts
+++ b/src/workers/parserClient.ts
@@ -1,4 +1,4 @@
-import type { Dataset } from "../services/persistence";
+import type { ParsedDataset } from "../services/persistence";
 import type { ParseSettings } from "../utils/data-parser";
 import type { ParserRequest, ParserResponse } from "./parser.worker";
 
@@ -6,7 +6,10 @@ let worker: Worker | null = null;
 let nextId = 1;
 const pending = new Map<
 	number,
-	{ resolve: (value: Dataset[]) => void; reject: (reason: unknown) => void }
+	{
+		resolve: (value: ParsedDataset[]) => void;
+		reject: (reason: unknown) => void;
+	}
 >();
 
 function ensureWorker(): Worker {
@@ -37,10 +40,10 @@ export function parseDataInWorker(
 	file: File,
 	type: string,
 	settings?: ParseSettings,
-): Promise<Dataset[]> {
+): Promise<ParsedDataset[]> {
 	const id = nextId++;
 	const w = ensureWorker();
-	return new Promise<Dataset[]>((resolve, reject) => {
+	return new Promise<ParsedDataset[]>((resolve, reject) => {
 		pending.set(id, { resolve, reject });
 		const req: ParserRequest = { id, file, type, settings };
 		w.postMessage(req);


### PR DESCRIPTION
## Summary

Follow-up to #516, working through the remaining open code-smell issues. All 618 tests, `tsc -b`, and `eslint` pass.

### Fully addressed
- **eslint hygiene:** replace the file-wide `/* eslint-disable react-hooks/refs */` in `ChartContainer` with a single targeted disable on the intentional latest-callback ref write, so the rest of the file is linted again. Fixes #511
- **Parser typing:** add a `ParsedDataset` type (Dataset without the store-assigned `xAxisId`/`xAxisColumn`) and thread it through parser → worker → import, removing the dishonest `as Dataset[]` cast. Fixes #514
- **Magic numbers:** named the meaningful recurring literals — `MIN/MAX_PIXEL_BUDGET_MULT` (also dedupes init/reset), `MAX_NUMERIC_TICKS`, `MAX_TIME_TICKS`, `MAX_SECONDARY_LABELS`, crosshair `MARKER_OUTER_HALF`/`MARKER_INNER_HALF`, `MAX_DERIVED_CATEGORY_LABELS`. (One local layout accumulator `est = 12+12+32` left as-is — its components need domain context to name meaningfully.) Fixes #510

### Partial progress (issue kept open)
- **God-component decomposition (#509):** extracted the pure `buildXAxisLayout` into its own module as a first safe step (ChartContainer 1453 → 1250 lines across this branch + #516). The substantive decomposition (component effects/memos, `WebGLRenderer`/`usePanZoom` internals) still needs incremental, **browser-verified** refactoring — kept open.

### Verification notes
- `tsc -b`, `eslint .`, `vitest run` (618 passing). All changes here are type-only, pure-function moves, or literal→constant renames — no intended runtime behavior change. WebGL/UI not browser-verified in this environment.

https://claude.ai/code/session_012F1qpofis2XzZ637YTHYRF