### PR TITLE
Extract syncStoreUpdates into its own module (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -22,7 +22,6 @@ import { useGraphStore } from "../../store/useGraphStore";
 import { THEMES } from "../../themes";
 import { getColumnIndex } from "../../utils/columns";
 import {
-	AXIS_EPSILON,
 	type AxesFrame,
 	DEFAULT_X_AXIS_ID,
 	calcYAxisTicks,
@@ -43,6 +42,7 @@ import { ChartLegend } from "./ChartLegend";
 import { Crosshair } from "./Crosshair";
 import type { XAxisLayout, XAxisMetrics, YAxisLayout } from "./chartTypes";
 import { EmptyState } from "./EmptyState";
+import { syncStoreUpdates } from "./syncStoreUpdates";
 import { WebGLRenderer, type WebGLRendererHandle } from "./WebGLRenderer";
 import { computeXAxesMetrics } from "./xAxisMetrics";
 
@@ -143,47 +143,6 @@ function updateOverlayAxes(
 	}
 
 	scratch.estVertexCount = est;
-}
-
-function syncStoreUpdates(
-	state: ReturnType<typeof useGraphStore.getState>,
-	xUpdates: Record<string, { min: number; max: number }>,
-	yUpdates: Record<string, { min: number; max: number }>,
-) {
-	const filteredXUpdates: Record<string, { min: number; max: number }> = {};
-	const filteredYUpdates: Record<string, { min: number; max: number }> = {};
-	let hasX = false;
-	let hasY = false;
-
-	const xAxisMap = new Map(state.xAxes.map((a) => [a.id, a]));
-	for (const [id, upd] of Object.entries(xUpdates)) {
-		const axis = xAxisMap.get(id);
-		if (
-			!axis ||
-			Math.abs(axis.min - upd.min) > AXIS_EPSILON ||
-			Math.abs(axis.max - upd.max) > AXIS_EPSILON
-		) {
-			filteredXUpdates[id] = upd;
-			hasX = true;
-		}
-	}
-
-	const yAxisMap = new Map(state.yAxes.map((a) => [a.id, a]));
-	for (const [id, upd] of Object.entries(yUpdates)) {
-		const axis = yAxisMap.get(id);
-		if (
-			!axis ||
-			Math.abs(axis.min - upd.min) > AXIS_EPSILON ||
-			Math.abs(axis.max - upd.max) > AXIS_EPSILON
-		) {
-			filteredYUpdates[id] = upd;
-			hasY = true;
-		}
-	}
-
-	if (hasX || hasY) {
-		state.batchUpdateAxes(filteredXUpdates, filteredYUpdates);
-	}
 }
 
 type DatasetsByAxisId = Record<string, Dataset[]>;

--- a/src/components/Plot/__tests__/syncStoreUpdates.test.ts
+++ b/src/components/Plot/__tests__/syncStoreUpdates.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { AXIS_EPSILON } from "../../../utils/axisCalculations";
+import { syncStoreUpdates } from "../syncStoreUpdates";
+
+function makeState(xAxes: Array<{ id: string; min: number; max: number }>, yAxes: Array<{ id: string; min: number; max: number }>) {
+	return {
+		xAxes,
+		yAxes,
+		batchUpdateAxes: vi.fn(),
+	};
+}
+
+describe("syncStoreUpdates", () => {
+	it("does nothing when no axes moved beyond epsilon", () => {
+		const state = makeState(
+			[{ id: "X", min: 0, max: 10 }],
+			[{ id: "Y", min: 0, max: 100 }],
+		);
+		syncStoreUpdates(
+			state,
+			{ X: { min: 0, max: 10 } },
+			{ Y: { min: 0, max: 100 } },
+		);
+		expect(state.batchUpdateAxes).not.toHaveBeenCalled();
+	});
+
+	it("ignores changes within epsilon", () => {
+		const state = makeState(
+			[{ id: "X", min: 0, max: 10 }],
+			[{ id: "Y", min: 0, max: 100 }],
+		);
+		const tinyDelta = AXIS_EPSILON / 2;
+		syncStoreUpdates(
+			state,
+			{ X: { min: tinyDelta, max: 10 - tinyDelta } },
+			{ Y: { min: tinyDelta, max: 100 - tinyDelta } },
+		);
+		expect(state.batchUpdateAxes).not.toHaveBeenCalled();
+	});
+
+	it("commits updates that exceed epsilon on min or max", () => {
+		const state = makeState(
+			[{ id: "X", min: 0, max: 10 }],
+			[{ id: "Y", min: 0, max: 100 }],
+		);
+		syncStoreUpdates(
+			state,
+			{ X: { min: 1, max: 10 } },
+			{ Y: { min: 0, max: 100 } },
+		);
+		expect(state.batchUpdateAxes).toHaveBeenCalledExactlyOnceWith(
+			{ X: { min: 1, max: 10 } },
+			{},
+		);
+	});
+
+	it("commits updates for axes missing from the store", () => {
+		const state = makeState(
+			[{ id: "X", min: 0, max: 10 }],
+			[],
+		);
+		syncStoreUpdates(
+			state,
+			{ ghost: { min: 5, max: 6 } },
+			{},
+		);
+		expect(state.batchUpdateAxes).toHaveBeenCalledExactlyOnceWith(
+			{ ghost: { min: 5, max: 6 } },
+			{},
+		);
+	});
+
+	it("filters per-axis: only changed axes are forwarded", () => {
+		const state = makeState(
+			[
+				{ id: "X1", min: 0, max: 10 },
+				{ id: "X2", min: 0, max: 20 },
+			],
+			[
+				{ id: "Y1", min: 0, max: 100 },
+				{ id: "Y2", min: 0, max: 200 },
+			],
+		);
+		syncStoreUpdates(
+			state,
+			{
+				X1: { min: 0, max: 10 }, // unchanged
+				X2: { min: 1, max: 20 }, // moved
+			},
+			{
+				Y1: { min: 0, max: 110 }, // moved
+				Y2: { min: 0, max: 200 }, // unchanged
+			},
+		);
+		expect(state.batchUpdateAxes).toHaveBeenCalledExactlyOnceWith(
+			{ X2: { min: 1, max: 20 } },
+			{ Y1: { min: 0, max: 110 } },
+		);
+	});
+
+	it("commits when only Y changed (X stays {})", () => {
+		const state = makeState(
+			[{ id: "X", min: 0, max: 10 }],
+			[{ id: "Y", min: 0, max: 100 }],
+		);
+		syncStoreUpdates(
+			state,
+			{ X: { min: 0, max: 10 } },
+			{ Y: { min: 5, max: 100 } },
+		);
+		expect(state.batchUpdateAxes).toHaveBeenCalledExactlyOnceWith(
+			{},
+			{ Y: { min: 5, max: 100 } },
+		);
+	});
+
+	it("handles empty update objects", () => {
+		const state = makeState(
+			[{ id: "X", min: 0, max: 10 }],
+			[{ id: "Y", min: 0, max: 100 }],
+		);
+		syncStoreUpdates(state, {}, {});
+		expect(state.batchUpdateAxes).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/Plot/syncStoreUpdates.ts
+++ b/src/components/Plot/syncStoreUpdates.ts
@@ -1,0 +1,62 @@
+// Reconcile axis-range updates produced during interactive panning/zooming
+// with the persisted store state. Filters out updates that match the current
+// store values within AXIS_EPSILON and only triggers a batched commit if any
+// axis actually moved. Extracted from ChartContainer so the filtering can be
+// unit-tested without spinning up the store.
+
+import { AXIS_EPSILON } from "../../utils/axisCalculations";
+
+export type AxisRangeUpdate = Record<string, { min: number; max: number }>;
+
+interface AxisRange {
+	id: string;
+	min: number;
+	max: number;
+}
+
+interface StoreLike {
+	xAxes: readonly AxisRange[];
+	yAxes: readonly AxisRange[];
+	batchUpdateAxes(xUpdates: AxisRangeUpdate, yUpdates: AxisRangeUpdate): void;
+}
+
+export function syncStoreUpdates(
+	state: StoreLike,
+	xUpdates: AxisRangeUpdate,
+	yUpdates: AxisRangeUpdate,
+): void {
+	const filteredXUpdates: AxisRangeUpdate = {};
+	const filteredYUpdates: AxisRangeUpdate = {};
+	let hasX = false;
+	let hasY = false;
+
+	const xAxisMap = new Map(state.xAxes.map((a) => [a.id, a]));
+	for (const [id, upd] of Object.entries(xUpdates)) {
+		const axis = xAxisMap.get(id);
+		if (
+			!axis ||
+			Math.abs(axis.min - upd.min) > AXIS_EPSILON ||
+			Math.abs(axis.max - upd.max) > AXIS_EPSILON
+		) {
+			filteredXUpdates[id] = upd;
+			hasX = true;
+		}
+	}
+
+	const yAxisMap = new Map(state.yAxes.map((a) => [a.id, a]));
+	for (const [id, upd] of Object.entries(yUpdates)) {
+		const axis = yAxisMap.get(id);
+		if (
+			!axis ||
+			Math.abs(axis.min - upd.min) > AXIS_EPSILON ||
+			Math.abs(axis.max - upd.max) > AXIS_EPSILON
+		) {
+			filteredYUpdates[id] = upd;
+			hasY = true;
+		}
+	}
+
+	if (hasX || hasY) {
+		state.batchUpdateAxes(filteredXUpdates, filteredYUpdates);
+	}
+}


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing the `ChartContainer` clean-up (after gutter offsets/sums #538, gutter sizing #539, x-axis row metrics #540). Same pattern: extract a pure-ish piece + tests, no behavior change.

- New `src/components/Plot/syncStoreUpdates.ts` containing the axis-update reconciliation helper that filters interactive pan/zoom outputs against the persisted store values using `AXIS_EPSILON` and only commits a `batchUpdateAxes` call if something actually moved.
- The function's signature is decoupled from the store via a minimal `StoreLike` interface (`xAxes`, `yAxes`, `batchUpdateAxes`), so it can be tested without spinning up `useGraphStore`.
- `ChartContainer` imports the helper instead of defining it locally; the now-unused `AXIS_EPSILON` import is dropped.
- New `syncStoreUpdates.test.ts` covering: no-op when all updates are within epsilon (and unchanged), commit when min or max exceeds epsilon, commit for axes missing from the store, per-axis filtering (mix of changed/unchanged X and Y), Y-only commit, and empty-input no-op.

## Test plan

- [x] `pnpm test` — 688 tests pass (61 files), including 7 new reconciliation cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that pan/zoom still produce a single batched store commit when interaction ends and skip it when nothing moved (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_