### PR TITLE
Extract pure zoom-range math from usePanZoom (#509)

### DIFF
--- a/src/hooks/__tests__/panZoomMath.test.ts
+++ b/src/hooks/__tests__/panZoomMath.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { applyZoomToRange } from "../panZoomMath";
+
+describe("applyZoomToRange", () => {
+	it("keeps the range unchanged at zoom factor 1", () => {
+		// pivot at the centre (weight 0.5) of [0, 100]
+		expect(applyZoomToRange(50, 0, 100, 0.5, 1)).toEqual({ min: 0, max: 100 });
+	});
+
+	it("zooms in (factor < 1) around the centre pivot", () => {
+		// range 100 -> 90, pivot 50 stays centred
+		expect(applyZoomToRange(50, 0, 100, 0.5, 0.9)).toEqual({
+			min: 5,
+			max: 95,
+		});
+	});
+
+	it("zooms out (factor > 1) around the centre pivot", () => {
+		const r = applyZoomToRange(50, 0, 100, 0.5, 1.1);
+		expect(r.min).toBeCloseTo(-5, 10);
+		expect(r.max).toBeCloseTo(105, 10);
+	});
+
+	it("anchors the left edge when weight is 0", () => {
+		// pivot is the range start; min stays, max moves
+		const r = applyZoomToRange(0, 0, 100, 0, 0.5);
+		expect(r.min).toBe(0);
+		expect(r.max).toBe(50);
+	});
+
+	it("anchors the right edge when weight is 1", () => {
+		// pivot is the range end; max stays, min moves
+		const r = applyZoomToRange(100, 0, 100, 1, 0.5);
+		expect(r.min).toBe(50);
+		expect(r.max).toBe(100);
+	});
+
+	it("keeps the pivot fixed in world space regardless of zoom", () => {
+		// pivot at weight 0.25 of [10, 30] => world 15
+		const pivot = 15;
+		const weight = 0.25;
+		const zoomedIn = applyZoomToRange(pivot, 10, 30, weight, 0.5);
+		// pivot must sit at the same fractional position after zoom
+		const fracIn = (pivot - zoomedIn.min) / (zoomedIn.max - zoomedIn.min);
+		expect(fracIn).toBeCloseTo(weight, 10);
+
+		const zoomedOut = applyZoomToRange(pivot, 10, 30, weight, 2);
+		const fracOut = (pivot - zoomedOut.min) / (zoomedOut.max - zoomedOut.min);
+		expect(fracOut).toBeCloseTo(weight, 10);
+	});
+
+	it("supports non-zero range offsets", () => {
+		// [200, 400], centre pivot 300, zoom out 2x -> [100, 500]
+		expect(applyZoomToRange(300, 200, 400, 0.5, 2)).toEqual({
+			min: 100,
+			max: 500,
+		});
+	});
+});

--- a/src/hooks/panZoomMath.ts
+++ b/src/hooks/panZoomMath.ts
@@ -1,0 +1,30 @@
+// Pure pan/zoom range math, extracted from usePanZoom so it can be
+// unit-tested in isolation. These helpers operate purely on axis ranges
+// and never touch DOM, refs, or React state.
+
+export interface Range {
+	min: number;
+	max: number;
+}
+
+/**
+ * Zoom an axis range around a fixed world-space pivot.
+ *
+ * The pivot is the world coordinate under the pointer, and `weight` is the
+ * pivot's fractional position across the chart (0 = range start edge,
+ * 1 = range end edge). The pivot stays put while the range is scaled by
+ * `zoomFactor` (>1 zooms out, <1 zooms in).
+ */
+export function applyZoomToRange(
+	pivotWorld: number,
+	min: number,
+	max: number,
+	weight: number,
+	zoomFactor: number,
+): Range {
+	const newRange = (max - min) * zoomFactor;
+	return {
+		min: pivotWorld - weight * newRange,
+		max: pivotWorld + (1 - weight) * newRange,
+	};
+}

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -9,6 +9,7 @@ import {
 import type { XAxisConfig, YAxisConfig } from "../services/persistence";
 import { getAxisById } from "../utils/axisCalculations";
 import { screenToWorld } from "../utils/coords";
+import { applyZoomToRange } from "./panZoomMath";
 
 interface UsePanZoomOptions {
 	containerRef: React.RefObject<HTMLDivElement | null>;
@@ -270,12 +271,14 @@ export function usePanZoom({
 					const worldMouse = screenToWorld(mouseX, 0, vp);
 					const zfX =
 						typeof zoomFactor === "number" ? zoomFactor : zoomFactor.x;
-					const newXRange = (currentX.max - currentX.min) * zfX;
 					const weight = (mouseX - padding.left) / chartWidth;
-					targetXAxes.current[axis.id] = {
-						min: worldMouse.x - weight * newXRange,
-						max: worldMouse.x + (1 - weight) * newXRange,
-					};
+					targetXAxes.current[axis.id] = applyZoomToRange(
+						worldMouse.x,
+						currentX.min,
+						currentX.max,
+						weight,
+						zfX,
+					);
 				});
 			}
 			if (
@@ -309,12 +312,14 @@ export function usePanZoom({
 					const worldMouse = screenToWorld(0, mouseY, axisVp);
 					const zfY =
 						typeof zoomFactor === "number" ? zoomFactor : zoomFactor.y;
-					const newYRange = (currentTarget.max - currentTarget.min) * zfY;
 					const weight = (height - padding.bottom - mouseY) / chartHeight;
-					targetYs.current[axis.id] = {
-						min: worldMouse.y - weight * newYRange,
-						max: worldMouse.y + (1 - weight) * newYRange,
-					};
+					targetYs.current[axis.id] = applyZoomToRange(
+						worldMouse.y,
+						currentTarget.min,
+						currentTarget.max,
+						weight,
+						zfY,
+					);
 				});
 			}
 			syncViewport();


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing the "extract a pure piece + tests, no behavior change" pattern (after the axis hit-testing extraction in #535).

- New `src/hooks/panZoomMath.ts` with `applyZoomToRange(pivotWorld, min, max, weight, zoomFactor)` — the pure "scale an axis range around a fixed world-space pivot" computation.
- `usePanZoom`'s `performZoom` now calls this helper for both the X and Y branches, which previously had identical inline math. The existing `screenToWorld` pivot and `weight` computations stay in the hook untouched, so only the final range derivation moved — zoom behavior is unchanged.
- New `panZoomMath.test.ts` covering identity (factor 1), zoom in/out around centre, edge-anchored pivots (weight 0 and 1), pivot-stays-fixed invariance, and non-zero range offsets.

This gives interaction math a tested home for further pan/zoom extractions in subsequent steps.

## Test plan

- [x] `pnpm test` — 655 tests pass (58 files), including 7 new zoom-math cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser verification of wheel/pinch zoom (recommended before merge, per the issue's note that interaction paths aren't fully covered by tests)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_