### PR TITLE
🧹 Fix URL.createObjectURL without unmount cleanup in downloadFile

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,8 +1,9 @@
 import type React from "react";
 import { useRef, useState } from "react";
 import { useDataImport } from "../../hooks/useDataImport";
+import { useFileDownload } from "../../hooks/useFileDownload";
 import { useTheme } from "../../hooks/useTheme";
-import { downloadFile, exportToPNG, exportToSVG } from "../../services/export";
+import { exportToPNG, exportToSVG } from "../../services/export";
 import { useGraphStore } from "../../store/useGraphStore";
 import { THEMES } from "../../themes";
 import { DataSeriesSection } from "../Sidebar/DataSeriesSection";
@@ -40,6 +41,7 @@ export const Sidebar: React.FC = () => {
 
 	const { importFile, confirmImport, cancelImport, changeSheet, pendingFile } =
 		useDataImport();
+	const downloadFile = useFileDownload();
 
 	const handleExportSVG = () => {
 		const plotContainer = document.querySelector(".plot-area") as HTMLElement;

--- a/src/components/Layout/__tests__/Sidebar.test.tsx
+++ b/src/components/Layout/__tests__/Sidebar.test.tsx
@@ -39,7 +39,10 @@ vi.mock("../../Sidebar/SeriesConfig", () => ({
 vi.mock("../../../services/export", () => ({
 	exportToSVG: vi.fn().mockReturnValue("<svg></svg>"),
 	exportToPNG: vi.fn().mockResolvedValue("data:image/png;base64,..."),
-	downloadFile: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useFileDownload", () => ({
+	useFileDownload: vi.fn().mockReturnValue(vi.fn()),
 }));
 
 // Mock indexedDB for the Reset/Demo buttons

--- a/src/hooks/useFileDownload.ts
+++ b/src/hooks/useFileDownload.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useRef } from "react";
+import { downloadFile } from "../services/export";
+
+/**
+ * Hook to manage file downloads and ensure object URLs are revoked on unmount.
+ */
+export const useFileDownload = () => {
+	const cleanups = useRef<Array<() => void>>([]);
+
+	useEffect(() => {
+		return () => {
+			cleanups.current.forEach((cleanup) => cleanup());
+			cleanups.current = [];
+		};
+	}, []);
+
+	const download = useCallback(
+		(content: string, fileName: string, contentType: string) => {
+			const cleanup = downloadFile(content, fileName, contentType);
+			if (cleanup) {
+				cleanups.current.push(cleanup);
+			}
+		},
+		[],
+	);
+
+	return download;
+};

--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -542,10 +542,9 @@ describe("downloadFile", () => {
 	});
 
 	it("should handle data URLs correctly", () => {
-		vi.useFakeTimers();
 		const content =
 			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
-		downloadFile(content, "test.png", "image/png");
+		const cleanup = downloadFile(content, "test.png", "image/png");
 
 		const mockedCreate = document.createElement as unknown as ReturnType<
 			typeof vi.fn
@@ -562,10 +561,12 @@ describe("downloadFile", () => {
 		expect(mockClick).toHaveBeenCalled();
 
 		expect(URL.revokeObjectURL).not.toHaveBeenCalled();
-		vi.advanceTimersByTime(100);
-		expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
 
-		vi.useRealTimers();
+		if (cleanup) {
+			cleanup();
+		}
+
+		expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
 	});
 
 	it("should throw an error for unsafe data URLs", () => {
@@ -619,8 +620,7 @@ describe("downloadFile", () => {
 	});
 
 	it("should handle normal strings using Blob correctly", () => {
-		vi.useFakeTimers();
-		downloadFile("Hello, world!", "test.txt", "text/plain");
+		const cleanup = downloadFile("Hello, world!", "test.txt", "text/plain");
 
 		const mockedCreate = document.createElement as unknown as ReturnType<
 			typeof vi.fn
@@ -637,10 +637,12 @@ describe("downloadFile", () => {
 		expect(mockClick).toHaveBeenCalled();
 
 		expect(URL.revokeObjectURL).not.toHaveBeenCalled();
-		vi.advanceTimersByTime(100);
-		expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
 
-		vi.useRealTimers();
+		if (cleanup) {
+			cleanup();
+		}
+
+		expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
 	});
 });
 

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -506,13 +506,13 @@ export const exportToPNG = async (
  * @param {string} content - File content (data URL or text) to download
  * @param {string} fileName - Name for the downloaded file (e.g., "chart.svg")
  * @param {string} contentType - MIME type (e.g., "image/svg+xml", "application/json")
- * @returns {void}
+ * @returns {(() => void) | void} Cleanup function to revoke the object URL
  */
 export const downloadFile = (
 	content: string,
 	fileName: string,
 	contentType: string,
-) => {
+): (() => void) | void => {
 	const a = document.createElement("a");
 	const isDataUrl = content.startsWith("data:");
 	let urlToDownload: string;
@@ -571,8 +571,6 @@ export const downloadFile = (
 	a.download = fileName;
 	a.click();
 
-	// Security/Memory leak prevention: revoke the object URL after download.
-	// Capture the URL directly rather than re-reading a.href, which can be
-	// detached/GC'd by the time the timeout fires.
-	setTimeout(() => URL.revokeObjectURL(urlToDownload), 100);
+	// Security/Memory leak prevention: return cleanup function to revoke the object URL after download.
+	return () => URL.revokeObjectURL(urlToDownload);
 };


### PR DESCRIPTION
* 🎯 **What:** Modified `downloadFile` to return a cleanup function instead of using a hacky `setTimeout` for revoking the object URL, and created a `useFileDownload` hook to manage the cleanup on component unmount.
* 💡 **Why:** `setTimeout` is unreliable for cleaning up Object URLs as the timeout may fire before the download begins or leave memory dangling if the timeout is cleared. Tying the cleanup to React's component lifecycle ensures proper resource management.
* ✅ **Verification:** Re-ran all tests with fake timer logic replaced by explicit cleanup function calls and ensured linter and formatting rules pass.
* ✨ **Result:** Prevents memory leaks and improves codebase maintainability by using proper React lifecycle hooks for cleanup.

---
*PR created automatically by Jules for task [803460861670214288](https://jules.google.com/task/803460861670214288) started by @michaelkrisper*