### PR TITLE
Type keyboard test mocks (apply #530) + fix no-explicit-any lint regression

### DIFF
--- a/src/utils/__tests__/keyboard.test.ts
+++ b/src/utils/__tests__/keyboard.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { applyKeyboardPan, applyKeyboardZoom } from "./keyboard";
+import type { useGraphStore } from "../../store/useGraphStore";
+import { applyKeyboardPan, applyKeyboardZoom } from "../keyboard";
 
 describe("applyKeyboardPan", () => {
 	it("should return false when no matching keys are pressed", () => {
-		const state = { xAxes: [], yAxes: [] } as any;
+		const state = { xAxes: [], yAxes: [] } as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["a", "b"]);
 		const targetXAxes = {};
 		const targetYs = {};
@@ -14,7 +15,7 @@ describe("applyKeyboardPan", () => {
 	});
 
 	it("should pan xAxes left and return true", () => {
-		const state = { xAxes: [{ id: "x1", min: 0, max: 100 }], yAxes: [] } as any;
+		const state = { xAxes: [{ id: "x1", min: 0, max: 100 }], yAxes: [] } as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["ArrowLeft"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -27,7 +28,7 @@ describe("applyKeyboardPan", () => {
 	});
 
 	it("should pan xAxes right and return true", () => {
-		const state = { xAxes: [{ id: "x1", min: 0, max: 100 }], yAxes: [] } as any;
+		const state = { xAxes: [{ id: "x1", min: 0, max: 100 }], yAxes: [] } as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["ArrowRight"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -40,7 +41,7 @@ describe("applyKeyboardPan", () => {
 	});
 
 	it("should pan yAxes up and return true", () => {
-		const state = { xAxes: [], yAxes: [{ id: "y1", min: 0, max: 100 }] } as any;
+		const state = { xAxes: [], yAxes: [{ id: "y1", min: 0, max: 100 }] } as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["ArrowUp"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -53,7 +54,7 @@ describe("applyKeyboardPan", () => {
 	});
 
 	it("should pan yAxes down and return true", () => {
-		const state = { xAxes: [], yAxes: [{ id: "y1", min: 0, max: 100 }] } as any;
+		const state = { xAxes: [], yAxes: [{ id: "y1", min: 0, max: 100 }] } as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["ArrowDown"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -69,7 +70,7 @@ describe("applyKeyboardPan", () => {
 		const state = {
 			xAxes: [{ id: "x1", min: 0, max: 100 }],
 			yAxes: [{ id: "y1", min: 0, max: 100 }],
-		} as any;
+		} as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["ArrowRight", "ArrowUp"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {
 			x1: { min: 10, max: 110 },
@@ -91,7 +92,7 @@ describe("applyKeyboardPan", () => {
 		const state = {
 			xAxes: [{ id: "x1", min: 0, max: 100 }],
 			yAxes: [{ id: "y1", min: 0, max: 100 }]
-		} as any;
+		} as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["ArrowLeft", "ArrowUp"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -106,7 +107,7 @@ describe("applyKeyboardPan", () => {
 	});
 
 	it("should handle conflicting x-axis keys (ArrowLeft + ArrowRight) by prioritizing right (1)", () => {
-		const state = { xAxes: [{ id: "x1", min: 0, max: 100 }], yAxes: [] } as any;
+		const state = { xAxes: [{ id: "x1", min: 0, max: 100 }], yAxes: [] } as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["ArrowLeft", "ArrowRight"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -119,7 +120,7 @@ describe("applyKeyboardPan", () => {
 	});
 
 	it("should handle conflicting y-axis keys (ArrowUp + ArrowDown) by prioritizing up (1)", () => {
-		const state = { xAxes: [], yAxes: [{ id: "y1", min: 0, max: 100 }] } as any;
+		const state = { xAxes: [], yAxes: [{ id: "y1", min: 0, max: 100 }] } as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["ArrowUp", "ArrowDown"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -134,7 +135,7 @@ describe("applyKeyboardPan", () => {
 
 describe("applyKeyboardZoom", () => {
 	it("should return false when no matching keys are pressed", () => {
-		const state = { xAxes: [], yAxes: [] } as any;
+		const state = { xAxes: [], yAxes: [] } as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["a", "b"]);
 		const targetXAxes = {};
 		const targetYs = {};
@@ -148,7 +149,7 @@ describe("applyKeyboardZoom", () => {
 		const state = {
 			xAxes: [{ id: "x1", min: 0, max: 100 }],
 			yAxes: [{ id: "y1", min: 0, max: 100 }],
-		} as any;
+		} as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["+"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -166,7 +167,7 @@ describe("applyKeyboardZoom", () => {
 		const state = {
 			xAxes: [{ id: "x1", min: 0, max: 100 }],
 			yAxes: [{ id: "y1", min: 0, max: 100 }],
-		} as any;
+		} as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["-"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -184,7 +185,7 @@ describe("applyKeyboardZoom", () => {
 		const state = {
 			xAxes: [{ id: "x1", min: 0, max: 100 }],
 			yAxes: [{ id: "y1", min: 0, max: 100 }],
-		} as any;
+		} as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["+", "Control"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -201,7 +202,7 @@ describe("applyKeyboardZoom", () => {
 		const state = {
 			xAxes: [{ id: "x1", min: 0, max: 100 }],
 			yAxes: [{ id: "y1", min: 0, max: 100 }],
-		} as any;
+		} as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["="]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};
@@ -219,7 +220,7 @@ describe("applyKeyboardZoom", () => {
 		const state = {
 			xAxes: [{ id: "x1", min: 0, max: 100 }],
 			yAxes: [{ id: "y1", min: 0, max: 100 }],
-		} as any;
+		} as unknown as ReturnType<typeof useGraphStore.getState>;
 		const keys = new Set(["_"]);
 		const targetXAxes: Record<string, { min: number; max: number }> = {};
 		const targetYs: Record<string, { min: number; max: number }> = {};


### PR DESCRIPTION
## Summary

Applies #530's intent at the current location and fixes a lint regression.

#530 couldn't merge because it was based on master before #524/#531 modified `keyboard.test.ts` (conflict + file rename). This redoes it on current master:
- Relocate `src/utils/keyboard.test.ts` → `src/utils/__tests__/keyboard.test.ts` (consistency with the other test dirs).
- Replace the `as any` state mocks (introduced by #531) with `as unknown as ReturnType<typeof useGraphStore.getState>`.

**Also fixes a regression:** #531 was merged with `as any` casts that violate `@typescript-eslint/no-explicit-any` — 15 lint errors that landed on master because CI runs CodeQL, not ESLint. This PR clears them; `eslint .` is green again.

Closes #530.

### Verification
- `tsc -b`, `eslint .` (green — was 15 errors on master), `vitest run` (638 passing).

https://claude.ai/code/session_012F1qpofis2XzZ637YTHYRF

---
_Generated by [Claude Code](https://claude.ai/code/session_012F1qpofis2XzZ637YTHYRF)_