### PR TITLE
Extract applyAxisUpdates scratch overlay from ChartContainer (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -35,6 +35,11 @@ import {
 	measureYAxisGutter,
 	sumGutterTotals,
 } from "./axisGutters";
+import {
+	type LiveAxesScratch,
+	applyAxisUpdates,
+	createLiveAxesScratch,
+} from "./buildLiveAxes";
 import { buildXAxisLayout } from "./buildXAxisLayout";
 import { ChartLegend } from "./ChartLegend";
 import {
@@ -255,13 +260,9 @@ export default function ChartContainer() {
 	const chartHeight = Math.max(0, height - padding.top - padding.bottom);
 
 	// 4. Callbacks for canvas rendering
-	const liveAxesScratchRef = useRef<{
-		liveX: XAxisConfig[];
-		liveY: YAxisConfig[];
-	}>({
-		liveX: [],
-		liveY: [],
-	});
+	const liveAxesScratchRef = useRef<LiveAxesScratch<XAxisConfig, YAxisConfig>>(
+		createLiveAxesScratch(),
+	);
 	const syncScratchRef = useRef<{
 		xUpdates: Record<string, { min: number; max: number }>;
 		yUpdates: Record<string, { min: number; max: number }>;
@@ -272,22 +273,13 @@ export default function ChartContainer() {
 			yUpdates: Record<string, { min: number; max: number }>,
 		) => {
 			const state = useGraphStore.getState();
-			const scratch = liveAxesScratchRef.current;
-			const liveX = scratch.liveX;
-			const liveY = scratch.liveY;
-			liveX.length = state.xAxes.length;
-			for (let i = 0; i < state.xAxes.length; i++) {
-				const a = state.xAxes[i];
-				const upd = xUpdates[a.id];
-				liveX[i] = upd ? { ...a, min: upd.min, max: upd.max } : a;
-			}
-			liveY.length = state.yAxes.length;
-			for (let i = 0; i < state.yAxes.length; i++) {
-				const a = state.yAxes[i];
-				const upd = yUpdates[a.id];
-				liveY[i] = upd ? { ...a, min: upd.min, max: upd.max } : a;
-			}
-			return { liveX, liveY };
+			return applyAxisUpdates(
+				liveAxesScratchRef.current,
+				state.xAxes,
+				state.yAxes,
+				xUpdates,
+				yUpdates,
+			);
 		},
 		[],
 	);

--- a/src/components/Plot/__tests__/buildLiveAxes.test.ts
+++ b/src/components/Plot/__tests__/buildLiveAxes.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyAxisUpdates,
+	createLiveAxesScratch,
+} from "../buildLiveAxes";
+
+interface Axis {
+	id: string;
+	name: string;
+	min: number;
+	max: number;
+}
+
+const xAxis = (id: string, min: number, max: number): Axis => ({
+	id,
+	name: id,
+	min,
+	max,
+});
+
+describe("createLiveAxesScratch", () => {
+	it("returns an empty scratch with mutable liveX/liveY arrays", () => {
+		const scratch = createLiveAxesScratch<Axis, Axis>();
+		expect(scratch.liveX).toEqual([]);
+		expect(scratch.liveY).toEqual([]);
+	});
+});
+
+describe("applyAxisUpdates", () => {
+	it("returns scratch arrays sized to the input axes when no updates are given", () => {
+		const scratch = createLiveAxesScratch<Axis, Axis>();
+		const xAxes = [xAxis("X1", 0, 10), xAxis("X2", 0, 20)];
+		const yAxes = [xAxis("Y1", 0, 100)];
+		const { liveX, liveY } = applyAxisUpdates(scratch, xAxes, yAxes, {}, {});
+		expect(liveX).toBe(scratch.liveX);
+		expect(liveY).toBe(scratch.liveY);
+		expect(liveX).toHaveLength(2);
+		expect(liveY).toHaveLength(1);
+	});
+
+	it("references the original axis when there is no matching update", () => {
+		const scratch = createLiveAxesScratch<Axis, Axis>();
+		const x = xAxis("X1", 0, 10);
+		const { liveX } = applyAxisUpdates(scratch, [x], [], {}, {});
+		expect(liveX[0]).toBe(x);
+	});
+
+	it("overlays min/max from the matching update onto a clone", () => {
+		const scratch = createLiveAxesScratch<Axis, Axis>();
+		const x = xAxis("X1", 0, 10);
+		const { liveX } = applyAxisUpdates(
+			scratch,
+			[x],
+			[],
+			{ X1: { min: 5, max: 15 } },
+			{},
+		);
+		expect(liveX[0]).not.toBe(x);
+		expect(liveX[0]).toMatchObject({ id: "X1", min: 5, max: 15, name: "X1" });
+		// Original untouched.
+		expect(x).toMatchObject({ min: 0, max: 10 });
+	});
+
+	it("applies updates per axis: only matching ids are overlaid", () => {
+		const scratch = createLiveAxesScratch<Axis, Axis>();
+		const a = xAxis("A", 0, 10);
+		const b = xAxis("B", 0, 20);
+		const { liveX } = applyAxisUpdates(
+			scratch,
+			[a, b],
+			[],
+			{ B: { min: 1, max: 2 } },
+			{},
+		);
+		expect(liveX[0]).toBe(a); // unchanged
+		expect(liveX[1]).not.toBe(b);
+		expect(liveX[1]).toMatchObject({ id: "B", min: 1, max: 2 });
+	});
+
+	it("applies X and Y updates independently", () => {
+		const scratch = createLiveAxesScratch<Axis, Axis>();
+		const x = xAxis("X", 0, 10);
+		const y = xAxis("Y", 0, 100);
+		const { liveX, liveY } = applyAxisUpdates(
+			scratch,
+			[x],
+			[y],
+			{ X: { min: 1, max: 9 } },
+			{ Y: { min: 50, max: 60 } },
+		);
+		expect(liveX[0]).toMatchObject({ min: 1, max: 9 });
+		expect(liveY[0]).toMatchObject({ min: 50, max: 60 });
+	});
+
+	it("reuses the scratch arrays across calls, growing and shrinking in place", () => {
+		const scratch = createLiveAxesScratch<Axis, Axis>();
+		const liveXRef = scratch.liveX;
+		const liveYRef = scratch.liveY;
+
+		applyAxisUpdates(
+			scratch,
+			[xAxis("A", 0, 1), xAxis("B", 0, 2)],
+			[xAxis("Y1", 0, 100), xAxis("Y2", 0, 200)],
+			{},
+			{},
+		);
+		expect(scratch.liveX).toBe(liveXRef);
+		expect(scratch.liveY).toBe(liveYRef);
+		expect(scratch.liveX).toHaveLength(2);
+		expect(scratch.liveY).toHaveLength(2);
+
+		applyAxisUpdates(scratch, [xAxis("A", 0, 1)], [], {}, {});
+		expect(scratch.liveX).toBe(liveXRef);
+		expect(scratch.liveY).toBe(liveYRef);
+		expect(scratch.liveX).toHaveLength(1);
+		expect(scratch.liveY).toHaveLength(0);
+	});
+
+	it("preserves extra axis fields on the clone (shallow spread)", () => {
+		const scratch = createLiveAxesScratch<Axis, Axis>();
+		const x = { ...xAxis("X", 0, 10), name: "X-label" };
+		const { liveX } = applyAxisUpdates(
+			scratch,
+			[x],
+			[],
+			{ X: { min: 5, max: 15 } },
+			{},
+		);
+		expect(liveX[0].name).toBe("X-label");
+	});
+});

--- a/src/components/Plot/buildLiveAxes.ts
+++ b/src/components/Plot/buildLiveAxes.ts
@@ -1,0 +1,49 @@
+// Overlays pending pan/zoom axis-range updates onto the persisted axis
+// configs to produce a "live" snapshot. Reuses the caller-owned scratch
+// arrays so the frequent (per rAF) snapshot doesn't churn the heap.
+// Extracted from ChartContainer so the overlay can be unit-tested without
+// the store.
+
+export type AxisRangeUpdate = Record<string, { min: number; max: number }>;
+
+export interface LiveAxesScratch<X, Y> {
+	liveX: X[];
+	liveY: Y[];
+}
+
+export function createLiveAxesScratch<X, Y>(): LiveAxesScratch<X, Y> {
+	return { liveX: [], liveY: [] };
+}
+
+/**
+ * For each axis in `xAxes`/`yAxes`, return either the axis as-is (no pending
+ * update) or a shallow clone with `min`/`max` overridden from the matching
+ * update entry. Output arrays are the scratch ones, truncated/grown to match
+ * the input lengths.
+ */
+export function applyAxisUpdates<
+	X extends { id: string; min: number; max: number },
+	Y extends { id: string; min: number; max: number },
+>(
+	scratch: LiveAxesScratch<X, Y>,
+	xAxes: readonly X[],
+	yAxes: readonly Y[],
+	xUpdates: AxisRangeUpdate,
+	yUpdates: AxisRangeUpdate,
+): { liveX: X[]; liveY: Y[] } {
+	const liveX = scratch.liveX;
+	const liveY = scratch.liveY;
+	liveX.length = xAxes.length;
+	for (let i = 0; i < xAxes.length; i++) {
+		const a = xAxes[i];
+		const upd = xUpdates[a.id];
+		liveX[i] = upd ? { ...a, min: upd.min, max: upd.max } : a;
+	}
+	liveY.length = yAxes.length;
+	for (let i = 0; i < yAxes.length; i++) {
+		const a = yAxes[i];
+		const upd = yUpdates[a.id];
+		liveY[i] = upd ? { ...a, min: upd.min, max: upd.max } : a;
+	}
+	return { liveX, liveY };
+}


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition, continuing inside `ChartContainer` (after #538–#545). Same pattern: extract a piece + tests, no behavior change.

- New `src/components/Plot/buildLiveAxes.ts` with:
  - `LiveAxesScratch<X, Y>` and `createLiveAxesScratch<X, Y>()` — the long-lived scratch arrays reused across frames so the per-rAF "live snapshot" doesn't allocate.
  - `applyAxisUpdates(scratch, xAxes, yAxes, xUpdates, yUpdates)` — for each axis, returns either the original (no pending update) or a shallow clone with `min`/`max` from the matching update. Output arrays are the scratch ones, grown/shrunk to match input lengths. Generic over the axis type so it works for both X and Y configs.
- `ChartContainer`'s `buildLiveAxes` callback now just pulls the store snapshot and delegates to the helper; the scratch ref is initialized via `createLiveAxesScratch`. Behavior, allocation profile, and per-axis "clone iff update present" semantics are unchanged.
- New `buildLiveAxes.test.ts` (8 cases): empty-scratch factory, scratch-array identity, original-axis-reference on no-update, clone with overlaid min/max, per-axis selective overlay, independent X/Y application, in-place scratch reuse with grow + shrink across calls, and shallow-spread preservation of extra fields.

## Test plan

- [x] `pnpm test` — 736 tests pass (65 files), including 8 new buildLiveAxes cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that interactive pan/zoom still produces a smooth live overlay (axis lines/labels track the gesture) without per-frame allocation spikes (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_