### PR TITLE
Extract pure series data-prep helpers from WebGLRenderer (#509)

### DIFF
--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -12,11 +12,7 @@ import type {
 	YAxisConfig,
 } from "../../services/persistence";
 import { useGraphStore } from "../../store/useGraphStore";
-import {
-	findFirstGE,
-	findLastLE,
-	findSegmentStartIndex,
-} from "../../utils/binarySearch";
+import { findSegmentStartIndex } from "../../utils/binarySearch";
 import { DEFAULT_X_AXIS_ID, getAxisById } from "../../utils/axisCalculations";
 import { hexToRgba } from "../../utils/colors";
 import { getColumnIndex } from "../../utils/columns";
@@ -30,6 +26,11 @@ import {
 	type SeriesDrawBundle,
 } from "./drawSeries";
 import { GLStateCache, type WebGLLocations } from "./GLStateCache";
+import {
+	computeDataSlice,
+	getOrComputeMonotonicity,
+	getOrComputeSegments,
+} from "./seriesPrep";
 
 const VERTEX_SHADER_SOURCE = `
       // === VERTEX SHADER ===
@@ -204,80 +205,6 @@ export interface WebGLRendererHandle {
 /**
  * WebGLRenderer Component (v0.6.0 - Highly Optimized Draw Loop)
  */
-
-function getOrComputeMonotonicity(
-	xData: Float32Array,
-	monoCache: WeakMap<Float32Array, boolean>,
-): boolean {
-	let isMonotonic = monoCache.get(xData);
-	if (isMonotonic === undefined) {
-		isMonotonic = true;
-		for (let i = 1; i < xData.length; i++) {
-			if (xData[i] < xData[i - 1]) {
-				isMonotonic = false;
-				break;
-			}
-		}
-		monoCache.set(xData, isMonotonic);
-	}
-	return isMonotonic;
-}
-
-function getOrComputeSegments(
-	xData: Float32Array,
-	yData: Float32Array,
-	segmentCache: WeakMap<Float32Array, { start: number; end: number }[]>,
-): { start: number; end: number }[] {
-	let cachedSegments = segmentCache.get(yData);
-	if (!cachedSegments) {
-		cachedSegments = [];
-		let segStart = -1;
-		const len = yData.length;
-		for (let i = 0; i < len; i++) {
-			if (Number.isNaN(yData[i])) {
-				if (segStart !== -1) {
-					cachedSegments.push({ start: segStart, end: i - 1 });
-					segStart = -1;
-				}
-			} else if (segStart === -1) {
-				segStart = i;
-			} else if (xData[i] < xData[i - 1]) {
-				cachedSegments.push({ start: segStart, end: i - 1 });
-				segStart = i;
-			}
-		}
-		if (segStart !== -1) {
-			cachedSegments.push({ start: segStart, end: len - 1 });
-		}
-		segmentCache.set(yData, cachedSegments);
-	}
-	return cachedSegments;
-}
-
-function computeDataSlice(
-	xData: Float32Array,
-	xAxisMin: number,
-	xAxisMax: number,
-	xRef: number,
-	isMonotonic: boolean,
-): { sliceStart: number; sliceEnd: number } {
-	const xDataLen = xData.length;
-	let rawStart = 0;
-	let rawEnd = xDataLen - 1;
-	if (isMonotonic) {
-		rawStart = findLastLE(xData, xAxisMin, xRef, 0);
-		rawEnd = findFirstGE(xData, xAxisMax, xRef, xDataLen - 1);
-	}
-
-	const sliceStart = isMonotonic
-		? Math.max(0, rawStart > 0 ? rawStart - 1 : 0)
-		: 0;
-	const sliceEnd = isMonotonic
-		? Math.min(xDataLen - 1, rawEnd < xDataLen - 1 ? rawEnd + 1 : rawEnd)
-		: xDataLen - 1;
-
-	return { sliceStart, sliceEnd };
-}
 
 function getOrInitBuffer(
 	gl: WebGLRenderingContext,

--- a/src/components/Plot/__tests__/seriesPrep.test.ts
+++ b/src/components/Plot/__tests__/seriesPrep.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	computeDataSlice,
+	getOrComputeMonotonicity,
+	getOrComputeSegments,
+} from "../seriesPrep";
+
+describe("getOrComputeMonotonicity", () => {
+	it("returns true for a monotonically non-decreasing array", () => {
+		const arr = new Float32Array([1, 2, 3, 3, 5]);
+		expect(getOrComputeMonotonicity(arr, new WeakMap())).toBe(true);
+	});
+
+	it("returns false when a value drops below its predecessor", () => {
+		const arr = new Float32Array([1, 2, 1, 3]);
+		expect(getOrComputeMonotonicity(arr, new WeakMap())).toBe(false);
+	});
+
+	it("treats single-element and empty arrays as monotonic", () => {
+		expect(
+			getOrComputeMonotonicity(new Float32Array([42]), new WeakMap()),
+		).toBe(true);
+		expect(getOrComputeMonotonicity(new Float32Array(), new WeakMap())).toBe(
+			true,
+		);
+	});
+
+	it("memoizes the result by Float32Array identity", () => {
+		const arr = new Float32Array([1, 2, 3]);
+		const cache = new WeakMap<Float32Array, boolean>();
+		getOrComputeMonotonicity(arr, cache);
+		const spy = vi.spyOn(cache, "set");
+		// Same array -> cache hit, no set
+		getOrComputeMonotonicity(arr, cache);
+		expect(spy).not.toHaveBeenCalled();
+	});
+});
+
+describe("getOrComputeSegments", () => {
+	it("yields one segment covering the whole array when y has no NaNs", () => {
+		const xData = new Float32Array([0, 1, 2, 3]);
+		const yData = new Float32Array([10, 20, 30, 40]);
+		expect(getOrComputeSegments(xData, yData, new WeakMap())).toEqual([
+			{ start: 0, end: 3 },
+		]);
+	});
+
+	it("splits on NaN gaps in y", () => {
+		const xData = new Float32Array([0, 1, 2, 3, 4]);
+		const yData = new Float32Array([1, NaN, 3, NaN, 5]);
+		expect(getOrComputeSegments(xData, yData, new WeakMap())).toEqual([
+			{ start: 0, end: 0 },
+			{ start: 2, end: 2 },
+			{ start: 4, end: 4 },
+		]);
+	});
+
+	it("splits on a backward x jump (wrap)", () => {
+		const xData = new Float32Array([0, 1, 2, 0, 1]);
+		const yData = new Float32Array([1, 2, 3, 4, 5]);
+		expect(getOrComputeSegments(xData, yData, new WeakMap())).toEqual([
+			{ start: 0, end: 2 },
+			{ start: 3, end: 4 },
+		]);
+	});
+
+	it("closes the trailing segment at the array end", () => {
+		const xData = new Float32Array([0, 1, 2]);
+		const yData = new Float32Array([NaN, 2, 3]);
+		expect(getOrComputeSegments(xData, yData, new WeakMap())).toEqual([
+			{ start: 1, end: 2 },
+		]);
+	});
+
+	it("memoizes by yData identity, not xData", () => {
+		const xData = new Float32Array([0, 1, 2]);
+		const yData = new Float32Array([1, 2, 3]);
+		const cache = new WeakMap<Float32Array, { start: number; end: number }[]>();
+		const first = getOrComputeSegments(xData, yData, cache);
+		const second = getOrComputeSegments(xData, yData, cache);
+		expect(second).toBe(first);
+	});
+});
+
+describe("computeDataSlice", () => {
+	it("returns the full array for non-monotonic data", () => {
+		const xData = new Float32Array([0, 5, 2, 10]);
+		const r = computeDataSlice(xData, 0, 10, 0, false);
+		expect(r).toEqual({ sliceStart: 0, sliceEnd: 3 });
+	});
+
+	it("returns a slice covering the visible window plus one sample on each side", () => {
+		const xData = new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+		const r = computeDataSlice(xData, 3.5, 6.5, 0, true);
+		// findLastLE(3.5) -> idx 3 (value 3), -1 padding -> 2
+		// findFirstGE(6.5) -> idx 7 (value 7), +1 padding -> 8
+		expect(r).toEqual({ sliceStart: 2, sliceEnd: 8 });
+	});
+
+	it("clamps the slice to array bounds", () => {
+		const xData = new Float32Array([10, 20, 30]);
+		// window covers everything
+		expect(computeDataSlice(xData, 0, 100, 0, true)).toEqual({
+			sliceStart: 0,
+			sliceEnd: 2,
+		});
+	});
+
+	it("respects xRef offsets when matching the window", () => {
+		// stored values are deltas; absolute = stored + ref
+		const xData = new Float32Array([0, 1, 2, 3]);
+		const ref = 1000;
+		// window in absolute coords
+		const r = computeDataSlice(xData, 1001, 1002, ref, true);
+		// absolute values are [1000, 1001, 1002, 1003]
+		// findLastLE(1001) -> idx 1, -1 padding -> 0
+		// findFirstGE(1002) -> idx 2, +1 padding -> 3
+		expect(r).toEqual({ sliceStart: 0, sliceEnd: 3 });
+	});
+});

--- a/src/components/Plot/seriesPrep.ts
+++ b/src/components/Plot/seriesPrep.ts
@@ -1,0 +1,95 @@
+// Data-shape analysis helpers used to prepare a series for WebGL drawing.
+// All three are pure (with optional WeakMap caches for repeat lookups by
+// Float32Array identity) and have no GL/state dependencies, so they can be
+// unit-tested in isolation.
+
+import { findFirstGE, findLastLE } from "../../utils/binarySearch";
+
+/**
+ * Returns true when `xData` is monotonically non-decreasing. Each call shares
+ * the result across the supplied cache, keyed by Float32Array identity.
+ */
+export function getOrComputeMonotonicity(
+	xData: Float32Array,
+	monoCache: WeakMap<Float32Array, boolean>,
+): boolean {
+	let isMonotonic = monoCache.get(xData);
+	if (isMonotonic === undefined) {
+		isMonotonic = true;
+		for (let i = 1; i < xData.length; i++) {
+			if (xData[i] < xData[i - 1]) {
+				isMonotonic = false;
+				break;
+			}
+		}
+		monoCache.set(xData, isMonotonic);
+	}
+	return isMonotonic;
+}
+
+/**
+ * Split a series into contiguous segments. A segment ends whenever the y
+ * value is NaN (a gap) or x jumps backwards (an unsorted wrap). Cached on the
+ * y array identity since the renderer keys segments by y.
+ */
+export function getOrComputeSegments(
+	xData: Float32Array,
+	yData: Float32Array,
+	segmentCache: WeakMap<Float32Array, { start: number; end: number }[]>,
+): { start: number; end: number }[] {
+	let cachedSegments = segmentCache.get(yData);
+	if (!cachedSegments) {
+		cachedSegments = [];
+		let segStart = -1;
+		const len = yData.length;
+		for (let i = 0; i < len; i++) {
+			if (Number.isNaN(yData[i])) {
+				if (segStart !== -1) {
+					cachedSegments.push({ start: segStart, end: i - 1 });
+					segStart = -1;
+				}
+			} else if (segStart === -1) {
+				segStart = i;
+			} else if (xData[i] < xData[i - 1]) {
+				cachedSegments.push({ start: segStart, end: i - 1 });
+				segStart = i;
+			}
+		}
+		if (segStart !== -1) {
+			cachedSegments.push({ start: segStart, end: len - 1 });
+		}
+		segmentCache.set(yData, cachedSegments);
+	}
+	return cachedSegments;
+}
+
+/**
+ * Index range of `xData` that covers the visible x window `[xAxisMin,
+ * xAxisMax]`, with one extra sample on each side so the renderer can draw
+ * the partial segment that enters/leaves the viewport. For non-monotonic
+ * data we conservatively return the whole array.
+ */
+export function computeDataSlice(
+	xData: Float32Array,
+	xAxisMin: number,
+	xAxisMax: number,
+	xRef: number,
+	isMonotonic: boolean,
+): { sliceStart: number; sliceEnd: number } {
+	const xDataLen = xData.length;
+	let rawStart = 0;
+	let rawEnd = xDataLen - 1;
+	if (isMonotonic) {
+		rawStart = findLastLE(xData, xAxisMin, xRef, 0);
+		rawEnd = findFirstGE(xData, xAxisMax, xRef, xDataLen - 1);
+	}
+
+	const sliceStart = isMonotonic
+		? Math.max(0, rawStart > 0 ? rawStart - 1 : 0)
+		: 0;
+	const sliceEnd = isMonotonic
+		? Math.min(xDataLen - 1, rawEnd < xDataLen - 1 ? rawEnd + 1 : rawEnd)
+		: xDataLen - 1;
+
+	return { sliceStart, sliceEnd };
+}


### PR DESCRIPTION
## Summary

First incremental step into `WebGLRenderer` (~1140 lines, untouched until now) as part of the #509 god-component decomposition. Same pattern: extract pure pieces + tests, no behavior change — and explicitly stay clear of the GL render path.

- New `src/components/Plot/seriesPrep.ts` with the three data-shape helpers that prepare a series for the WebGL draw step. All are pure functions with no GL or React/state dependencies:
  - `getOrComputeMonotonicity(xData, monoCache)` — whether `xData` is non-decreasing, cached by Float32Array identity.
  - `getOrComputeSegments(xData, yData, segmentCache)` — splits a series into contiguous segments separated by NaN gaps in y or backward jumps in x. Cached by yData identity.
  - `computeDataSlice(xData, xAxisMin, xAxisMax, xRef, isMonotonic)` — index range covering the visible x window (plus one sample of padding on each side), conservative for non-monotonic data.
- `WebGLRenderer` imports the helpers instead of defining them locally; drops the now-unused `findLastLE` / `findFirstGE` imports.
- New `seriesPrep.test.ts` (13 cases) covering: monotonic vs. dropped, edge sizes (empty/single), cache memoization; segments for no-NaN/NaN gaps/wraparound x/trailing close, cache keyed on yData; data slice for non-monotonic, padded slice, clamped bounds, and refOffset-shifted window.

## Test plan

- [x] `pnpm test` — 759 tests pass (66 files), including 13 new helper cases
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that line + point rendering still tracks the visible window correctly during pan/zoom, gaps and unsorted x segments still split as before, and there are no extra per-frame allocations (recommended before merge — the renderer draw loop wasn't touched but this is the first cut into it)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_