### PR TITLE
Extract Y-axis category label resolution from ChartContainer (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -45,6 +45,7 @@ import {
 	computeYAxesLayoutCached,
 	createAxesLayoutCache,
 } from "./computeAxesLayout";
+import { computeYAxisCategoryLabels } from "./categoryLabels";
 import { Crosshair } from "./Crosshair";
 import type { XAxisLayout, XAxisMetrics, YAxisLayout } from "./chartTypes";
 import { EmptyState } from "./EmptyState";
@@ -169,47 +170,10 @@ export default function ChartContainer() {
 		return yAxes.filter((a) => usedYAxisIdsSet.has(a.id));
 	}, [yAxes, usedYAxisIdsSet]);
 
-	// Per-axis categorical labels: only when ALL series on the axis bind to a column
-	// that has categoryLabels, and they all share the same label set.
-	const yAxisCategoryLabels = useMemo(() => {
-		const dsById = new Map(datasets.map((d) => [d.id, d]));
-
-		const out = new Map<string, string[] | undefined>();
-		const seriesByAxis = new Map<string, typeof series>();
-		series.forEach((s) => {
-			const arr = seriesByAxis.get(s.yAxisId) || [];
-			arr.push(s);
-			seriesByAxis.set(s.yAxisId, arr);
-		});
-		seriesByAxis.forEach((axisSeries, axisId) => {
-			let labels: string[] | undefined;
-			let mismatch = false;
-			for (const s of axisSeries) {
-				const ds = dsById.get(s.sourceId);
-				if (!ds) {
-					mismatch = true;
-					break;
-				}
-				const colIdx = getColumnIndex(ds, s.yColumn);
-				const col = colIdx >= 0 ? ds.data[colIdx] : undefined;
-				const cl = col?.categoryLabels;
-				if (!cl) {
-					mismatch = true;
-					break;
-				}
-				if (!labels) labels = cl;
-				else if (
-					labels.length !== cl.length ||
-					labels.some((v, i) => v !== cl[i])
-				) {
-					mismatch = true;
-					break;
-				}
-			}
-			out.set(axisId, mismatch ? undefined : labels);
-		});
-		return out;
-	}, [series, datasets]);
+	const yAxisCategoryLabels = useMemo(
+		() => computeYAxisCategoryLabels(series, datasets),
+		[series, datasets],
+	);
 
 	// Per-X-axis categorical labels:
 	// - if axis.xMode === "categorical": force categorical, derive labels from

--- a/src/components/Plot/__tests__/categoryLabels.test.ts
+++ b/src/components/Plot/__tests__/categoryLabels.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type {
+	DataColumn,
+	Dataset,
+	SeriesConfig,
+} from "../../../services/persistence";
+import { computeYAxisCategoryLabels } from "../categoryLabels";
+
+function makeColumn(categoryLabels?: string[]): DataColumn {
+	return {
+		isFloat64: false,
+		refPoint: 0,
+		bounds: { min: 0, max: 0 },
+		data: new Float32Array(),
+		categoryLabels,
+	};
+}
+
+function makeDataset(
+	id: string,
+	columns: Array<{ name: string; categoryLabels?: string[] }>,
+): Dataset {
+	return {
+		id,
+		name: id,
+		columns: columns.map((c) => c.name),
+		data: columns.map((c) => makeColumn(c.categoryLabels)),
+		rowCount: 0,
+		xAxisColumn: "x",
+		xAxisId: "X",
+	};
+}
+
+function makeSeries(
+	id: string,
+	sourceId: string,
+	yColumn: string,
+	yAxisId: string,
+): SeriesConfig {
+	return {
+		id,
+		sourceId,
+		name: id,
+		yColumn,
+		yAxisId,
+		pointStyle: "none",
+		pointColor: "#000",
+		lineStyle: "solid",
+		lineColor: "#000",
+	};
+}
+
+describe("computeYAxisCategoryLabels", () => {
+	it("returns an empty map when there are no series", () => {
+		expect(computeYAxisCategoryLabels([], [])).toEqual(new Map());
+	});
+
+	it("resolves labels when the single series' column is categorical", () => {
+		const ds = makeDataset("ds1", [
+			{ name: "x" },
+			{ name: "status", categoryLabels: ["new", "in_progress", "done"] },
+		]);
+		const series = [makeSeries("s1", "ds1", "status", "Y")];
+		const result = computeYAxisCategoryLabels(series, [ds]);
+		expect(result.get("Y")).toEqual(["new", "in_progress", "done"]);
+	});
+
+	it("preserves labels when every series on an axis agrees", () => {
+		const labels = ["a", "b", "c"];
+		const ds = makeDataset("ds1", [
+			{ name: "x" },
+			{ name: "col1", categoryLabels: labels },
+			{ name: "col2", categoryLabels: labels.slice() },
+		]);
+		const series = [
+			makeSeries("s1", "ds1", "col1", "Y"),
+			makeSeries("s2", "ds1", "col2", "Y"),
+		];
+		expect(computeYAxisCategoryLabels(series, [ds]).get("Y")).toEqual(labels);
+	});
+
+	it("returns undefined when one series' column lacks categoryLabels", () => {
+		const ds = makeDataset("ds1", [
+			{ name: "x" },
+			{ name: "cat", categoryLabels: ["a", "b"] },
+			{ name: "num" },
+		]);
+		const series = [
+			makeSeries("s1", "ds1", "cat", "Y"),
+			makeSeries("s2", "ds1", "num", "Y"),
+		];
+		expect(computeYAxisCategoryLabels(series, [ds]).get("Y")).toBeUndefined();
+	});
+
+	it("returns undefined when two series' label sets disagree", () => {
+		const ds = makeDataset("ds1", [
+			{ name: "x" },
+			{ name: "c1", categoryLabels: ["a", "b"] },
+			{ name: "c2", categoryLabels: ["a", "c"] },
+		]);
+		const series = [
+			makeSeries("s1", "ds1", "c1", "Y"),
+			makeSeries("s2", "ds1", "c2", "Y"),
+		];
+		expect(computeYAxisCategoryLabels(series, [ds]).get("Y")).toBeUndefined();
+	});
+
+	it("returns undefined when the series' sourceId is missing from datasets", () => {
+		const series = [makeSeries("s1", "ghost", "col", "Y")];
+		expect(computeYAxisCategoryLabels(series, []).get("Y")).toBeUndefined();
+	});
+
+	it("returns undefined when the column name does not resolve in the dataset", () => {
+		const ds = makeDataset("ds1", [
+			{ name: "x" },
+			{ name: "real", categoryLabels: ["a", "b"] },
+		]);
+		const series = [makeSeries("s1", "ds1", "missing", "Y")];
+		expect(computeYAxisCategoryLabels(series, [ds]).get("Y")).toBeUndefined();
+	});
+
+	it("classifies axes independently", () => {
+		const ds = makeDataset("ds1", [
+			{ name: "x" },
+			{ name: "cat", categoryLabels: ["x", "y"] },
+			{ name: "num" },
+		]);
+		const series = [
+			makeSeries("s1", "ds1", "cat", "Ycat"),
+			makeSeries("s2", "ds1", "num", "Ynum"),
+		];
+		const result = computeYAxisCategoryLabels(series, [ds]);
+		expect(result.get("Ycat")).toEqual(["x", "y"]);
+		expect(result.get("Ynum")).toBeUndefined();
+	});
+});

--- a/src/components/Plot/categoryLabels.ts
+++ b/src/components/Plot/categoryLabels.ts
@@ -1,0 +1,58 @@
+// Per-axis categorical-label resolution, extracted from ChartContainer so
+// the (deterministic, store-input-only) computation can be unit-tested in
+// isolation.
+
+import type { Dataset, SeriesConfig } from "../../services/persistence";
+import { getColumnIndex } from "../../utils/columns";
+
+/**
+ * Resolve Y-axis categorical labels.
+ *
+ * Returns labels for an axis only when every series bound to it points at a
+ * column whose data carries `categoryLabels` and all those label sets are
+ * identical. Axes that mix categorical with non-categorical columns, or
+ * disagree on labels, map to `undefined`.
+ */
+export function computeYAxisCategoryLabels(
+	series: readonly SeriesConfig[],
+	datasets: readonly Dataset[],
+): Map<string, string[] | undefined> {
+	const dsById = new Map(datasets.map((d) => [d.id, d]));
+
+	const seriesByAxis = new Map<string, SeriesConfig[]>();
+	for (const s of series) {
+		const arr = seriesByAxis.get(s.yAxisId) || [];
+		arr.push(s);
+		seriesByAxis.set(s.yAxisId, arr);
+	}
+
+	const out = new Map<string, string[] | undefined>();
+	seriesByAxis.forEach((axisSeries, axisId) => {
+		let labels: string[] | undefined;
+		let mismatch = false;
+		for (const s of axisSeries) {
+			const ds = dsById.get(s.sourceId);
+			if (!ds) {
+				mismatch = true;
+				break;
+			}
+			const colIdx = getColumnIndex(ds, s.yColumn);
+			const col = colIdx >= 0 ? ds.data[colIdx] : undefined;
+			const cl = col?.categoryLabels;
+			if (!cl) {
+				mismatch = true;
+				break;
+			}
+			if (!labels) labels = cl;
+			else if (
+				labels.length !== cl.length ||
+				labels.some((v, i) => v !== cl[i])
+			) {
+				mismatch = true;
+				break;
+			}
+		}
+		out.set(axisId, mismatch ? undefined : labels);
+	});
+	return out;
+}


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing inside `ChartContainer` (after gutter offsets/sums #538, gutter sizing #539, x-axis row metrics #540, syncStoreUpdates #541, updateOverlayAxes #542, cached layouts #543). Same pattern: extract a pure piece + tests, no behavior change.

- New `src/components/Plot/categoryLabels.ts` containing `computeYAxisCategoryLabels(series, datasets)`: groups series by `yAxisId`, then for each axis returns the shared `categoryLabels` only when every series on it points at a column carrying labels and all those label sets are identical — otherwise returns `undefined` for that axis.
- `ChartContainer`'s `yAxisCategoryLabels` memo now just delegates to the helper; deps and output shape are unchanged.
- New `categoryLabels.test.ts` (8 cases) covering: empty input, single categorical series, multi-series agreement, mixed categorical/non-categorical (undefined), disagreeing label sets (undefined), missing dataset (undefined), missing column (undefined), and independent axis classification.

## Test plan

- [x] `pnpm test` — 719 tests pass (64 files), including 8 new category-label cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that Y axes with only-categorical series still show categorical tick labels and that mixing categorical with numeric on the same axis falls back to numeric ticks (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_