### PR TITLE
🧪 Add edge-case tests for formatFullDate

### DIFF
--- a/src/utils/__tests__/time.test.ts
+++ b/src/utils/__tests__/time.test.ts
@@ -37,6 +37,26 @@ describe("formatFullDate", () => {
 		const ts = 1673784000.1;
 		expect(formatFullDate(ts)).toBe("15.01.2023, 12:00:00,1");
 	});
+
+	it("handles exact zero epoch", () => {
+		expect(formatFullDate(0)).toBe("01.01.1970, 00:00:00");
+	});
+
+	it("handles fractional seconds that resolve to exactly zero after formatting", () => {
+		expect(formatFullDate(0.0001)).toBe("01.01.1970, 00:00:00");
+	});
+
+	it("handles single-digit zero in fractional second (e.g. .01)", () => {
+		expect(formatFullDate(0.01)).toBe("01.01.1970, 00:00:00,01");
+	});
+
+	it("handles two-digit zero in fractional second (e.g. .001)", () => {
+		expect(formatFullDate(0.001)).toBe("01.01.1970, 00:00:00,001");
+	});
+
+	it("handles negative timestamps correctly", () => {
+		expect(formatFullDate(-1.5)).toBe("31.12.1969, 23:59:58,5");
+	});
 });
 
 describe("generateTimeTicks", () => {


### PR DESCRIPTION
🎯 **What:** The testing gap for edge cases in `formatFullDate` has been addressed.
📊 **Coverage:** The new tests cover crucial edge scenarios such as:
- Exactly zero epoch (`0`).
- Fractional seconds that resolve to `0` during formatting (e.g., `0.0001`).
- Specific truncation of trailing fractional zeroes (e.g., `.01` keeping `01` and `.001` keeping `001`).
- Negative timestamps (e.g., `-1.5`).
✨ **Result:** Test coverage for `formatFullDate` is now improved and handles zeroing bounds robustly, ensuring regressions are caught if rounding logic changes.

---
*PR created automatically by Jules for task [1014839202310128859](https://jules.google.com/task/1014839202310128859) started by @michaelkrisper*