### PR TITLE
🧹 [Remove redundant console.error in JSON parsing]

### DIFF
--- a/src/utils/__tests__/data-parser.test.ts
+++ b/src/utils/__tests__/data-parser.test.ts
@@ -235,9 +235,6 @@ describe("data-parser", () => {
 		});
 
 		it("should throw error for invalid JSON format", async () => {
-			const consoleSpy = vi
-				.spyOn(console, "error")
-				.mockImplementation(() => {});
 			const file = createMockFile(
 				"[not json]",
 				"test.json",
@@ -246,18 +243,9 @@ describe("data-parser", () => {
 			await expect(parseData(file, "json", {})).rejects.toThrow(
 				/^Invalid JSON format: /
 			);
-			expect(consoleSpy).toHaveBeenCalledWith(
-				"Failed to parse JSON data:",
-				expect.any(Error)
-			);
-
-			consoleSpy.mockRestore();
 		});
 
 		it("should handle non-Error instances when parsing JSON", async () => {
-			const consoleSpy = vi
-				.spyOn(console, "error")
-				.mockImplementation(() => {});
 			const parseSpy = vi.spyOn(jsonUtils, "secureJSONParse").mockImplementation(() => {
 				throw "String error thrown";
 			});
@@ -267,13 +255,8 @@ describe("data-parser", () => {
 			await expect(parseData(file, "json", {})).rejects.toThrow(
 				"Invalid JSON format: String error thrown",
 			);
-			expect(consoleSpy).toHaveBeenCalledWith(
-				"Failed to parse JSON data:",
-				"String error thrown"
-			);
 
 			parseSpy.mockRestore();
-			consoleSpy.mockRestore();
 		});
 
 		it("should handle parsing configurations in JSON", async () => {

--- a/src/utils/data-parser.ts
+++ b/src/utils/data-parser.ts
@@ -581,7 +581,6 @@ async function parseJSON(file: File, settings?: ParseSettings) {
 		// secureJSONParse strips __proto__/constructor keys to prevent prototype pollution.
 		raw = secureJSONParse(text);
 	} catch (error) {
-		console.error("Failed to parse JSON data:", error);
 		throw new Error(
 			"Invalid JSON format: " +
 				(error instanceof Error ? error.message : String(error)),


### PR DESCRIPTION
🎯 **What:** Removed the `console.error` call from the `catch` block in `parseJSON` in `src/utils/data-parser.ts`, and updated the corresponding test file to remove redundant `consoleSpy` mocking.

💡 **Why:** The error is already wrapped and re-thrown with a clear message and the original error attached as the `cause`. Logging and then immediately throwing ("log and throw") is a known anti-pattern that creates unnecessary noise in the console for errors that should simply be propagated to and handled by the caller.

✅ **Verification:** 
- Visual inspection via `git diff`
- Ran localized tests for `src/utils/__tests__/data-parser.test.ts`
- Ran the full project test suite (`pnpm run test`): all 618 tests passed.

✨ **Result:** Improved codebase maintainability by standardizing error propagation and eliminating redundant console noise.

---
*PR created automatically by Jules for task [803460861670213102](https://jules.google.com/task/803460861670213102) started by @michaelkrisper*