### PR TITLE
Extract pure X-axis row metrics from ChartContainer (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -44,6 +44,7 @@ import { Crosshair } from "./Crosshair";
 import type { XAxisLayout, XAxisMetrics, YAxisLayout } from "./chartTypes";
 import { EmptyState } from "./EmptyState";
 import { WebGLRenderer, type WebGLRendererHandle } from "./WebGLRenderer";
+import { computeXAxesMetrics } from "./xAxisMetrics";
 
 type OverlayXEntry = {
 	id: string;
@@ -191,20 +192,6 @@ const BASE_PADDING_DESKTOP = { top: 20, right: 20, bottom: 60, left: 20 };
 
 /** Cap on x-values sampled when deriving categorical labels for a forced axis. */
 const MAX_DERIVED_CATEGORY_LABELS = 1000;
-
-const getXAxisMetrics = (
-	xMode: "date" | "numeric" | "categorical",
-): Omit<XAxisMetrics, "id" | "cumulativeOffset"> => {
-	if (xMode === "date") {
-		return {
-			height: 70,
-			labelBottom: 22,
-			secLabelBottom: 38,
-			titleBottom: 60,
-		};
-	}
-	return { height: 50, labelBottom: 26, secLabelBottom: 0, titleBottom: 40 };
-};
 
 export default function ChartContainer() {
 	// 1. Core Refs and State
@@ -475,16 +462,10 @@ export default function ChartContainer() {
 		[leftAxes, rightAxes, axisLayout],
 	);
 
-	const xAxesMetrics = useMemo((): XAxisMetrics[] => {
-		const result: XAxisMetrics[] = [];
-		let currentOffset = 0;
-		for (const axis of activeXAxesUsed) {
-			const base = getXAxisMetrics(axis.xMode);
-			result.push({ ...base, id: axis.id, cumulativeOffset: currentOffset });
-			currentOffset += base.height;
-		}
-		return result;
-	}, [activeXAxesUsed]);
+	const xAxesMetrics = useMemo(
+		() => computeXAxesMetrics(activeXAxesUsed),
+		[activeXAxesUsed],
+	);
 
 	const padding = useMemo(() => {
 		const base = BASE_PADDING_DESKTOP;

--- a/src/components/Plot/__tests__/xAxisMetrics.test.ts
+++ b/src/components/Plot/__tests__/xAxisMetrics.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { computeXAxesMetrics, getXAxisRowMetrics } from "../xAxisMetrics";
+
+describe("getXAxisRowMetrics", () => {
+	it("returns the taller layout for date axes (room for the secondary row)", () => {
+		expect(getXAxisRowMetrics("date")).toEqual({
+			height: 70,
+			labelBottom: 22,
+			secLabelBottom: 38,
+			titleBottom: 60,
+		});
+	});
+
+	it("returns the compact layout for numeric axes", () => {
+		expect(getXAxisRowMetrics("numeric")).toEqual({
+			height: 50,
+			labelBottom: 26,
+			secLabelBottom: 0,
+			titleBottom: 40,
+		});
+	});
+
+	it("treats categorical axes like numeric (no secondary row)", () => {
+		expect(getXAxisRowMetrics("categorical")).toEqual(
+			getXAxisRowMetrics("numeric"),
+		);
+	});
+});
+
+describe("computeXAxesMetrics", () => {
+	it("returns an empty array when there are no axes", () => {
+		expect(computeXAxesMetrics([])).toEqual([]);
+	});
+
+	it("places the first axis flush against the plot (offset 0)", () => {
+		const [m] = computeXAxesMetrics([{ id: "X", xMode: "numeric" }]);
+		expect(m.id).toBe("X");
+		expect(m.cumulativeOffset).toBe(0);
+		expect(m.height).toBe(50);
+	});
+
+	it("stacks each axis by its preceding heights", () => {
+		const result = computeXAxesMetrics([
+			{ id: "A", xMode: "date" }, // height 70
+			{ id: "B", xMode: "numeric" }, // height 50
+			{ id: "C", xMode: "categorical" }, // height 50
+		]);
+		expect(result.map((m) => m.cumulativeOffset)).toEqual([0, 70, 120]);
+		expect(result.map((m) => m.id)).toEqual(["A", "B", "C"]);
+	});
+
+	it("preserves the per-axis label baselines from getXAxisRowMetrics", () => {
+		const [date, num] = computeXAxesMetrics([
+			{ id: "A", xMode: "date" },
+			{ id: "B", xMode: "numeric" },
+		]);
+		expect(date.labelBottom).toBe(22);
+		expect(date.secLabelBottom).toBe(38);
+		expect(num.labelBottom).toBe(26);
+		expect(num.secLabelBottom).toBe(0);
+	});
+});

--- a/src/components/Plot/xAxisMetrics.ts
+++ b/src/components/Plot/xAxisMetrics.ts
@@ -1,0 +1,41 @@
+// Pure X-axis row geometry, extracted from ChartContainer. Each visible
+// x-axis occupies a horizontal strip below the plot — date axes are taller
+// to fit the secondary-label row, others are shorter. `computeXAxesMetrics`
+// stacks these strips and records each axis' cumulative pixel offset from
+// the plot's bottom edge.
+
+import type { XAxisMetrics } from "./chartTypes";
+
+type XMode = "date" | "numeric" | "categorical";
+
+/** Heights and label baselines for a single x-axis strip, by mode. */
+export function getXAxisRowMetrics(
+	xMode: XMode,
+): Omit<XAxisMetrics, "id" | "cumulativeOffset"> {
+	if (xMode === "date") {
+		return {
+			height: 70,
+			labelBottom: 22,
+			secLabelBottom: 38,
+			titleBottom: 60,
+		};
+	}
+	return { height: 50, labelBottom: 26, secLabelBottom: 0, titleBottom: 40 };
+}
+
+/**
+ * Stack each axis' strip below the plot and tag it with its cumulative
+ * offset (the sum of preceding strips' heights).
+ */
+export function computeXAxesMetrics(
+	axes: readonly { id: string; xMode: XMode }[],
+): XAxisMetrics[] {
+	const result: XAxisMetrics[] = [];
+	let currentOffset = 0;
+	for (const axis of axes) {
+		const base = getXAxisRowMetrics(axis.xMode);
+		result.push({ ...base, id: axis.id, cumulativeOffset: currentOffset });
+		currentOffset += base.height;
+	}
+	return result;
+}


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing inside `ChartContainer` (after the gutter offsets/sums #538 and gutter sizing #539). Same pattern: extract a pure piece + tests, no behavior change.

- New `src/components/Plot/xAxisMetrics.ts` with:
  - `getXAxisRowMetrics(xMode)` — height/labelBottom/secLabelBottom/titleBottom for a single x-axis strip (taller for `date`, compact for `numeric`/`categorical`).
  - `computeXAxesMetrics(axes)` — stacks the strips below the plot and tags each one with its `cumulativeOffset`.
- `ChartContainer` drops the module-level `getXAxisMetrics` helper; the `xAxesMetrics` memo now just calls `computeXAxesMetrics(activeXAxesUsed)`. Memo deps and output are unchanged.
- New `xAxisMetrics.test.ts` covering each mode's row metrics, the empty case, first-axis-flush, cumulative stacking with mixed modes, and label-baseline preservation.

## Test plan

- [x] `pnpm test` — 681 tests pass (60 files), including 7 new x-axis metrics cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that single and stacked x-axis rows render at the same positions for date/numeric/categorical modes (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_