### PR TITLE
Extract pure Y-axis gutter geometry from ChartContainer (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -36,6 +36,7 @@ import { applyKeyboardPan, applyKeyboardZoom } from "../../utils/keyboard";
 import ErrorBoundary from "../ErrorBoundary";
 import { ImportSettingsDialog } from "../Layout/ImportSettingsDialog";
 import { AxesLayer, type AxesLayerHandle } from "./AxesLayer";
+import { computeAxisOffsets, sumGutterTotals } from "./axisGutters";
 import { buildXAxisLayout } from "./buildXAxisLayout";
 import { ChartLegend } from "./ChartLegend";
 import { Crosshair } from "./Crosshair";
@@ -480,21 +481,13 @@ export default function ChartContainer() {
 		return { leftAxes: left, rightAxes: right };
 	}, [activeYAxes]);
 
-	const { leftOffsets, rightOffsets } = useMemo(() => {
-		const leftOffsets: Record<string, number> = {};
-		let lOff = 0;
-		for (const a of leftAxes) {
-			leftOffsets[a.id] = lOff;
-			lOff += axisLayout[a.id]?.total || 40;
-		}
-		const rightOffsets: Record<string, number> = {};
-		let rOff = 0;
-		for (const a of rightAxes) {
-			rightOffsets[a.id] = rOff;
-			rOff += axisLayout[a.id]?.total || 40;
-		}
-		return { leftOffsets, rightOffsets };
-	}, [leftAxes, rightAxes, axisLayout]);
+	const { leftOffsets, rightOffsets } = useMemo(
+		() => ({
+			leftOffsets: computeAxisOffsets(leftAxes, axisLayout),
+			rightOffsets: computeAxisOffsets(rightAxes, axisLayout),
+		}),
+		[leftAxes, rightAxes, axisLayout],
+	);
 
 	const xAxesMetrics = useMemo((): XAxisMetrics[] => {
 		const result: XAxisMetrics[] = [];
@@ -509,14 +502,8 @@ export default function ChartContainer() {
 
 	const padding = useMemo(() => {
 		const base = BASE_PADDING_DESKTOP;
-		const leftSum = leftAxes.reduce(
-			(sum, a) => sum + (axisLayout[a.id]?.total || 40),
-			0,
-		);
-		const rightSum = rightAxes.reduce(
-			(sum, a) => sum + (axisLayout[a.id]?.total || 40),
-			0,
-		);
+		const leftSum = sumGutterTotals(leftAxes, axisLayout);
+		const rightSum = sumGutterTotals(rightAxes, axisLayout);
 		const bottom =
 			xAxesMetrics.length > 0
 				? xAxesMetrics.reduce((sum, m) => sum + m.height, 0)

--- a/src/components/Plot/__tests__/axisGutters.test.ts
+++ b/src/components/Plot/__tests__/axisGutters.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_GUTTER_TOTAL,
+	computeAxisOffsets,
+	gutterTotal,
+	sumGutterTotals,
+} from "../axisGutters";
+
+const layout = {
+	A: { total: 50 },
+	B: { total: 30 },
+	C: { total: 64 },
+};
+
+describe("gutterTotal", () => {
+	it("returns the configured total", () => {
+		expect(gutterTotal(layout, "A")).toBe(50);
+	});
+
+	it("falls back to the default when the axis is missing", () => {
+		expect(gutterTotal(layout, "missing")).toBe(DEFAULT_GUTTER_TOTAL);
+	});
+
+	it("falls back to the default when total is zero/falsy", () => {
+		expect(gutterTotal({ Z: { total: 0 } }, "Z")).toBe(DEFAULT_GUTTER_TOTAL);
+	});
+});
+
+describe("computeAxisOffsets", () => {
+	it("returns an empty map for no axes", () => {
+		expect(computeAxisOffsets([], layout)).toEqual({});
+	});
+
+	it("places the first axis flush (offset 0) and stacks the rest outward", () => {
+		expect(computeAxisOffsets([{ id: "A" }, { id: "B" }, { id: "C" }], layout)).toEqual(
+			{ A: 0, B: 50, C: 80 },
+		);
+	});
+
+	it("uses the default width for axes missing from the layout", () => {
+		expect(computeAxisOffsets([{ id: "A" }, { id: "missing" }], layout)).toEqual({
+			A: 0,
+			missing: 50,
+		});
+	});
+});
+
+describe("sumGutterTotals", () => {
+	it("returns 0 for no axes", () => {
+		expect(sumGutterTotals([], layout)).toBe(0);
+	});
+
+	it("sums the configured gutter widths", () => {
+		expect(sumGutterTotals([{ id: "A" }, { id: "B" }], layout)).toBe(80);
+	});
+
+	it("includes the default for missing axes", () => {
+		expect(sumGutterTotals([{ id: "A" }, { id: "missing" }], layout)).toBe(
+			50 + DEFAULT_GUTTER_TOTAL,
+		);
+	});
+});

--- a/src/components/Plot/axisGutters.ts
+++ b/src/components/Plot/axisGutters.ts
@@ -1,0 +1,45 @@
+// Pure geometry for the Y-axis "gutters" — the stacked label/tick strips on
+// the left and right of the plot. Extracted from ChartContainer so the
+// offset/width math can be unit-tested in isolation.
+
+export const DEFAULT_GUTTER_TOTAL = 40;
+
+interface GutterLayout {
+	total: number;
+}
+
+/** Pixel width reserved for an axis gutter, falling back to a default. */
+export function gutterTotal(
+	axisLayout: Record<string, GutterLayout>,
+	id: string,
+): number {
+	return axisLayout[id]?.total || DEFAULT_GUTTER_TOTAL;
+}
+
+/**
+ * Cumulative pixel offset of each gutter from the plot edge, in order.
+ * The first axis sits flush against the plot (offset 0) and each subsequent
+ * axis is pushed outward by the preceding gutters' widths.
+ */
+export function computeAxisOffsets(
+	axes: readonly { id: string }[],
+	axisLayout: Record<string, GutterLayout>,
+): Record<string, number> {
+	const offsets: Record<string, number> = {};
+	let off = 0;
+	for (const a of axes) {
+		offsets[a.id] = off;
+		off += gutterTotal(axisLayout, a.id);
+	}
+	return offsets;
+}
+
+/** Combined pixel width of a set of axis gutters. */
+export function sumGutterTotals(
+	axes: readonly { id: string }[],
+	axisLayout: Record<string, GutterLayout>,
+): number {
+	let sum = 0;
+	for (const a of axes) sum += gutterTotal(axisLayout, a.id);
+	return sum;
+}


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, moving from `usePanZoom` (axis hit-testing #535, zoom math #536, pan math #537) into `ChartContainer`. Same pattern: extract a pure, cohesive piece + tests, no behavior change.

- New `src/components/Plot/axisGutters.ts` with:
  - `gutterTotal(axisLayout, id)` — reserved pixel width of an axis gutter with the shared `|| 40` default.
  - `computeAxisOffsets(axes, axisLayout)` — cumulative pixel offset of each stacked gutter from the plot edge.
  - `sumGutterTotals(axes, axisLayout)` — combined width of a set of gutters.
- `ChartContainer`'s `leftOffsets`/`rightOffsets` memo now calls `computeAxisOffsets`, and the `padding` memo's `leftSum`/`rightSum` now call `sumGutterTotals`. The memo dependency arrays are unchanged, so layout output is identical.
- New `axisGutters.test.ts` covering offsets (empty, stacked, missing-axis default), sums, and the gutter-width fallback (including the falsy-`total` case).

## Test plan

- [x] `pnpm test` — 669 tests pass (59 files), including 9 new gutter cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that multi-axis left/right gutter spacing and plot padding render unchanged (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_