### PR TITLE
Extract cached axis layout computations from ChartContainer (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -39,6 +39,12 @@ import {
 } from "./axisGutters";
 import { buildXAxisLayout } from "./buildXAxisLayout";
 import { ChartLegend } from "./ChartLegend";
+import {
+	type AxesLayoutCache,
+	computeXAxesLayoutCached,
+	computeYAxesLayoutCached,
+	createAxesLayoutCache,
+} from "./computeAxesLayout";
 import { Crosshair } from "./Crosshair";
 import type { XAxisLayout, XAxisMetrics, YAxisLayout } from "./chartTypes";
 import { EmptyState } from "./EmptyState";
@@ -389,49 +395,21 @@ export default function ChartContainer() {
 		[],
 	);
 
-	const xLayoutCacheRef = useRef<
-		Map<string, { key: string; layout: XAxisLayout }>
-	>(new Map());
-	const xLayoutCacheDepsRef = useRef<string>("");
+	const xLayoutCacheRef = useRef<AxesLayoutCache<XAxisLayout>>(
+		createAxesLayoutCache(),
+	);
 	const computeXAxesLayout = useCallback(
-		(liveXAxes: XAxisConfig[]): XAxisLayout[] => {
-			const dsByX: DatasetsByAxisId = {};
-			datasets.forEach((d) => {
-				if (activeDsIdsSet.has(d.id)) {
-					const xId = d.xAxisId || DEFAULT_X_AXIS_ID;
-					if (!dsByX[xId]) dsByX[xId] = [];
-					dsByX[xId].push(d);
-				}
-			});
-
-			const depsKey = `${chartWidth}|${themeColors.labelColor}|${datasets.length}|${activeDsIdsSet.size}`;
-			if (xLayoutCacheDepsRef.current !== depsKey) {
-				xLayoutCacheRef.current.clear();
-				xLayoutCacheDepsRef.current = depsKey;
-			}
-			const cache = xLayoutCacheRef.current;
-
-			return liveXAxes
-				.filter((axis) => activeXAxesUsed.some((ax) => ax.id === axis.id))
-				.map((axis) => {
-					const cacheKey = `${axis.min}|${axis.max}|${axis.showGrid}|${axis.xMode}|${axis.name ?? ""}`;
-					const cached = cache.get(axis.id);
-					if (cached && cached.key === cacheKey) return cached.layout;
-
-					const catInfo = xAxisCategoryLabels.get(axis.id);
-					const dss = dsByX[axis.id] || [];
-					const layout = buildXAxisLayout(
-						axis,
-						chartWidth,
-						themeColors.labelColor,
-						catInfo?.labels,
-						catInfo?.ticks,
-						dss,
-					);
-					cache.set(axis.id, { key: cacheKey, layout });
-					return layout;
-				});
-		},
+		(liveXAxes: XAxisConfig[]): XAxisLayout[] =>
+			computeXAxesLayoutCached({
+				liveXAxes,
+				activeXAxesUsed,
+				datasets,
+				activeDsIdsSet,
+				chartWidth,
+				labelColor: themeColors.labelColor,
+				xAxisCategoryLabels,
+				cache: xLayoutCacheRef.current,
+			}),
 		[
 			activeDsIdsSet,
 			datasets,
@@ -442,43 +420,18 @@ export default function ChartContainer() {
 		],
 	);
 
-	const yLayoutCacheRef = useRef<
-		Map<string, { key: string; layout: YAxisLayout }>
-	>(new Map());
-	const yLayoutCacheDepsRef = useRef<string>("");
+	const yLayoutCacheRef = useRef<AxesLayoutCache<YAxisLayout>>(
+		createAxesLayoutCache(),
+	);
 	const computeYAxesLayout = useCallback(
-		(liveYAxes: YAxisConfig[]): YAxisLayout[] => {
-			const depsKey = `${chartHeight}|${usedYAxisIdsSet.size}`;
-			if (yLayoutCacheDepsRef.current !== depsKey) {
-				yLayoutCacheRef.current.clear();
-				yLayoutCacheDepsRef.current = depsKey;
-			}
-			const cache = yLayoutCacheRef.current;
-			return liveYAxes
-				.filter((a) => usedYAxisIdsSet.has(a.id))
-				.map((axis) => {
-					const cacheKey = `${axis.min}|${axis.max}|${axis.position}|${axis.showGrid}|${axis.name ?? ""}`;
-					const cached = cache.get(axis.id);
-					if (cached && cached.key === cacheKey) return cached.layout;
-					const categoryLabels = yAxisCategoryLabels.get(axis.id);
-					const { ticks, precision, actualStep } = calcYAxisTicks(
-						axis.min,
-						axis.max,
-						chartHeight,
-						categoryLabels ? 1 : undefined,
-						categoryLabels?.length,
-					);
-					const layout = {
-						...axis,
-						ticks,
-						precision,
-						actualStep,
-						categoryLabels,
-					};
-					cache.set(axis.id, { key: cacheKey, layout });
-					return layout;
-				});
-		},
+		(liveYAxes: YAxisConfig[]): YAxisLayout[] =>
+			computeYAxesLayoutCached({
+				liveYAxes,
+				usedYAxisIdsSet,
+				chartHeight,
+				yAxisCategoryLabels,
+				cache: yLayoutCacheRef.current,
+			}),
 		[usedYAxisIdsSet, chartHeight, yAxisCategoryLabels],
 	);
 

--- a/src/components/Plot/__tests__/computeAxesLayout.test.ts
+++ b/src/components/Plot/__tests__/computeAxesLayout.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import type {
+	Dataset,
+	XAxisConfig,
+	YAxisConfig,
+} from "../../../services/persistence";
+import {
+	computeXAxesLayoutCached,
+	computeYAxesLayoutCached,
+	createAxesLayoutCache,
+} from "../computeAxesLayout";
+import type { XAxisLayout, YAxisLayout } from "../chartTypes";
+
+function makeXAxis(
+	id: string,
+	overrides: Partial<XAxisConfig> = {},
+): XAxisConfig {
+	return {
+		id,
+		name: id,
+		min: 0,
+		max: 100,
+		showGrid: false,
+		xMode: "numeric",
+		...overrides,
+	};
+}
+
+function makeYAxis(
+	id: string,
+	overrides: Partial<YAxisConfig> = {},
+): YAxisConfig {
+	return {
+		id,
+		name: id,
+		min: 0,
+		max: 100,
+		position: "left",
+		color: "#000",
+		showGrid: false,
+		...overrides,
+	};
+}
+
+function makeDataset(id: string, xAxisId: string): Dataset {
+	return {
+		id,
+		name: id,
+		columns: ["x", "y"],
+		data: [],
+		rowCount: 0,
+		xAxisColumn: "x",
+		xAxisId,
+	};
+}
+
+describe("createAxesLayoutCache", () => {
+	it("returns an empty cache with no deps key", () => {
+		const cache = createAxesLayoutCache<XAxisLayout>();
+		expect(cache.entries.size).toBe(0);
+		expect(cache.depsKey).toBe("");
+	});
+});
+
+describe("computeXAxesLayoutCached", () => {
+	const baseParams = () => ({
+		liveXAxes: [makeXAxis("X")],
+		activeXAxesUsed: [makeXAxis("X")],
+		datasets: [makeDataset("ds1", "X")],
+		activeDsIdsSet: new Set(["ds1"]),
+		chartWidth: 800,
+		labelColor: "#111",
+		xAxisCategoryLabels: new Map(),
+		cache: createAxesLayoutCache<XAxisLayout>(),
+	});
+
+	it("returns an empty array when liveXAxes is empty", () => {
+		const params = baseParams();
+		params.liveXAxes = [];
+		expect(computeXAxesLayoutCached(params)).toEqual([]);
+	});
+
+	it("filters out axes not in activeXAxesUsed", () => {
+		const params = baseParams();
+		params.liveXAxes = [makeXAxis("X"), makeXAxis("Y")];
+		params.activeXAxesUsed = [makeXAxis("X")];
+		const out = computeXAxesLayoutCached(params);
+		expect(out.map((l) => l.id)).toEqual(["X"]);
+	});
+
+	it("returns the same layout object on cache hit", () => {
+		const params = baseParams();
+		const first = computeXAxesLayoutCached(params);
+		const second = computeXAxesLayoutCached(params);
+		expect(second[0]).toBe(first[0]);
+	});
+
+	it("rebuilds a layout when the axis fields change", () => {
+		const params = baseParams();
+		const first = computeXAxesLayoutCached(params);
+		params.liveXAxes = [makeXAxis("X", { min: 10 })];
+		const second = computeXAxesLayoutCached(params);
+		expect(second[0]).not.toBe(first[0]);
+		expect(second[0].min).toBe(10);
+	});
+
+	it("invalidates the entire cache when chartWidth changes", () => {
+		const params = baseParams();
+		params.liveXAxes = [makeXAxis("X"), makeXAxis("X2")];
+		params.activeXAxesUsed = [makeXAxis("X"), makeXAxis("X2")];
+		const first = computeXAxesLayoutCached(params);
+		params.chartWidth = 1000;
+		const second = computeXAxesLayoutCached(params);
+		expect(second[0]).not.toBe(first[0]);
+		expect(second[1]).not.toBe(first[1]);
+		expect(params.cache.entries.size).toBe(2);
+	});
+
+	it("invalidates the entire cache when labelColor changes", () => {
+		const params = baseParams();
+		const first = computeXAxesLayoutCached(params);
+		params.labelColor = "#fff";
+		const second = computeXAxesLayoutCached(params);
+		expect(second[0]).not.toBe(first[0]);
+	});
+
+	it("invalidates the entire cache when dataset count changes", () => {
+		const params = baseParams();
+		const first = computeXAxesLayoutCached(params);
+		params.datasets = [makeDataset("ds1", "X"), makeDataset("ds2", "X")];
+		params.activeDsIdsSet = new Set(["ds1", "ds2"]);
+		const second = computeXAxesLayoutCached(params);
+		expect(second[0]).not.toBe(first[0]);
+	});
+});
+
+describe("computeYAxesLayoutCached", () => {
+	const baseParams = () => ({
+		liveYAxes: [makeYAxis("Y")],
+		usedYAxisIdsSet: new Set(["Y"]),
+		chartHeight: 600,
+		yAxisCategoryLabels: new Map<string, string[] | undefined>(),
+		cache: createAxesLayoutCache<YAxisLayout>(),
+	});
+
+	it("returns an empty array when liveYAxes is empty", () => {
+		const params = baseParams();
+		params.liveYAxes = [];
+		expect(computeYAxesLayoutCached(params)).toEqual([]);
+	});
+
+	it("filters out axes not in usedYAxisIdsSet", () => {
+		const params = baseParams();
+		params.liveYAxes = [makeYAxis("Y"), makeYAxis("Z")];
+		params.usedYAxisIdsSet = new Set(["Y"]);
+		const out = computeYAxesLayoutCached(params);
+		expect(out.map((l) => l.id)).toEqual(["Y"]);
+	});
+
+	it("returns the same layout object on cache hit", () => {
+		const params = baseParams();
+		const first = computeYAxesLayoutCached(params);
+		const second = computeYAxesLayoutCached(params);
+		expect(second[0]).toBe(first[0]);
+	});
+
+	it("rebuilds a layout when axis fields change", () => {
+		const params = baseParams();
+		const first = computeYAxesLayoutCached(params);
+		params.liveYAxes = [makeYAxis("Y", { position: "right" })];
+		const second = computeYAxesLayoutCached(params);
+		expect(second[0]).not.toBe(first[0]);
+		expect(second[0].position).toBe("right");
+	});
+
+	it("invalidates the entire cache when chartHeight changes", () => {
+		const params = baseParams();
+		const first = computeYAxesLayoutCached(params);
+		params.chartHeight = 400;
+		const second = computeYAxesLayoutCached(params);
+		expect(second[0]).not.toBe(first[0]);
+	});
+
+	it("invalidates the entire cache when the used-axis set size changes", () => {
+		const params = baseParams();
+		const first = computeYAxesLayoutCached(params);
+		params.liveYAxes = [makeYAxis("Y"), makeYAxis("Y2")];
+		params.usedYAxisIdsSet = new Set(["Y", "Y2"]);
+		const second = computeYAxesLayoutCached(params);
+		expect(second[0]).not.toBe(first[0]);
+	});
+
+	it("forwards category labels onto the layout", () => {
+		const params = baseParams();
+		params.yAxisCategoryLabels = new Map([["Y", ["A", "B", "C"]]]);
+		const [layout] = computeYAxesLayoutCached(params);
+		expect(layout.categoryLabels).toEqual(["A", "B", "C"]);
+	});
+});

--- a/src/components/Plot/computeAxesLayout.ts
+++ b/src/components/Plot/computeAxesLayout.ts
@@ -1,0 +1,138 @@
+// Memoized axis-layout computation, extracted from ChartContainer so the
+// cache behavior can be unit-tested. Each Map keys per-axis layouts by the
+// fields that affect the layout output (range, name, grid flag, mode); the
+// adjacent depsKey is a coarse invalidator wiped on chart-wide changes
+// (chart size, label color, dataset set).
+
+import type {
+	Dataset,
+	XAxisConfig,
+	YAxisConfig,
+} from "../../services/persistence";
+import {
+	DEFAULT_X_AXIS_ID,
+	calcYAxisTicks,
+} from "../../utils/axisCalculations";
+import { buildXAxisLayout } from "./buildXAxisLayout";
+import type { XAxisLayout, YAxisLayout } from "./chartTypes";
+
+interface CacheEntry<T> {
+	key: string;
+	layout: T;
+}
+
+export interface AxesLayoutCache<T> {
+	entries: Map<string, CacheEntry<T>>;
+	depsKey: string;
+}
+
+export function createAxesLayoutCache<T>(): AxesLayoutCache<T> {
+	return { entries: new Map(), depsKey: "" };
+}
+
+export interface ComputeXAxesLayoutParams {
+	liveXAxes: readonly XAxisConfig[];
+	activeXAxesUsed: readonly XAxisConfig[];
+	datasets: readonly Dataset[];
+	activeDsIdsSet: ReadonlySet<string>;
+	chartWidth: number;
+	labelColor: string;
+	xAxisCategoryLabels: ReadonlyMap<
+		string,
+		{ labels: string[]; ticks?: number[] } | undefined
+	>;
+	cache: AxesLayoutCache<XAxisLayout>;
+}
+
+export function computeXAxesLayoutCached({
+	liveXAxes,
+	activeXAxesUsed,
+	datasets,
+	activeDsIdsSet,
+	chartWidth,
+	labelColor,
+	xAxisCategoryLabels,
+	cache,
+}: ComputeXAxesLayoutParams): XAxisLayout[] {
+	const dsByX: Record<string, Dataset[]> = {};
+	for (const d of datasets) {
+		if (activeDsIdsSet.has(d.id)) {
+			const xId = d.xAxisId || DEFAULT_X_AXIS_ID;
+			if (!dsByX[xId]) dsByX[xId] = [];
+			dsByX[xId].push(d);
+		}
+	}
+
+	const depsKey = `${chartWidth}|${labelColor}|${datasets.length}|${activeDsIdsSet.size}`;
+	if (cache.depsKey !== depsKey) {
+		cache.entries.clear();
+		cache.depsKey = depsKey;
+	}
+
+	return liveXAxes
+		.filter((axis) => activeXAxesUsed.some((ax) => ax.id === axis.id))
+		.map((axis) => {
+			const cacheKey = `${axis.min}|${axis.max}|${axis.showGrid}|${axis.xMode}|${axis.name ?? ""}`;
+			const cached = cache.entries.get(axis.id);
+			if (cached && cached.key === cacheKey) return cached.layout;
+
+			const catInfo = xAxisCategoryLabels.get(axis.id);
+			const dss = dsByX[axis.id] || [];
+			const layout = buildXAxisLayout(
+				axis,
+				chartWidth,
+				labelColor,
+				catInfo?.labels,
+				catInfo?.ticks,
+				dss,
+			);
+			cache.entries.set(axis.id, { key: cacheKey, layout });
+			return layout;
+		});
+}
+
+export interface ComputeYAxesLayoutParams {
+	liveYAxes: readonly YAxisConfig[];
+	usedYAxisIdsSet: ReadonlySet<string>;
+	chartHeight: number;
+	yAxisCategoryLabels: ReadonlyMap<string, string[] | undefined>;
+	cache: AxesLayoutCache<YAxisLayout>;
+}
+
+export function computeYAxesLayoutCached({
+	liveYAxes,
+	usedYAxisIdsSet,
+	chartHeight,
+	yAxisCategoryLabels,
+	cache,
+}: ComputeYAxesLayoutParams): YAxisLayout[] {
+	const depsKey = `${chartHeight}|${usedYAxisIdsSet.size}`;
+	if (cache.depsKey !== depsKey) {
+		cache.entries.clear();
+		cache.depsKey = depsKey;
+	}
+	return liveYAxes
+		.filter((a) => usedYAxisIdsSet.has(a.id))
+		.map((axis) => {
+			const cacheKey = `${axis.min}|${axis.max}|${axis.position}|${axis.showGrid}|${axis.name ?? ""}`;
+			const cached = cache.entries.get(axis.id);
+			if (cached && cached.key === cacheKey) return cached.layout;
+			const categoryLabels = yAxisCategoryLabels.get(axis.id);
+			const { ticks, precision, actualStep } = calcYAxisTicks(
+				axis.min,
+				axis.max,
+				chartHeight,
+				categoryLabels ? 1 : undefined,
+				categoryLabels?.length,
+			);
+			const layout = {
+				...axis,
+				ticks,
+				precision,
+				actualStep,
+				categoryLabels,
+			};
+			cache.entries.set(axis.id, { key: cacheKey, layout });
+			return layout;
+		});
+}


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing inside `ChartContainer` (after gutter offsets/sums #538, gutter sizing #539, x-axis row metrics #540, syncStoreUpdates #541, updateOverlayAxes #542). Same pattern: extract a piece + tests, no behavior change.

- New `src/components/Plot/computeAxesLayout.ts` containing the memoized layout builders that used to live inline as `useCallback`s in `ChartContainer`.
  - `AxesLayoutCache<T>` bundles each axis kind's `Map<id, {key, layout}>` and its coarse `depsKey` into a single object, replacing the two parallel `useRef`s previously held per axis kind.
  - `createAxesLayoutCache<T>()` factory.
  - `computeXAxesLayoutCached(params)` — groups datasets per x-axis, invalidates on `chartWidth | labelColor | datasets.length | activeDsIdsSet.size`, caches per axis by `min | max | showGrid | xMode | name`, calls `buildXAxisLayout` on miss.
  - `computeYAxesLayoutCached(params)` — invalidates on `chartHeight | usedYAxisIdsSet.size`, caches per axis by `min | max | position | showGrid | name`, calls `calcYAxisTicks` on miss.
- `ChartContainer`'s two `useCallback` wrappers now delegate to the new helpers; their dependency arrays are unchanged so memoization (and `syncViewport`'s deps) behave the same.
- New `computeAxesLayout.test.ts` (15 cases) covering the empty cache factory, empty/filtered inputs, cache hits (identity preservation), cache misses on axis-field changes, full-cache invalidation on each coarse dep (chartWidth, labelColor, dataset count, chartHeight, used-axis size), and Y category-label forwarding.

## Test plan

- [x] `pnpm test` — 711 tests pass (63 files), including 15 new cached-layout cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that interactive pan/zoom still reuses cached axis layouts (no extra work per frame) and that resizing or switching themes correctly rebuilds them (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_