### PR TITLE
🧹 Refactor: use crypto.randomUUID() for sparse dataset ID generation

### DIFF
--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -196,7 +196,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 				const xColName = dataset.xAxisColumn;
 				const sparseRowCount = sparseXColumn.data.length;
 				const sparseDataset: Dataset = {
-					id: `${datasetId}-sparse-${trimmedName}-${Date.now()}`,
+					id: `${datasetId}-sparse-${trimmedName}-${crypto.randomUUID()}`,
 					name: trimmedName,
 					columns: [xColName, trimmedName],
 					data: [{ ...sparseXColumn }, { ...newColumn, formula }],


### PR DESCRIPTION
🎯 **What:** Replaced the use of `Date.now()` with `crypto.randomUUID()` for generating sparse dataset IDs in `src/store/useGraphStore.ts`.

💡 **Why:** `Date.now()` can lead to ID collisions if multiple operations happen in the same millisecond, whereas `crypto.randomUUID()` provides standard, secure, and collision-resistant unique identifiers.

✅ **Verification:** Verified by running the full test suite (`pnpm run test`), particularly ensuring that `useGraphStore.test.ts` passes without regressions. Code review confirmed the safety and correctness of the change.

✨ **Result:** A more robust and standardized approach to ID generation for sparse datasets, improving overall code health and reliability.

---
*PR created automatically by Jules for task [2265297265906151972](https://jules.google.com/task/2265297265906151972) started by @michaelkrisper*