### PR TITLE
Apply #521 buildXAxisLayout dedupe optimization at relocated module

### DIFF
--- a/src/components/Plot/buildXAxisLayout.ts
+++ b/src/components/Plot/buildXAxisLayout.ts
@@ -22,12 +22,11 @@ export function buildXAxisLayout(
 ): XAxisLayout {
 	const r = axis.max - axis.min;
 	const isDate = axis.xMode === "date";
-	const uniqueColumns = Array.from(
-		datasets.reduce(
-			(acc, d: Dataset) => acc.add(d.xAxisColumn),
-			new Set<string>(),
-		),
-	);
+	const uniqueColumns: string[] = [];
+	for (let i = 0; i < datasets.length; i++) {
+		const col = datasets[i].xAxisColumn;
+		if (!uniqueColumns.includes(col)) uniqueColumns.push(col);
+	}
 	const defaultTitle =
 		datasets.length > 1 ? uniqueColumns.join(" / ") : uniqueColumns[0];
 	const title = axis.name || defaultTitle || "";


### PR DESCRIPTION
## Summary

Reapplies the optimization from #521 at the correct location. #521 couldn't be merged because it edited `buildXAxisLayout` inside `ChartContainer.tsx`, but that function was extracted to its own module `buildXAxisLayout.ts` in #520 — so #521 had merge conflicts.

This applies the same change (Set-based dedup → `for` loop + `includes`) to `buildXAxisLayout.ts`. Behavior identical: unique `xAxisColumn` values in insertion order.

Closes #521 (superseded by relocation).

### Verification
- `tsc -b`, `eslint .`, `vitest run` (635 passing).

https://claude.ai/code/session_012F1qpofis2XzZ637YTHYRF

---
_Generated by [Claude Code](https://claude.ai/code/session_012F1qpofis2XzZ637YTHYRF)_