### PR TITLE
Unify static axis layout memos with the cached helpers (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -13,17 +13,12 @@ import { useAutoScale } from "../../hooks/useAutoScale";
 import { useDataImport } from "../../hooks/useDataImport";
 import { usePanZoom } from "../../hooks/usePanZoom";
 import { useTheme } from "../../hooks/useTheme";
-import type {
-	Dataset,
-	XAxisConfig,
-	YAxisConfig,
-} from "../../services/persistence";
+import type { XAxisConfig, YAxisConfig } from "../../services/persistence";
 import { useGraphStore } from "../../store/useGraphStore";
 import { THEMES } from "../../themes";
 import {
 	type AxesFrame,
 	DEFAULT_X_AXIS_ID,
-	calcYAxisTicks,
 	syncAxesWithTargets,
 } from "../../utils/axisCalculations";
 import { applyKeyboardPan, applyKeyboardZoom } from "../../utils/keyboard";
@@ -40,13 +35,15 @@ import {
 	applyAxisUpdates,
 	createLiveAxesScratch,
 } from "./buildLiveAxes";
-import { buildXAxisLayout } from "./buildXAxisLayout";
 import { ChartLegend } from "./ChartLegend";
 import {
 	type AxesLayoutCache,
+	buildXAxisLayoutFor,
+	buildYAxisLayoutFor,
 	computeXAxesLayoutCached,
 	computeYAxesLayoutCached,
 	createAxesLayoutCache,
+	groupActiveDatasetsByXAxis,
 } from "./computeAxesLayout";
 import {
 	computeXAxisCategoryLabels,
@@ -63,8 +60,6 @@ import {
 } from "./overlayAxes";
 import { WebGLRenderer, type WebGLRendererHandle } from "./WebGLRenderer";
 import { computeXAxesMetrics } from "./xAxisMetrics";
-
-type DatasetsByAxisId = Record<string, Dataset[]>;
 
 const BASE_PADDING_DESKTOP = { top: 20, right: 20, bottom: 60, left: 20 };
 
@@ -507,42 +502,25 @@ export default function ChartContainer() {
 	}, [isLoaded, xAxes, yAxes, series, datasets, themeColors, width, height]);
 
 	// 7. Memos for static rendering (JSX)
-	const activeYAxesLayout = useMemo((): YAxisLayout[] => {
-		return activeYAxes.map((axis) => {
-			const categoryLabels = yAxisCategoryLabels.get(axis.id);
-			const { ticks, precision, actualStep } = calcYAxisTicks(
-				axis.min,
-				axis.max,
-				chartHeight,
-				categoryLabels ? 1 : undefined,
-				categoryLabels?.length,
-			);
-			return { ...axis, ticks, precision, actualStep, categoryLabels };
-		});
-	}, [activeYAxes, chartHeight, yAxisCategoryLabels]);
+	const activeYAxesLayout = useMemo(
+		() =>
+			activeYAxes.map((axis) =>
+				buildYAxisLayoutFor(axis, chartHeight, yAxisCategoryLabels),
+			),
+		[activeYAxes, chartHeight, yAxisCategoryLabels],
+	);
 
-	const xAxesLayout = useMemo((): XAxisLayout[] => {
-		const dsByX: DatasetsByAxisId = {};
-		datasets.forEach((d) => {
-			if (activeDsIdsSet.has(d.id)) {
-				const xId = d.xAxisId || DEFAULT_X_AXIS_ID;
-				if (!dsByX[xId]) dsByX[xId] = [];
-				dsByX[xId].push(d);
-			}
-		});
-
-		return activeXAxesUsed.map((axis) => {
-			const catInfo = xAxisCategoryLabels.get(axis.id);
-			const dss = dsByX[axis.id] || [];
-			return buildXAxisLayout(
+	const xAxesLayout = useMemo(() => {
+		const dsByX = groupActiveDatasetsByXAxis(datasets, activeDsIdsSet);
+		return activeXAxesUsed.map((axis) =>
+			buildXAxisLayoutFor(
 				axis,
 				chartWidth,
 				themeColors.labelColor,
-				catInfo?.labels,
-				catInfo?.ticks,
-				dss,
-			);
-		});
+				xAxisCategoryLabels,
+				dsByX,
+			),
+		);
 	}, [
 		activeXAxesUsed,
 		chartWidth,

--- a/src/components/Plot/__tests__/computeAxesLayout.test.ts
+++ b/src/components/Plot/__tests__/computeAxesLayout.test.ts
@@ -5,9 +5,12 @@ import type {
 	YAxisConfig,
 } from "../../../services/persistence";
 import {
+	buildXAxisLayoutFor,
+	buildYAxisLayoutFor,
 	computeXAxesLayoutCached,
 	computeYAxesLayoutCached,
 	createAxesLayoutCache,
+	groupActiveDatasetsByXAxis,
 } from "../computeAxesLayout";
 import type { XAxisLayout, YAxisLayout } from "../chartTypes";
 
@@ -195,5 +198,94 @@ describe("computeYAxesLayoutCached", () => {
 		params.yAxisCategoryLabels = new Map([["Y", ["A", "B", "C"]]]);
 		const [layout] = computeYAxesLayoutCached(params);
 		expect(layout.categoryLabels).toEqual(["A", "B", "C"]);
+	});
+});
+
+describe("groupActiveDatasetsByXAxis", () => {
+	it("returns an empty object when there are no datasets", () => {
+		expect(groupActiveDatasetsByXAxis([], new Set())).toEqual({});
+	});
+
+	it("skips datasets not in the active set", () => {
+		const ds = makeDataset("ds1", "X");
+		expect(groupActiveDatasetsByXAxis([ds], new Set())).toEqual({});
+	});
+
+	it("groups active datasets by their xAxisId", () => {
+		const a1 = makeDataset("a1", "X");
+		const a2 = makeDataset("a2", "X");
+		const b = makeDataset("b", "Y");
+		const out = groupActiveDatasetsByXAxis(
+			[a1, a2, b],
+			new Set(["a1", "a2", "b"]),
+		);
+		expect(out.X).toEqual([a1, a2]);
+		expect(out.Y).toEqual([b]);
+	});
+
+	it("falls back to the default x-axis id when xAxisId is empty", () => {
+		const d = { ...makeDataset("d", "X"), xAxisId: "" };
+		const out = groupActiveDatasetsByXAxis([d], new Set(["d"]));
+		// fallback id comes from axisCalculations.DEFAULT_X_AXIS_ID
+		const ids = Object.keys(out);
+		expect(ids).toHaveLength(1);
+		expect(out[ids[0]]).toEqual([d]);
+	});
+});
+
+describe("buildXAxisLayoutFor", () => {
+	it("builds a layout for a numeric axis", () => {
+		const axis = makeXAxis("X");
+		const layout = buildXAxisLayoutFor(axis, 800, "#000", new Map(), {});
+		expect(layout.id).toBe("X");
+		expect(layout.min).toBe(0);
+		expect(layout.max).toBe(100);
+	});
+
+	it("forwards category labels from the supplied map", () => {
+		const axis = makeXAxis("X", { xMode: "categorical" });
+		const layout = buildXAxisLayoutFor(
+			axis,
+			800,
+			"#000",
+			new Map([["X", { labels: ["A", "B", "C"] }]]),
+			{},
+		);
+		expect(layout.categoryLabels).toEqual(["A", "B", "C"]);
+	});
+
+	it("uses an empty dataset list when the axis has none in dsByX", () => {
+		const axis = makeXAxis("X");
+		// No throw, just returns a layout
+		expect(() =>
+			buildXAxisLayoutFor(axis, 800, "#000", new Map(), {}),
+		).not.toThrow();
+	});
+});
+
+describe("buildYAxisLayoutFor", () => {
+	it("builds a layout with computed ticks for a numeric axis", () => {
+		const axis = makeYAxis("Y");
+		const layout = buildYAxisLayoutFor(axis, 600, new Map());
+		expect(layout.id).toBe("Y");
+		expect(layout.ticks.length).toBeGreaterThan(0);
+		expect(layout.categoryLabels).toBeUndefined();
+	});
+
+	it("forwards category labels and forces step 1 when categorical", () => {
+		const axis = makeYAxis("Y");
+		const layout = buildYAxisLayoutFor(
+			axis,
+			600,
+			new Map([["Y", ["A", "B", "C"]]]),
+		);
+		expect(layout.categoryLabels).toEqual(["A", "B", "C"]);
+	});
+
+	it("preserves the original axis fields via spread", () => {
+		const axis = makeYAxis("Y", { name: "Pressure", position: "right" });
+		const layout = buildYAxisLayoutFor(axis, 600, new Map());
+		expect(layout.name).toBe("Pressure");
+		expect(layout.position).toBe("right");
 	});
 });

--- a/src/components/Plot/computeAxesLayout.ts
+++ b/src/components/Plot/computeAxesLayout.ts
@@ -30,6 +30,63 @@ export function createAxesLayoutCache<T>(): AxesLayoutCache<T> {
 	return { entries: new Map(), depsKey: "" };
 }
 
+export type DatasetsByXAxis = Record<string, Dataset[]>;
+
+/** Bucket active datasets by their x-axis id (falling back to the default). */
+export function groupActiveDatasetsByXAxis(
+	datasets: readonly Dataset[],
+	activeDsIds: ReadonlySet<string>,
+): DatasetsByXAxis {
+	const out: DatasetsByXAxis = {};
+	for (const d of datasets) {
+		if (!activeDsIds.has(d.id)) continue;
+		const xId = d.xAxisId || DEFAULT_X_AXIS_ID;
+		if (!out[xId]) out[xId] = [];
+		out[xId].push(d);
+	}
+	return out;
+}
+
+/** Build the layout for a single x-axis using the pre-grouped datasets. */
+export function buildXAxisLayoutFor(
+	axis: XAxisConfig,
+	chartWidth: number,
+	labelColor: string,
+	xAxisCategoryLabels: ReadonlyMap<
+		string,
+		{ labels: string[]; ticks?: number[] } | undefined
+	>,
+	dsByX: DatasetsByXAxis,
+): XAxisLayout {
+	const catInfo = xAxisCategoryLabels.get(axis.id);
+	const dss = dsByX[axis.id] || [];
+	return buildXAxisLayout(
+		axis,
+		chartWidth,
+		labelColor,
+		catInfo?.labels,
+		catInfo?.ticks,
+		dss,
+	);
+}
+
+/** Build the layout for a single y-axis. */
+export function buildYAxisLayoutFor(
+	axis: YAxisConfig,
+	chartHeight: number,
+	yAxisCategoryLabels: ReadonlyMap<string, string[] | undefined>,
+): YAxisLayout {
+	const categoryLabels = yAxisCategoryLabels.get(axis.id);
+	const { ticks, precision, actualStep } = calcYAxisTicks(
+		axis.min,
+		axis.max,
+		chartHeight,
+		categoryLabels ? 1 : undefined,
+		categoryLabels?.length,
+	);
+	return { ...axis, ticks, precision, actualStep, categoryLabels };
+}
+
 export interface ComputeXAxesLayoutParams {
 	liveXAxes: readonly XAxisConfig[];
 	activeXAxesUsed: readonly XAxisConfig[];
@@ -54,14 +111,7 @@ export function computeXAxesLayoutCached({
 	xAxisCategoryLabels,
 	cache,
 }: ComputeXAxesLayoutParams): XAxisLayout[] {
-	const dsByX: Record<string, Dataset[]> = {};
-	for (const d of datasets) {
-		if (activeDsIdsSet.has(d.id)) {
-			const xId = d.xAxisId || DEFAULT_X_AXIS_ID;
-			if (!dsByX[xId]) dsByX[xId] = [];
-			dsByX[xId].push(d);
-		}
-	}
+	const dsByX = groupActiveDatasetsByXAxis(datasets, activeDsIdsSet);
 
 	const depsKey = `${chartWidth}|${labelColor}|${datasets.length}|${activeDsIdsSet.size}`;
 	if (cache.depsKey !== depsKey) {
@@ -76,15 +126,12 @@ export function computeXAxesLayoutCached({
 			const cached = cache.entries.get(axis.id);
 			if (cached && cached.key === cacheKey) return cached.layout;
 
-			const catInfo = xAxisCategoryLabels.get(axis.id);
-			const dss = dsByX[axis.id] || [];
-			const layout = buildXAxisLayout(
+			const layout = buildXAxisLayoutFor(
 				axis,
 				chartWidth,
 				labelColor,
-				catInfo?.labels,
-				catInfo?.ticks,
-				dss,
+				xAxisCategoryLabels,
+				dsByX,
 			);
 			cache.entries.set(axis.id, { key: cacheKey, layout });
 			return layout;
@@ -117,21 +164,11 @@ export function computeYAxesLayoutCached({
 			const cacheKey = `${axis.min}|${axis.max}|${axis.position}|${axis.showGrid}|${axis.name ?? ""}`;
 			const cached = cache.entries.get(axis.id);
 			if (cached && cached.key === cacheKey) return cached.layout;
-			const categoryLabels = yAxisCategoryLabels.get(axis.id);
-			const { ticks, precision, actualStep } = calcYAxisTicks(
-				axis.min,
-				axis.max,
+			const layout = buildYAxisLayoutFor(
+				axis,
 				chartHeight,
-				categoryLabels ? 1 : undefined,
-				categoryLabels?.length,
+				yAxisCategoryLabels,
 			);
-			const layout = {
-				...axis,
-				ticks,
-				precision,
-				actualStep,
-				categoryLabels,
-			};
 			cache.entries.set(axis.id, { key: cacheKey, layout });
 			return layout;
 		});


### PR DESCRIPTION
## Summary

Next incremental step in the #509 god-component decomposition (after #538–#546). Same pattern: extract pieces + tests, no behavior change — this step also unifies a previously-duplicated computation path.

Before this change, `ChartContainer` had two parallel implementations of the axis-layout computation:
- the **cached** `computeXAxesLayoutCached` / `computeYAxesLayoutCached` (from #543) used by interactive pan/zoom via `syncViewport`, and
- the **inline static** memos `activeYAxesLayout` / `xAxesLayout` used directly by JSX render, with the same per-axis logic copy-pasted.

This PR unifies both call sites onto a single source of truth.

- Add to `src/components/Plot/computeAxesLayout.ts`:
  - `groupActiveDatasetsByXAxis(datasets, activeDsIds)` — bucket active datasets by their x-axis id (falling back to `DEFAULT_X_AXIS_ID`).
  - `buildXAxisLayoutFor(axis, chartWidth, labelColor, xAxisCategoryLabels, dsByX)` — pure per-x-axis builder.
  - `buildYAxisLayoutFor(axis, chartHeight, yAxisCategoryLabels)` — pure per-y-axis builder (calls `calcYAxisTicks`, forces step 1 when categorical).
- `computeXAxesLayoutCached` / `computeYAxesLayoutCached` now delegate their per-axis work to these helpers. Cache invalidation/hit semantics are unchanged.
- `ChartContainer`'s `xAxesLayout` and `activeYAxesLayout` memos shrink to a `.map(...)` over the same helpers. Dep arrays are unchanged.
- Drops the now-unused `calcYAxisTicks`, `buildXAxisLayout`, and `Dataset` imports plus the local `DatasetsByAxisId` type from `ChartContainer`.
- New cases in `computeAxesLayout.test.ts` (10 new): empty/inactive grouping, axis-id bucketing, default-id fallback; numeric and categorical `buildXAxisLayoutFor`; numeric, categorical, and field-preservation `buildYAxisLayoutFor`.

## Test plan

- [x] `pnpm test` — 746 tests pass (65 files), including 10 new helper cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that axes and tick labels still render identically after the unification, especially with multiple x-axes and a mix of numeric/categorical Y axes (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_