### PR TITLE
Extract pure pan-shift math from usePanZoom (#509)

### DIFF
--- a/src/hooks/__tests__/panZoomMath.test.ts
+++ b/src/hooks/__tests__/panZoomMath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyZoomToRange } from "../panZoomMath";
+import { applyZoomToRange, panRangeByPixels } from "../panZoomMath";
 
 describe("applyZoomToRange", () => {
 	it("keeps the range unchanged at zoom factor 1", () => {
@@ -55,5 +55,31 @@ describe("applyZoomToRange", () => {
 			min: 100,
 			max: 500,
 		});
+	});
+});
+
+describe("panRangeByPixels", () => {
+	it("leaves the range unchanged for a zero pixel delta", () => {
+		expect(panRangeByPixels(0, 100, 0, 500)).toEqual({ min: 0, max: 100 });
+	});
+
+	it("preserves the range width while shifting both edges", () => {
+		// span 500px, range 100 -> 1 world unit per 5px; +50px shift = +10 world
+		const r = panRangeByPixels(0, 100, 50, 500);
+		expect(r).toEqual({ min: 10, max: 110 });
+		expect(r.max - r.min).toBe(100);
+	});
+
+	it("shifts in the opposite direction for a negative delta", () => {
+		expect(panRangeByPixels(0, 100, -50, 500)).toEqual({ min: -10, max: 90 });
+	});
+
+	it("scales the world shift by the range size", () => {
+		// wider range moves more world units for the same pixel delta
+		expect(panRangeByPixels(0, 1000, 50, 500)).toEqual({ min: 100, max: 1100 });
+	});
+
+	it("supports non-zero range offsets", () => {
+		expect(panRangeByPixels(200, 400, 25, 100)).toEqual({ min: 250, max: 450 });
 	});
 });

--- a/src/hooks/panZoomMath.ts
+++ b/src/hooks/panZoomMath.ts
@@ -28,3 +28,21 @@ export function applyZoomToRange(
 		max: pivotWorld + (1 - weight) * newRange,
 	};
 }
+
+/**
+ * Translate an axis range by a pointer movement measured in pixels.
+ *
+ * `deltaPx` is the signed pixel movement already oriented for the axis
+ * (callers negate it where the data should move opposite to the pointer),
+ * and `chartSpanPx` is the axis' on-screen length in pixels. The range width
+ * is preserved; both edges shift by the equivalent world distance.
+ */
+export function panRangeByPixels(
+	min: number,
+	max: number,
+	deltaPx: number,
+	chartSpanPx: number,
+): Range {
+	const worldShift = (deltaPx * (max - min)) / chartSpanPx;
+	return { min: min + worldShift, max: max + worldShift };
+}

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -9,7 +9,7 @@ import {
 import type { XAxisConfig, YAxisConfig } from "../services/persistence";
 import { getAxisById } from "../utils/axisCalculations";
 import { screenToWorld } from "../utils/coords";
-import { applyZoomToRange } from "./panZoomMath";
+import { applyZoomToRange, panRangeByPixels } from "./panZoomMath";
 
 interface UsePanZoomOptions {
 	containerRef: React.RefObject<HTMLDivElement | null>;
@@ -140,10 +140,12 @@ export function usePanZoom({
 					continue;
 				const startConf = ps.startTargetX[axis.id];
 				if (!startConf) continue;
-				const pxPerWorld = chartWidth / (startConf.max - startConf.min);
-				const shiftWorld = -dx / pxPerWorld;
-				const newMin = startConf.min + shiftWorld;
-				const newMax = startConf.max + shiftWorld;
+				const { min: newMin, max: newMax } = panRangeByPixels(
+					startConf.min,
+					startConf.max,
+					-dx,
+					chartWidth,
+				);
 				const cur = targetXAxes.current[axis.id];
 				if (cur.min !== newMin || cur.max !== newMax) {
 					// eslint-disable-next-line react-hooks/immutability
@@ -173,10 +175,12 @@ export function usePanZoom({
 				}
 				const startConf = ps.startTargetY[axis.id];
 				if (!startConf) continue;
-				const pxPerWorld = chartHeight / (startConf.max - startConf.min);
-				const shiftWorld = dy / pxPerWorld;
-				const newMin = startConf.min + shiftWorld;
-				const newMax = startConf.max + shiftWorld;
+				const { min: newMin, max: newMax } = panRangeByPixels(
+					startConf.min,
+					startConf.max,
+					dy,
+					chartHeight,
+				);
 				const cur = targetYs.current[axis.id];
 				if (cur.min !== newMin || cur.max !== newMax) {
 					// eslint-disable-next-line react-hooks/immutability
@@ -538,13 +542,12 @@ export function usePanZoom({
 				activeXAxes.forEach((a) => {
 					const cur = targetXAxes.current[a.id];
 					if (cur) {
-						const pxPerWorld = chartWidth / (cur.max - cur.min);
-						const shiftWorld = panDx / pxPerWorld;
-						targetXAxes.current[a.id] = {
-							...cur,
-							min: cur.min - shiftWorld,
-							max: cur.max - shiftWorld,
-						};
+						targetXAxes.current[a.id] = panRangeByPixels(
+							cur.min,
+							cur.max,
+							-panDx,
+							chartWidth,
+						);
 					}
 				});
 			}
@@ -556,13 +559,12 @@ export function usePanZoom({
 				activeYAxes.forEach((a) => {
 					const cur = targetYs.current[a.id];
 					if (cur) {
-						const pxPerWorld = chartHeight / (cur.max - cur.min);
-						const shiftWorld = panDy / pxPerWorld;
-						targetYs.current[a.id] = {
-							...cur,
-							min: cur.min + shiftWorld,
-							max: cur.max + shiftWorld,
-						};
+						targetYs.current[a.id] = panRangeByPixels(
+							cur.min,
+							cur.max,
+							panDy,
+							chartHeight,
+						);
 					}
 				});
 			}


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing the "extract a pure piece + tests, no behavior change" pattern (after axis hit-testing #535 and zoom-range math #536).

- Add `panRangeByPixels(min, max, deltaPx, chartSpanPx)` to `src/hooks/panZoomMath.ts` — translate an axis range by a pointer movement in pixels while preserving the range width.
- Replace the four inlined `pxPerWorld` range-translation blocks in `usePanZoom` with calls to the helper: the X and Y branches of `updatePan` (mouse/single-touch drag) and the X and Y pan adjustments inside the pinch-zoom handler.
- The direction sign stays explicit at each call site (e.g. `-dx` / `-panDx` for X), exactly mirroring the previous inline code, so pan behavior is unchanged.
- Extend `panZoomMath.test.ts` with cases for zero delta, width preservation, negative delta, range-size scaling, and non-zero offsets.

`usePanZoom`'s `updatePan` and pinch handler shrink and the pan math is now unit-tested.

## Test plan

- [x] `pnpm test` — 660 tests pass (58 files), including 5 new pan-shift cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser verification of mouse drag, single-touch drag, and two-finger pinch pan (recommended before merge, per the issue's note that interaction paths aren't fully covered by tests)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_