### PR TITLE
Extract pure Y-axis gutter sizing from ChartContainer (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -25,10 +25,7 @@ import {
 	AXIS_EPSILON,
 	type AxesFrame,
 	DEFAULT_X_AXIS_ID,
-	calcNumericPrecision,
-	calcNumericStep,
 	calcYAxisTicks,
-	formatAxisLabel,
 	getAxisById,
 	syncAxesWithTargets,
 } from "../../utils/axisCalculations";
@@ -36,7 +33,11 @@ import { applyKeyboardPan, applyKeyboardZoom } from "../../utils/keyboard";
 import ErrorBoundary from "../ErrorBoundary";
 import { ImportSettingsDialog } from "../Layout/ImportSettingsDialog";
 import { AxesLayer, type AxesLayerHandle } from "./AxesLayer";
-import { computeAxisOffsets, sumGutterTotals } from "./axisGutters";
+import {
+	computeAxisOffsets,
+	measureYAxisGutter,
+	sumGutterTotals,
+} from "./axisGutters";
 import { buildXAxisLayout } from "./buildXAxisLayout";
 import { ChartLegend } from "./ChartLegend";
 import { Crosshair } from "./Crosshair";
@@ -443,28 +444,13 @@ export default function ChartContainer() {
 
 	const axisLayout = useMemo(() => {
 		const layout: Record<string, { total: number; label: number }> = {};
-		activeYAxes.forEach((axis) => {
-			const categoryLabels = yAxisCategoryLabels.get(axis.id);
-			let widestValChars: number;
-			if (categoryLabels) {
-				widestValChars = categoryLabels.reduce(
-					(acc, n) => Math.max(acc, n?.length ?? 0),
-					1,
-				);
-			} else {
-				const step = calcNumericStep(
-					axis.max - axis.min,
-					Math.max(2, Math.floor(height / 30)),
-				);
-				const precision = calcNumericPrecision(step);
-				widestValChars = Math.max(
-					formatAxisLabel(axis.min, precision).length,
-					formatAxisLabel(axis.max, precision).length,
-				);
-			}
-			const labelWidth = Math.min(100, widestValChars * 6);
-			layout[axis.id] = { label: labelWidth, total: labelWidth + 24 };
-		});
+		for (const axis of activeYAxes) {
+			layout[axis.id] = measureYAxisGutter(
+				axis,
+				height,
+				yAxisCategoryLabels.get(axis.id),
+			);
+		}
 		return layout;
 	}, [activeYAxes, height, yAxisCategoryLabels]);
 

--- a/src/components/Plot/__tests__/axisGutters.test.ts
+++ b/src/components/Plot/__tests__/axisGutters.test.ts
@@ -3,6 +3,7 @@ import {
 	DEFAULT_GUTTER_TOTAL,
 	computeAxisOffsets,
 	gutterTotal,
+	measureYAxisGutter,
 	sumGutterTotals,
 } from "../axisGutters";
 
@@ -58,5 +59,45 @@ describe("sumGutterTotals", () => {
 		expect(sumGutterTotals([{ id: "A" }, { id: "missing" }], layout)).toBe(
 			50 + DEFAULT_GUTTER_TOTAL,
 		);
+	});
+});
+
+describe("measureYAxisGutter", () => {
+	it("sizes a categorical gutter from the widest category label", () => {
+		// widest is "Charlie" (7 chars) -> labelWidth = 7*6 = 42, total = 66
+		const r = measureYAxisGutter(
+			{ min: 0, max: 2 },
+			500,
+			["A", "Bee", "Charlie"],
+		);
+		expect(r).toEqual({ label: 42, total: 66 });
+	});
+
+	it("treats empty/undefined category labels as 1 char wide", () => {
+		const r = measureYAxisGutter({ min: 0, max: 0 }, 500, []);
+		expect(r).toEqual({ label: 6, total: 30 });
+	});
+
+	it("caps the categorical label width at 100px", () => {
+		const r = measureYAxisGutter({ min: 0, max: 1 }, 500, [
+			"a".repeat(50),
+		]);
+		expect(r).toEqual({ label: 100, total: 124 });
+	});
+
+	it("sizes a numeric gutter from the formatted range endpoints", () => {
+		const r = measureYAxisGutter({ min: 0, max: 100 }, 500, undefined);
+		// integer ticks at this scale -> 3-char endpoint "100"
+		expect(r.label % 6).toBe(0);
+		expect(r.total).toBe(r.label + 24);
+		expect(r.label).toBeGreaterThanOrEqual(6);
+		expect(r.label).toBeLessThanOrEqual(100);
+	});
+
+	it("grows the numeric gutter when negative endpoints need more chars", () => {
+		const narrow = measureYAxisGutter({ min: 0, max: 100 }, 500, undefined);
+		const wide = measureYAxisGutter({ min: -1000, max: 100 }, 500, undefined);
+		expect(wide.label).toBeGreaterThan(narrow.label);
+		expect(wide.total).toBe(wide.label + 24);
 	});
 });

--- a/src/components/Plot/axisGutters.ts
+++ b/src/components/Plot/axisGutters.ts
@@ -2,6 +2,12 @@
 // the left and right of the plot. Extracted from ChartContainer so the
 // offset/width math can be unit-tested in isolation.
 
+import {
+	calcNumericPrecision,
+	calcNumericStep,
+	formatAxisLabel,
+} from "../../utils/axisCalculations";
+
 export const DEFAULT_GUTTER_TOTAL = 40;
 
 interface GutterLayout {
@@ -42,4 +48,37 @@ export function sumGutterTotals(
 	let sum = 0;
 	for (const a of axes) sum += gutterTotal(axisLayout, a.id);
 	return sum;
+}
+
+/**
+ * Size a single Y-axis gutter based on the widest label it will need to
+ * render. For categorical axes the widest category label drives the width;
+ * for numeric axes the precision implied by the range and chart height does.
+ * Returns the inner label width and the total gutter width (label + tick
+ * area). The label width is capped at 100px.
+ */
+export function measureYAxisGutter(
+	axis: { min: number; max: number },
+	height: number,
+	categoryLabels: readonly string[] | undefined,
+): { label: number; total: number } {
+	let widestValChars: number;
+	if (categoryLabels) {
+		widestValChars = categoryLabels.reduce(
+			(acc, n) => Math.max(acc, n?.length ?? 0),
+			1,
+		);
+	} else {
+		const step = calcNumericStep(
+			axis.max - axis.min,
+			Math.max(2, Math.floor(height / 30)),
+		);
+		const precision = calcNumericPrecision(step);
+		widestValChars = Math.max(
+			formatAxisLabel(axis.min, precision).length,
+			formatAxisLabel(axis.max, precision).length,
+		);
+	}
+	const labelWidth = Math.min(100, widestValChars * 6);
+	return { label: labelWidth, total: labelWidth + 24 };
 }


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing inside `ChartContainer` (after the gutter offsets/sums in #538). Same pattern: extract a pure piece + tests, no behavior change.

- Add `measureYAxisGutter(axis, height, categoryLabels)` to `src/components/Plot/axisGutters.ts`. Returns `{label, total}` for a single Y-axis gutter:
  - Categorical: widest category label (clamped ≥ 1 char) times 6px.
  - Numeric: precision derived from the range and chart height, label width from the widest formatted endpoint.
  - Label width capped at 100px; total = label + 24px.
- `ChartContainer`'s `axisLayout` memo now maps each active Y axis through the helper. Memo deps and output shape are unchanged.
- Drops three now-unused imports (`calcNumericPrecision`, `calcNumericStep`, `formatAxisLabel`) from `ChartContainer`.
- New cases in `axisGutters.test.ts`: categorical widest-label sizing, empty-list 1-char fallback, 100px cap, numeric structural invariants, and the negative-endpoint width-growth comparison.

## Test plan

- [x] `pnpm test` — 674 tests pass (59 files), including 5 new measure cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that Y-axis label/tick spacing renders unchanged for both categorical and numeric axes (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_