### PR TITLE
Extract X-axis category label resolution from ChartContainer (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -20,12 +20,10 @@ import type {
 } from "../../services/persistence";
 import { useGraphStore } from "../../store/useGraphStore";
 import { THEMES } from "../../themes";
-import { getColumnIndex } from "../../utils/columns";
 import {
 	type AxesFrame,
 	DEFAULT_X_AXIS_ID,
 	calcYAxisTicks,
-	getAxisById,
 	syncAxesWithTargets,
 } from "../../utils/axisCalculations";
 import { applyKeyboardPan, applyKeyboardZoom } from "../../utils/keyboard";
@@ -45,7 +43,10 @@ import {
 	computeYAxesLayoutCached,
 	createAxesLayoutCache,
 } from "./computeAxesLayout";
-import { computeYAxisCategoryLabels } from "./categoryLabels";
+import {
+	computeXAxisCategoryLabels,
+	computeYAxisCategoryLabels,
+} from "./categoryLabels";
 import { Crosshair } from "./Crosshair";
 import type { XAxisLayout, XAxisMetrics, YAxisLayout } from "./chartTypes";
 import { EmptyState } from "./EmptyState";
@@ -61,9 +62,6 @@ import { computeXAxesMetrics } from "./xAxisMetrics";
 type DatasetsByAxisId = Record<string, Dataset[]>;
 
 const BASE_PADDING_DESKTOP = { top: 20, right: 20, bottom: 60, left: 20 };
-
-/** Cap on x-values sampled when deriving categorical labels for a forced axis. */
-const MAX_DERIVED_CATEGORY_LABELS = 1000;
 
 export default function ChartContainer() {
 	// 1. Core Refs and State
@@ -175,75 +173,10 @@ export default function ChartContainer() {
 		[series, datasets],
 	);
 
-	// Per-X-axis categorical labels:
-	// - if axis.xMode === "categorical": force categorical, derive labels from
-	//   column.categoryLabels if available, else stringify unique integer values.
-	// - else: auto-detect (all bound datasets' xAxisColumn share categoryLabels).
-	const xAxisCategoryLabels = useMemo(() => {
-		const out = new Map<
-			string,
-			{ labels: string[]; ticks?: number[] } | undefined
-		>();
-		const dssByX = new Map<string, Dataset[]>();
-
-		datasets.forEach((d) => {
-			if (!activeDsIdsSet.has(d.id)) return;
-			const xId = d.xAxisId || DEFAULT_X_AXIS_ID;
-			const arr = dssByX.get(xId) || [];
-			arr.push(d);
-			dssByX.set(xId, arr);
-		});
-		dssByX.forEach((dss, axisId) => {
-			const cfg = getAxisById(xAxes, axisId);
-			const forced = cfg?.xMode === "categorical";
-			let labels: string[] | undefined;
-			let mismatch = false;
-			for (const d of dss) {
-				const colIdx = getColumnIndex(d, d.xAxisColumn);
-				const col = colIdx >= 0 ? d.data[colIdx] : undefined;
-				const cl = col?.categoryLabels;
-				if (!cl) {
-					mismatch = true;
-					break;
-				}
-				if (!labels) labels = cl;
-				else if (
-					labels.length !== cl.length ||
-					labels.some((v, i) => v !== cl[i])
-				) {
-					mismatch = true;
-					break;
-				}
-			}
-			if (!mismatch && labels) {
-				out.set(axisId, { labels });
-				return;
-			}
-			if (forced) {
-				// Derive labels from unique values across bound datasets.
-				const uniq = new Set<number>();
-				outer: for (const d of dss) {
-					const colIdx = getColumnIndex(d, d.xAxisColumn);
-					const col = colIdx >= 0 ? d.data[colIdx] : undefined;
-					if (!col) continue;
-					const ref = col.refPoint;
-					const arr = col.data;
-					for (let i = 0; i < arr.length; i++) {
-						uniq.add(arr[i] + ref);
-						if (uniq.size > MAX_DERIVED_CATEGORY_LABELS) break outer;
-					}
-				}
-				const sorted = Array.from(uniq).sort((a, b) => a - b);
-				out.set(axisId, {
-					labels: sorted.map((v) => String(v)),
-					ticks: sorted,
-				});
-				return;
-			}
-			out.set(axisId, undefined);
-		});
-		return out;
-	}, [activeDsIdsSet, datasets, xAxes]);
+	const xAxisCategoryLabels = useMemo(
+		() => computeXAxisCategoryLabels(activeDsIdsSet, datasets, xAxes),
+		[activeDsIdsSet, datasets, xAxes],
+	);
 
 	const activeXAxesUsed = useMemo(() => {
 		const axisToMinDsIdx = new Map<string, number>();

--- a/src/components/Plot/__tests__/categoryLabels.test.ts
+++ b/src/components/Plot/__tests__/categoryLabels.test.ts
@@ -3,32 +3,56 @@ import type {
 	DataColumn,
 	Dataset,
 	SeriesConfig,
+	XAxisConfig,
 } from "../../../services/persistence";
-import { computeYAxisCategoryLabels } from "../categoryLabels";
+import {
+	MAX_DERIVED_CATEGORY_LABELS,
+	computeXAxisCategoryLabels,
+	computeYAxisCategoryLabels,
+} from "../categoryLabels";
 
-function makeColumn(categoryLabels?: string[]): DataColumn {
+function makeColumn(
+	categoryLabels?: string[],
+	data: Float32Array = new Float32Array(),
+	refPoint = 0,
+): DataColumn {
 	return {
 		isFloat64: false,
-		refPoint: 0,
+		refPoint,
 		bounds: { min: 0, max: 0 },
-		data: new Float32Array(),
+		data,
 		categoryLabels,
 	};
 }
 
 function makeDataset(
 	id: string,
-	columns: Array<{ name: string; categoryLabels?: string[] }>,
+	columns: Array<{
+		name: string;
+		categoryLabels?: string[];
+		data?: Float32Array;
+		refPoint?: number;
+	}>,
+	xOpts: { xAxisId?: string; xAxisColumn?: string } = {},
 ): Dataset {
 	return {
 		id,
 		name: id,
 		columns: columns.map((c) => c.name),
-		data: columns.map((c) => makeColumn(c.categoryLabels)),
+		data: columns.map((c) =>
+			makeColumn(c.categoryLabels, c.data, c.refPoint),
+		),
 		rowCount: 0,
-		xAxisColumn: "x",
-		xAxisId: "X",
+		xAxisColumn: xOpts.xAxisColumn ?? "x",
+		xAxisId: xOpts.xAxisId ?? "X",
 	};
+}
+
+function makeXAxis(
+	id: string,
+	xMode: "date" | "numeric" | "categorical" = "numeric",
+): XAxisConfig {
+	return { id, name: id, min: 0, max: 100, showGrid: false, xMode };
 }
 
 function makeSeries(
@@ -132,5 +156,145 @@ describe("computeYAxisCategoryLabels", () => {
 		const result = computeYAxisCategoryLabels(series, [ds]);
 		expect(result.get("Ycat")).toEqual(["x", "y"]);
 		expect(result.get("Ynum")).toBeUndefined();
+	});
+});
+
+describe("computeXAxisCategoryLabels", () => {
+	it("returns an empty map when there are no active datasets", () => {
+		const result = computeXAxisCategoryLabels(new Set(), [], []);
+		expect(result.size).toBe(0);
+	});
+
+	it("ignores datasets that are not in the active set", () => {
+		const ds = makeDataset(
+			"inactive",
+			[{ name: "x", categoryLabels: ["a"] }],
+			{ xAxisId: "X" },
+		);
+		const result = computeXAxisCategoryLabels(
+			new Set(),
+			[ds],
+			[makeXAxis("X")],
+		);
+		expect(result.size).toBe(0);
+	});
+
+	it("auto-detects labels when the active dataset's x column is categorical", () => {
+		const ds = makeDataset(
+			"ds1",
+			[{ name: "x", categoryLabels: ["A", "B", "C"] }],
+			{ xAxisId: "X", xAxisColumn: "x" },
+		);
+		const result = computeXAxisCategoryLabels(
+			new Set(["ds1"]),
+			[ds],
+			[makeXAxis("X")],
+		);
+		expect(result.get("X")).toEqual({ labels: ["A", "B", "C"] });
+		expect(result.get("X")?.ticks).toBeUndefined();
+	});
+
+	it("auto-detects when two datasets agree on the same labels", () => {
+		const labels = ["A", "B"];
+		const ds1 = makeDataset(
+			"ds1",
+			[{ name: "x", categoryLabels: labels }],
+			{ xAxisId: "X" },
+		);
+		const ds2 = makeDataset(
+			"ds2",
+			[{ name: "x", categoryLabels: labels.slice() }],
+			{ xAxisId: "X" },
+		);
+		const result = computeXAxisCategoryLabels(
+			new Set(["ds1", "ds2"]),
+			[ds1, ds2],
+			[makeXAxis("X")],
+		);
+		expect(result.get("X")).toEqual({ labels });
+	});
+
+	it("returns undefined for a non-forced axis when datasets disagree", () => {
+		const ds1 = makeDataset(
+			"ds1",
+			[{ name: "x", categoryLabels: ["A", "B"] }],
+			{ xAxisId: "X" },
+		);
+		const ds2 = makeDataset(
+			"ds2",
+			[{ name: "x", categoryLabels: ["A", "C"] }],
+			{ xAxisId: "X" },
+		);
+		const result = computeXAxisCategoryLabels(
+			new Set(["ds1", "ds2"]),
+			[ds1, ds2],
+			[makeXAxis("X", "numeric")],
+		);
+		expect(result.get("X")).toBeUndefined();
+	});
+
+	it("returns undefined for a non-forced axis lacking categoryLabels", () => {
+		const ds = makeDataset("ds1", [{ name: "x" }], { xAxisId: "X" });
+		const result = computeXAxisCategoryLabels(
+			new Set(["ds1"]),
+			[ds],
+			[makeXAxis("X", "numeric")],
+		);
+		expect(result.get("X")).toBeUndefined();
+	});
+
+	it("derives labels for a forced-categorical axis from unique x values", () => {
+		const ds = makeDataset(
+			"ds1",
+			[
+				{
+					name: "x",
+					data: new Float32Array([2, 1, 2, 3, 1]),
+				},
+			],
+			{ xAxisId: "X" },
+		);
+		const result = computeXAxisCategoryLabels(
+			new Set(["ds1"]),
+			[ds],
+			[makeXAxis("X", "categorical")],
+		);
+		expect(result.get("X")).toEqual({
+			labels: ["1", "2", "3"],
+			ticks: [1, 2, 3],
+		});
+	});
+
+	it("derived labels respect refPoint when reconstructing absolute values", () => {
+		const ds = makeDataset(
+			"ds1",
+			[{ name: "x", data: new Float32Array([0, 1]), refPoint: 100 }],
+			{ xAxisId: "X" },
+		);
+		const result = computeXAxisCategoryLabels(
+			new Set(["ds1"]),
+			[ds],
+			[makeXAxis("X", "categorical")],
+		);
+		expect(result.get("X")).toEqual({
+			labels: ["100", "101"],
+			ticks: [100, 101],
+		});
+	});
+
+	it("caps derived labels at MAX_DERIVED_CATEGORY_LABELS", () => {
+		const big = new Float32Array(MAX_DERIVED_CATEGORY_LABELS + 500);
+		for (let i = 0; i < big.length; i++) big[i] = i;
+		const ds = makeDataset("ds1", [{ name: "x", data: big }], {
+			xAxisId: "X",
+		});
+		const result = computeXAxisCategoryLabels(
+			new Set(["ds1"]),
+			[ds],
+			[makeXAxis("X", "categorical")],
+		);
+		const info = result.get("X");
+		// Loop breaks the first time uniq.size > cap, after one extra insert.
+		expect(info?.labels.length).toBe(MAX_DERIVED_CATEGORY_LABELS + 1);
 	});
 });

--- a/src/components/Plot/categoryLabels.ts
+++ b/src/components/Plot/categoryLabels.ts
@@ -2,8 +2,24 @@
 // the (deterministic, store-input-only) computation can be unit-tested in
 // isolation.
 
-import type { Dataset, SeriesConfig } from "../../services/persistence";
+import type {
+	Dataset,
+	SeriesConfig,
+	XAxisConfig,
+} from "../../services/persistence";
+import {
+	DEFAULT_X_AXIS_ID,
+	getAxisById,
+} from "../../utils/axisCalculations";
 import { getColumnIndex } from "../../utils/columns";
+
+/** Cap on x-values sampled when deriving categorical labels for a forced axis. */
+export const MAX_DERIVED_CATEGORY_LABELS = 1000;
+
+export interface XAxisCategoryInfo {
+	labels: string[];
+	ticks?: number[];
+}
 
 /**
  * Resolve Y-axis categorical labels.
@@ -53,6 +69,87 @@ export function computeYAxisCategoryLabels(
 			}
 		}
 		out.set(axisId, mismatch ? undefined : labels);
+	});
+	return out;
+}
+
+/**
+ * Resolve X-axis categorical labels for each axis bound by an active dataset.
+ *
+ * Auto-detect: when every active dataset on an axis points at an x-column
+ * whose data carries `categoryLabels` and they all agree, those labels are
+ * returned.
+ *
+ * Forced: if auto-detect fails but `axis.xMode === "categorical"`, labels are
+ * derived from the unique integer x-values across the bound datasets
+ * (capped at MAX_DERIVED_CATEGORY_LABELS) and returned with explicit ticks
+ * at those values.
+ *
+ * Otherwise the axis maps to `undefined`.
+ */
+export function computeXAxisCategoryLabels(
+	activeDsIds: ReadonlySet<string>,
+	datasets: readonly Dataset[],
+	xAxes: XAxisConfig[],
+): Map<string, XAxisCategoryInfo | undefined> {
+	const out = new Map<string, XAxisCategoryInfo | undefined>();
+
+	const dssByX = new Map<string, Dataset[]>();
+	for (const d of datasets) {
+		if (!activeDsIds.has(d.id)) continue;
+		const xId = d.xAxisId || DEFAULT_X_AXIS_ID;
+		const arr = dssByX.get(xId) || [];
+		arr.push(d);
+		dssByX.set(xId, arr);
+	}
+
+	dssByX.forEach((dss, axisId) => {
+		const cfg = getAxisById(xAxes, axisId);
+		const forced = cfg?.xMode === "categorical";
+		let labels: string[] | undefined;
+		let mismatch = false;
+		for (const d of dss) {
+			const colIdx = getColumnIndex(d, d.xAxisColumn);
+			const col = colIdx >= 0 ? d.data[colIdx] : undefined;
+			const cl = col?.categoryLabels;
+			if (!cl) {
+				mismatch = true;
+				break;
+			}
+			if (!labels) labels = cl;
+			else if (
+				labels.length !== cl.length ||
+				labels.some((v, i) => v !== cl[i])
+			) {
+				mismatch = true;
+				break;
+			}
+		}
+		if (!mismatch && labels) {
+			out.set(axisId, { labels });
+			return;
+		}
+		if (forced) {
+			const uniq = new Set<number>();
+			outer: for (const d of dss) {
+				const colIdx = getColumnIndex(d, d.xAxisColumn);
+				const col = colIdx >= 0 ? d.data[colIdx] : undefined;
+				if (!col) continue;
+				const ref = col.refPoint;
+				const arr = col.data;
+				for (let i = 0; i < arr.length; i++) {
+					uniq.add(arr[i] + ref);
+					if (uniq.size > MAX_DERIVED_CATEGORY_LABELS) break outer;
+				}
+			}
+			const sorted = Array.from(uniq).sort((a, b) => a - b);
+			out.set(axisId, {
+				labels: sorted.map((v) => String(v)),
+				ticks: sorted,
+			});
+			return;
+		}
+		out.set(axisId, undefined);
 	});
 	return out;
 }


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing inside `ChartContainer` (after #538–#544). Same pattern: extract a pure piece + tests, no behavior change.

- Add `computeXAxisCategoryLabels(activeDsIds, datasets, xAxes)` to `src/components/Plot/categoryLabels.ts` alongside the existing Y helper. Behavior matches the original memo:
  - **Auto-detect**: returns the shared `categoryLabels` when every active dataset on the axis points at an x-column carrying labels and they all agree.
  - **Forced** (`axis.xMode === "categorical"`): derives labels from the unique numeric x-values across the bound datasets (respecting each column's `refPoint`), sorted, with explicit ticks.
  - Otherwise `undefined`.
  - The 1000-value cap is exported as the named `MAX_DERIVED_CATEGORY_LABELS`.
- The `XAxisCategoryInfo` type (`{labels, ticks?}`) is exported for reuse.
- `ChartContainer`'s `xAxisCategoryLabels` memo now just delegates to the helper; deps and output shape are unchanged. Drops the now-unused `getColumnIndex`, `getAxisById`, and local `MAX_DERIVED_CATEGORY_LABELS` from `ChartContainer`.
- New cases in `categoryLabels.test.ts` (9 cases): empty/inactive inputs, single-dataset auto-detect, multi-dataset agreement, non-forced disagreement → undefined, non-forced no-labels → undefined, forced derivation from unique values, refPoint-aware derivation, and the MAX_DERIVED_CATEGORY_LABELS cap.

## Test plan

- [x] `pnpm test` — 728 tests pass (64 files), including 9 new X-axis category cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that an x-axis whose datasets share categorical x columns shows the shared category labels, and that an axis switched to `xMode: "categorical"` over numeric data renders derived tick labels at the unique values (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_