### PR TITLE
Extract pure axis hover hit-testing from usePanZoom (#509)

### DIFF
--- a/src/components/Plot/__tests__/axisHitTest.test.ts
+++ b/src/components/Plot/__tests__/axisHitTest.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { hitTestXAxis, hitTestYAxis } from "../axisHitTest";
+
+const padding = { top: 20, right: 50, bottom: 60, left: 80 };
+const width = 1000;
+const height = 500;
+
+describe("hitTestYAxis", () => {
+	const base = {
+		width,
+		height,
+		padding,
+		leftAxes: [{ id: "L0" }, { id: "L1" }],
+		rightAxes: [{ id: "R0" }],
+		axisLayout: {
+			L0: { total: 40 },
+			L1: { total: 30 },
+			R0: { total: 50 },
+		},
+	};
+
+	it("returns null outside the plot's vertical band", () => {
+		expect(hitTestYAxis(60, padding.top - 1, base)).toBeNull();
+		expect(hitTestYAxis(60, height - padding.bottom + 1, base)).toBeNull();
+	});
+
+	it("hits the first left axis gutter adjacent to the plot", () => {
+		// L0 occupies [left-40, left] = [40, 80]
+		expect(hitTestYAxis(60, 200, base)).toBe("L0");
+		expect(hitTestYAxis(80, 200, base)).toBe("L0");
+	});
+
+	it("hits the second (outer) left axis gutter", () => {
+		// L1 occupies [left-40-30, left-40] = [10, 40]
+		expect(hitTestYAxis(20, 200, base)).toBe("L1");
+	});
+
+	it("hits the right axis gutter", () => {
+		// R0 occupies [width-right, width-right+50] = [950, 1000]
+		expect(hitTestYAxis(970, 200, base)).toBe("R0");
+	});
+
+	it("returns null in the plot interior between the gutters", () => {
+		expect(hitTestYAxis(500, 200, base)).toBeNull();
+	});
+
+	it("falls back to a default gutter width when layout is missing", () => {
+		const params = { ...base, axisLayout: {} };
+		// default total 40 -> L0 occupies [40, 80]
+		expect(hitTestYAxis(50, 200, params)).toBe("L0");
+	});
+});
+
+describe("hitTestXAxis", () => {
+	const base = {
+		width,
+		height,
+		padding,
+		xAxesMetrics: [
+			{ id: "X0", height: 30, cumulativeOffset: 0 },
+			{ id: "X1", height: 25, cumulativeOffset: 30 },
+		],
+	};
+
+	it("returns null outside the plot's horizontal band", () => {
+		expect(hitTestXAxis(padding.left - 1, 460, base)).toBeNull();
+		expect(hitTestXAxis(width - padding.right + 1, 460, base)).toBeNull();
+	});
+
+	it("hits the first x-axis row directly below the plot", () => {
+		// baseY = height - bottom = 440, row [440, 470]
+		expect(hitTestXAxis(500, 440, base)).toBe("X0");
+		expect(hitTestXAxis(500, 469, base)).toBe("X0");
+	});
+
+	it("hits the stacked second x-axis row", () => {
+		// baseY = 440 + 30 = 470, row [470, 495]
+		expect(hitTestXAxis(500, 480, base)).toBe("X1");
+	});
+
+	it("returns null above the first row (inside the plot)", () => {
+		expect(hitTestXAxis(500, 400, base)).toBeNull();
+	});
+});

--- a/src/components/Plot/axisHitTest.ts
+++ b/src/components/Plot/axisHitTest.ts
@@ -1,0 +1,69 @@
+// Pure hit-testing helpers: given pointer coordinates and the current axis
+// layout, return the id of the axis gutter under the pointer (or null).
+// Extracted from usePanZoom so the geometry can be unit-tested in isolation.
+
+interface Padding {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
+}
+
+interface YAxisHitTestParams {
+	width: number;
+	height: number;
+	padding: Padding;
+	leftAxes: readonly { id: string }[];
+	rightAxes: readonly { id: string }[];
+	axisLayout: Record<string, { total: number }>;
+}
+
+interface XAxisHitTestParams {
+	width: number;
+	height: number;
+	padding: Padding;
+	xAxesMetrics: readonly { id: string; height: number; cumulativeOffset: number }[];
+}
+
+const DEFAULT_AXIS_TOTAL = 40;
+
+/** Id of the Y-axis gutter (left or right) under the pointer, or null. */
+export function hitTestYAxis(
+	mouseX: number,
+	mouseY: number,
+	{ width, height, padding, leftAxes, rightAxes, axisLayout }: YAxisHitTestParams,
+): string | null {
+	if (mouseY < padding.top || mouseY > height - padding.bottom) return null;
+	let lOff = 0;
+	for (let i = 0; i < leftAxes.length; i++) {
+		const total = axisLayout[leftAxes[i].id]?.total ?? DEFAULT_AXIS_TOTAL;
+		if (mouseX >= padding.left - lOff - total && mouseX <= padding.left - lOff)
+			return leftAxes[i].id;
+		lOff += total;
+	}
+	let rOff = 0;
+	for (let i = 0; i < rightAxes.length; i++) {
+		const total = axisLayout[rightAxes[i].id]?.total ?? DEFAULT_AXIS_TOTAL;
+		if (
+			mouseX >= width - padding.right + rOff &&
+			mouseX <= width - padding.right + rOff + total
+		)
+			return rightAxes[i].id;
+		rOff += total;
+	}
+	return null;
+}
+
+/** Id of the X-axis gutter (below the plot) under the pointer, or null. */
+export function hitTestXAxis(
+	mouseX: number,
+	mouseY: number,
+	{ width, height, padding, xAxesMetrics }: XAxisHitTestParams,
+): string | null {
+	if (mouseX < padding.left || mouseX > width - padding.right) return null;
+	for (const m of xAxesMetrics) {
+		const baseY = height - padding.bottom + m.cumulativeOffset;
+		if (mouseY >= baseY && mouseY <= baseY + m.height) return m.id;
+	}
+	return null;
+}

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -1,5 +1,6 @@
 // src/hooks/usePanZoom.ts
 import { useCallback, useEffect, useRef, useState } from "react";
+import { hitTestXAxis, hitTestYAxis } from "../components/Plot/axisHitTest";
 import {
 	type PanTarget,
 	panTargetXAxisId,
@@ -214,42 +215,21 @@ export function usePanZoom({
 	const hoveredXAxisIdRef = useRef<string | null>(null);
 
 	const getHoveredYAxis = useCallback(
-		(mouseX: number, mouseY: number) => {
-			if (mouseY < padding.top || mouseY > height - padding.bottom) return null;
-			let lOff = 0;
-			for (let i = 0; i < leftAxes.length; i++) {
-				const am = axisLayout[leftAxes[i].id] || { total: 40 };
-				if (
-					mouseX >= padding.left - lOff - am.total &&
-					mouseX <= padding.left - lOff
-				)
-					return leftAxes[i].id;
-				lOff += am.total;
-			}
-			let rOff = 0;
-			for (let i = 0; i < rightAxes.length; i++) {
-				const am = axisLayout[rightAxes[i].id] || { total: 40 };
-				if (
-					mouseX >= width - padding.right + rOff &&
-					mouseX <= width - padding.right + rOff + am.total
-				)
-					return rightAxes[i].id;
-				rOff += am.total;
-			}
-			return null;
-		},
+		(mouseX: number, mouseY: number) =>
+			hitTestYAxis(mouseX, mouseY, {
+				width,
+				height,
+				padding,
+				leftAxes,
+				rightAxes,
+				axisLayout,
+			}),
 		[leftAxes, rightAxes, axisLayout, padding, width, height],
 	);
 
 	const getHoveredXAxis = useCallback(
-		(mouseX: number, mouseY: number) => {
-			if (mouseX < padding.left || mouseX > width - padding.right) return null;
-			for (const m of xAxesMetrics) {
-				const baseY = height - padding.bottom + m.cumulativeOffset;
-				if (mouseY >= baseY && mouseY <= baseY + m.height) return m.id;
-			}
-			return null;
-		},
+		(mouseX: number, mouseY: number) =>
+			hitTestXAxis(mouseX, mouseY, { width, height, padding, xAxesMetrics }),
 		[xAxesMetrics, padding, width, height],
 	);
 


### PR DESCRIPTION
## Summary

Continues the incremental decomposition tracked in #509. This step pulls the pure axis hover hit-testing geometry out of the `usePanZoom` god-hook into a standalone, unit-tested module — following the same "extract a pure piece, add tests" pattern as the earlier `buildXAxisLayout` extraction (#520).

- New `src/components/Plot/axisHitTest.ts` with `hitTestYAxis` / `hitTestXAxis` pure functions (which axis gutter is under the pointer).
- `usePanZoom`'s `getHoveredYAxis` / `getHoveredXAxis` now delegate to these helpers. The `useCallback` wrappers and their dependency arrays are unchanged, so memoization and interaction behavior are identical.
- New `axisHitTest.test.ts` covering left/right Y gutters, stacked X-axis rows, out-of-band misses, and the missing-layout default-width fallback.

No behavior change intended — this is a pure refactor that shrinks the hook and makes the hit-testing geometry independently testable.

## Test plan

- [x] `pnpm test` — 648 tests pass (57 files), including 9 new hit-test cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser verification of pan/zoom hover behavior on axis gutters (recommended before merge, per the issue's note that interaction paths aren't fully covered by tests)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_