### PR TITLE
Extract updateOverlayAxes into its own module (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -43,107 +43,13 @@ import { Crosshair } from "./Crosshair";
 import type { XAxisLayout, XAxisMetrics, YAxisLayout } from "./chartTypes";
 import { EmptyState } from "./EmptyState";
 import { syncStoreUpdates } from "./syncStoreUpdates";
+import {
+	type OverlayXEntry,
+	type OverlayYEntry,
+	updateOverlayAxes,
+} from "./overlayAxes";
 import { WebGLRenderer, type WebGLRendererHandle } from "./WebGLRenderer";
 import { computeXAxesMetrics } from "./xAxisMetrics";
-
-type OverlayXEntry = {
-	id: string;
-	min: number;
-	max: number;
-	showGrid: boolean;
-	ticks: number[];
-	categoryLabels?: string[];
-};
-type OverlayYEntry = {
-	id: string;
-	min: number;
-	max: number;
-	showGrid: boolean;
-	ticks: number[];
-	position: "left" | "right";
-	categoryLabels?: string[];
-};
-
-function updateOverlayAxes(
-	scratch: {
-		xAxes: OverlayXEntry[];
-		yAxes: OverlayYEntry[];
-		estVertexCount?: number;
-	},
-	xLayout: XAxisLayout[],
-	yLayout: YAxisLayout[],
-) {
-	let est = 12 + 12 + 32;
-
-	const sx = scratch.xAxes;
-	sx.length = xLayout.length;
-	for (let i = 0; i < xLayout.length; i++) {
-		const a = xLayout[i];
-		let entry = sx[i];
-		if (!entry) {
-			entry = {
-				id: a.id,
-				min: a.min,
-				max: a.max,
-				showGrid: a.showGrid,
-				ticks: [],
-				categoryLabels: a.categoryLabels,
-			};
-			sx[i] = entry;
-		} else {
-			entry.id = a.id;
-			entry.min = a.min;
-			entry.max = a.max;
-			entry.showGrid = a.showGrid;
-			entry.categoryLabels = a.categoryLabels;
-		}
-		const src = a.ticks.result;
-		const dst = entry.ticks;
-		dst.length = src.length;
-		for (let j = 0; j < src.length; j++) {
-			const t = src[j];
-			dst[j] = typeof t === "number" ? t : t.timestamp;
-		}
-
-		est += (src.length + 1) * 4 + 6;
-		if (i === 0 && a.showGrid) {
-			est += src.length * 4;
-		}
-	}
-	const sy = scratch.yAxes;
-	sy.length = yLayout.length;
-	for (let i = 0; i < yLayout.length; i++) {
-		const a = yLayout[i];
-		let entry = sy[i];
-		if (!entry) {
-			entry = {
-				id: a.id,
-				min: a.min,
-				max: a.max,
-				showGrid: a.showGrid,
-				ticks: a.ticks,
-				position: a.position,
-				categoryLabels: a.categoryLabels,
-			};
-			sy[i] = entry;
-		} else {
-			entry.id = a.id;
-			entry.min = a.min;
-			entry.max = a.max;
-			entry.showGrid = a.showGrid;
-			entry.ticks = a.ticks;
-			entry.position = a.position;
-			entry.categoryLabels = a.categoryLabels;
-		}
-
-		est += (a.ticks.length + 1) * 4 + 6;
-		if (a.showGrid) {
-			est += a.ticks.length * 4;
-		}
-	}
-
-	scratch.estVertexCount = est;
-}
 
 type DatasetsByAxisId = Record<string, Dataset[]>;
 

--- a/src/components/Plot/__tests__/overlayAxes.test.ts
+++ b/src/components/Plot/__tests__/overlayAxes.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import type { XAxisLayout, YAxisLayout } from "../chartTypes";
+import {
+	type OverlayXEntry,
+	type OverlayYEntry,
+	updateOverlayAxes,
+} from "../overlayAxes";
+
+const BASE_VERTEX_COUNT = 12 + 12 + 32;
+
+function makeScratch(): {
+	xAxes: OverlayXEntry[];
+	yAxes: OverlayYEntry[];
+	estVertexCount?: number;
+} {
+	return { xAxes: [], yAxes: [] };
+}
+
+function makeNumericX(
+	id: string,
+	ticks: number[],
+	showGrid = false,
+): XAxisLayout {
+	return {
+		id,
+		min: 0,
+		max: 100,
+		showGrid,
+		title: id,
+		color: "#000",
+		ticks: { result: ticks, step: 10, precision: 0, isXDate: false },
+	};
+}
+
+function makeDateX(
+	id: string,
+	timestamps: number[],
+	showGrid = false,
+): XAxisLayout {
+	return {
+		id,
+		min: 0,
+		max: 100,
+		showGrid,
+		title: id,
+		color: "#000",
+		ticks: {
+			result: timestamps.map((t) => ({ timestamp: t, label: String(t) })),
+			isXDate: true,
+			secondaryLabels: [],
+		},
+	};
+}
+
+function makeY(
+	id: string,
+	ticks: number[],
+	position: "left" | "right" = "left",
+	showGrid = false,
+): YAxisLayout {
+	return {
+		id,
+		name: id,
+		min: 0,
+		max: 100,
+		color: "#000",
+		position,
+		showGrid,
+		ticks,
+		precision: 0,
+		actualStep: 10,
+	};
+}
+
+describe("updateOverlayAxes", () => {
+	it("yields empty arrays and the baseline vertex count for empty input", () => {
+		const scratch = makeScratch();
+		updateOverlayAxes(scratch, [], []);
+		expect(scratch.xAxes).toEqual([]);
+		expect(scratch.yAxes).toEqual([]);
+		expect(scratch.estVertexCount).toBe(BASE_VERTEX_COUNT);
+	});
+
+	it("copies numeric x ticks verbatim and accounts for them in the vertex estimate", () => {
+		const scratch = makeScratch();
+		const xLayout = [makeNumericX("X", [0, 10, 20])];
+		updateOverlayAxes(scratch, xLayout, []);
+
+		expect(scratch.xAxes).toHaveLength(1);
+		expect(scratch.xAxes[0]).toMatchObject({
+			id: "X",
+			min: 0,
+			max: 100,
+			showGrid: false,
+			ticks: [0, 10, 20],
+		});
+		// (3 + 1) * 4 + 6 = 22; no grid contribution
+		expect(scratch.estVertexCount).toBe(BASE_VERTEX_COUNT + 22);
+	});
+
+	it("flattens date ticks to their timestamps", () => {
+		const scratch = makeScratch();
+		updateOverlayAxes(scratch, [makeDateX("X", [1700, 1800, 1900])], []);
+		expect(scratch.xAxes[0].ticks).toEqual([1700, 1800, 1900]);
+	});
+
+	it("adds the grid contribution only for the first x-axis", () => {
+		const scratch = makeScratch();
+		const a = makeNumericX("A", [0, 1, 2], true); // grid contributes
+		const b = makeNumericX("B", [0, 1, 2], true); // grid ignored (i !== 0)
+		updateOverlayAxes(scratch, [a, b], []);
+		// per axis: (3+1)*4+6 = 22; grid on first only: 3*4 = 12
+		expect(scratch.estVertexCount).toBe(BASE_VERTEX_COUNT + 22 + 22 + 12);
+	});
+
+	it("copies y-axis entries including position and aliases the ticks array", () => {
+		const scratch = makeScratch();
+		const yTicks = [0, 50, 100];
+		const yLayout = [makeY("Y", yTicks, "right")];
+		updateOverlayAxes(scratch, [], yLayout);
+
+		expect(scratch.yAxes).toHaveLength(1);
+		expect(scratch.yAxes[0]).toMatchObject({
+			id: "Y",
+			min: 0,
+			max: 100,
+			showGrid: false,
+			position: "right",
+			ticks: [0, 50, 100],
+		});
+		// in-place reuse: y entry's ticks should reference the source array
+		expect(scratch.yAxes[0].ticks).toBe(yTicks);
+	});
+
+	it("adds y-axis grid contribution for every gridded axis", () => {
+		const scratch = makeScratch();
+		const yLayout = [
+			makeY("Y1", [0, 50, 100], "left", true), // grid on
+			makeY("Y2", [0, 25, 50, 75, 100], "right", false), // grid off
+		];
+		updateOverlayAxes(scratch, [], yLayout);
+		// Y1: (3+1)*4+6 + 3*4 = 22 + 12 = 34
+		// Y2: (5+1)*4+6 + 0    = 30
+		expect(scratch.estVertexCount).toBe(BASE_VERTEX_COUNT + 34 + 30);
+	});
+
+	it("reuses existing scratch entries in place across calls", () => {
+		const scratch = makeScratch();
+		updateOverlayAxes(scratch, [makeNumericX("X", [0, 10])], [makeY("Y", [0, 50])]);
+		const xEntryFirstCall = scratch.xAxes[0];
+		const yEntryFirstCall = scratch.yAxes[0];
+
+		updateOverlayAxes(
+			scratch,
+			[makeNumericX("X", [5, 15, 25])], // new ticks
+			[makeY("Y", [10, 60], "right")], // new ticks + position
+		);
+
+		// Same object identities — entries mutated, not replaced.
+		expect(scratch.xAxes[0]).toBe(xEntryFirstCall);
+		expect(scratch.yAxes[0]).toBe(yEntryFirstCall);
+		// Fields updated in place.
+		expect(scratch.xAxes[0].ticks).toEqual([5, 15, 25]);
+		expect(scratch.yAxes[0].position).toBe("right");
+	});
+
+	it("shrinks scratch arrays when fewer axes are passed", () => {
+		const scratch = makeScratch();
+		updateOverlayAxes(
+			scratch,
+			[makeNumericX("A", [0]), makeNumericX("B", [0])],
+			[makeY("Y1", [0]), makeY("Y2", [0])],
+		);
+		expect(scratch.xAxes).toHaveLength(2);
+		expect(scratch.yAxes).toHaveLength(2);
+
+		updateOverlayAxes(scratch, [makeNumericX("A", [0])], []);
+		expect(scratch.xAxes).toHaveLength(1);
+		expect(scratch.yAxes).toHaveLength(0);
+	});
+});

--- a/src/components/Plot/overlayAxes.ts
+++ b/src/components/Plot/overlayAxes.ts
@@ -1,0 +1,113 @@
+// Copies axis-layout snapshots into a long-lived overlay-scratch buffer for
+// the WebGL renderer, in place — entries are reused across frames to avoid
+// allocations during pan/zoom — and updates an estimated vertex count used to
+// size the renderer's GPU buffers. Extracted from ChartContainer so the
+// transformation can be exercised independently.
+
+import type { XAxisLayout, YAxisLayout } from "./chartTypes";
+
+export interface OverlayXEntry {
+	id: string;
+	min: number;
+	max: number;
+	showGrid: boolean;
+	ticks: number[];
+	categoryLabels?: string[];
+}
+
+export interface OverlayYEntry {
+	id: string;
+	min: number;
+	max: number;
+	showGrid: boolean;
+	ticks: number[];
+	position: "left" | "right";
+	categoryLabels?: string[];
+}
+
+interface OverlayScratch {
+	xAxes: OverlayXEntry[];
+	yAxes: OverlayYEntry[];
+	estVertexCount?: number;
+}
+
+// Baseline vertex budget covering chart-frame primitives that are always drawn
+// (plot border, zero-axis line, padding triangles).
+const BASE_VERTEX_COUNT = 12 + 12 + 32;
+
+export function updateOverlayAxes(
+	scratch: OverlayScratch,
+	xLayout: XAxisLayout[],
+	yLayout: YAxisLayout[],
+): void {
+	let est = BASE_VERTEX_COUNT;
+
+	const sx = scratch.xAxes;
+	sx.length = xLayout.length;
+	for (let i = 0; i < xLayout.length; i++) {
+		const a = xLayout[i];
+		let entry = sx[i];
+		if (!entry) {
+			entry = {
+				id: a.id,
+				min: a.min,
+				max: a.max,
+				showGrid: a.showGrid,
+				ticks: [],
+				categoryLabels: a.categoryLabels,
+			};
+			sx[i] = entry;
+		} else {
+			entry.id = a.id;
+			entry.min = a.min;
+			entry.max = a.max;
+			entry.showGrid = a.showGrid;
+			entry.categoryLabels = a.categoryLabels;
+		}
+		const src = a.ticks.result;
+		const dst = entry.ticks;
+		dst.length = src.length;
+		for (let j = 0; j < src.length; j++) {
+			const t = src[j];
+			dst[j] = typeof t === "number" ? t : t.timestamp;
+		}
+
+		est += (src.length + 1) * 4 + 6;
+		if (i === 0 && a.showGrid) {
+			est += src.length * 4;
+		}
+	}
+	const sy = scratch.yAxes;
+	sy.length = yLayout.length;
+	for (let i = 0; i < yLayout.length; i++) {
+		const a = yLayout[i];
+		let entry = sy[i];
+		if (!entry) {
+			entry = {
+				id: a.id,
+				min: a.min,
+				max: a.max,
+				showGrid: a.showGrid,
+				ticks: a.ticks,
+				position: a.position,
+				categoryLabels: a.categoryLabels,
+			};
+			sy[i] = entry;
+		} else {
+			entry.id = a.id;
+			entry.min = a.min;
+			entry.max = a.max;
+			entry.showGrid = a.showGrid;
+			entry.ticks = a.ticks;
+			entry.position = a.position;
+			entry.categoryLabels = a.categoryLabels;
+		}
+
+		est += (a.ticks.length + 1) * 4 + 6;
+		if (a.showGrid) {
+			est += a.ticks.length * 4;
+		}
+	}
+
+	scratch.estVertexCount = est;
+}


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing inside `ChartContainer` (after gutter offsets/sums #538, gutter sizing #539, x-axis row metrics #540, syncStoreUpdates #541). Same pattern: extract a module-level helper + tests, no behavior change.

- New `src/components/Plot/overlayAxes.ts` containing the `OverlayXEntry` / `OverlayYEntry` types and the `updateOverlayAxes` helper that copies x/y layout snapshots into the long-lived overlay scratch buffer (entries reused in place to avoid per-frame allocations) and updates an estimated WebGL vertex count.
- Baseline 56-vertex constant pulled out as the named `BASE_VERTEX_COUNT`.
- `ChartContainer` imports the helper and the types instead of defining them locally; behavior, the scratch object's identity-preservation contract, and the est-vertex math are all unchanged.
- New `overlayAxes.test.ts` (8 cases) covering: empty input baseline, numeric tick copy + vertex estimate, date-tick flattening to timestamps, first-axis-only x-grid contribution, y entries with position + ticks aliasing, per-axis y-grid contributions, in-place scratch reuse across calls, and array shrinking.

## Test plan

- [x] `pnpm test` — 696 tests pass (62 files), including 8 new overlay-axes cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that the WebGL overlay (grid, tick lines, zero line) keeps rendering identically during pan/zoom and stays smooth without extra allocations (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_