### PR TITLE
Decompose ChartContainer/WebGLRenderer: colours, vertex-count, container size (#509)

### DIFF
--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -10,6 +10,7 @@ import {
 	useState,
 } from "react";
 import { useAutoScale } from "../../hooks/useAutoScale";
+import { useContainerSize } from "../../hooks/useContainerSize";
 import { useDataImport } from "../../hooks/useDataImport";
 import { usePanZoom } from "../../hooks/usePanZoom";
 import { useTheme } from "../../hooks/useTheme";
@@ -69,8 +70,7 @@ export default function ChartContainer() {
 	const [isDragOver, setIsDragOver] = useState(false);
 	const { importFile, confirmImport, cancelImport, changeSheet, pendingFile } =
 		useDataImport();
-	const [width, setWidth] = useState(800);
-	const [height, setHeight] = useState(600);
+	const { width, height } = useContainerSize(containerRef, 800, 600);
 	const [editingXAxisId, setEditingXAxisId] = useState<string | null>(null);
 
 	const targetXAxes = useRef<Record<string, { min: number; max: number }>>({});
@@ -124,28 +124,6 @@ export default function ChartContainer() {
 	const crosshairVisible = useGraphStore((s) => s.crosshairVisible);
 	const [themeName] = useTheme();
 	const themeColors = THEMES[themeName];
-
-	// Dimension management
-	useEffect(() => {
-		if (!containerRef.current) return;
-		const observer = new ResizeObserver((entries) => {
-			if (entries.length > 0) {
-				const e = entries[entries.length - 1];
-				setWidth(e.contentRect.width);
-				setHeight(e.contentRect.height);
-			}
-		});
-		observer.observe(containerRef.current);
-		return () => observer.disconnect();
-	}, []);
-
-	useEffect(() => {
-		if (containerRef.current) {
-			const rect = containerRef.current.getBoundingClientRect();
-			setWidth(rect.width);
-			setHeight(rect.height);
-		}
-	}, []);
 
 	// 3. Layout Memos
 	const activeDsIdsSet = useMemo(() => {

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -26,6 +26,7 @@ import {
 	type SeriesDrawBundle,
 } from "./drawSeries";
 import { GLStateCache, type WebGLLocations } from "./GLStateCache";
+import { estimateOverlayVertexCount } from "./overlayAxes";
 import {
 	computeDataSlice,
 	getOrComputeMonotonicity,
@@ -240,17 +241,9 @@ function buildOverlay(
 	const bgRgba = hexToRgbaWithAlpha(overlay.plotBg, 1);
 
 	// Estimate vertex count and grow packed buffer as needed.
-	let est = overlay.estVertexCount;
-	if (est === undefined) {
-		est = 12; // bg quad (6 verts * 2 floats)
-		if (overlay.xAxes[0]?.showGrid) est += overlay.xAxes[0].ticks.length * 4;
-		for (const ax of overlay.xAxes) est += (ax.ticks.length + 1) * 4 + 6;
-		for (const ax of overlay.yAxes) {
-			if (ax.showGrid) est += ax.ticks.length * 4;
-			est += (ax.ticks.length + 1) * 4 + 6;
-		}
-		est += 12 + 32;
-	}
+	const est =
+		overlay.estVertexCount ??
+		estimateOverlayVertexCount(overlay.xAxes, overlay.yAxes);
 	if (ov.packed.length < est)
 		ov.packed = new Float32Array(Math.max(est, ov.packed.length * 2));
 	const buf = ov.packed;

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -14,7 +14,7 @@ import type {
 import { useGraphStore } from "../../store/useGraphStore";
 import { findSegmentStartIndex } from "../../utils/binarySearch";
 import { DEFAULT_X_AXIS_ID, getAxisById } from "../../utils/axisCalculations";
-import { hexToRgba } from "../../utils/colors";
+import { hexToRgba, hexToRgbaWithAlpha } from "../../utils/colors";
 import { getColumnIndex } from "../../utils/columns";
 import {
 	type DecimEntry,
@@ -234,14 +234,10 @@ function buildOverlay(
 	const cw = w - pad.left - pad.right;
 	const ch = h - pad.top - pad.bottom;
 
-	const hexRgba = (hex: string, a = 1): [number, number, number, number] => {
-		const c = hexToRgba(hex);
-		return [c[0], c[1], c[2], a];
-	};
-	const gridRgba = hexRgba(overlay.gridColor, 1);
-	const axisRgba = hexRgba(overlay.axisColor, 1);
-	const zeroRgba = hexRgba(overlay.zeroLineColor, 1);
-	const bgRgba = hexRgba(overlay.plotBg, 1);
+	const gridRgba = hexToRgbaWithAlpha(overlay.gridColor, 1);
+	const axisRgba = hexToRgbaWithAlpha(overlay.axisColor, 1);
+	const zeroRgba = hexToRgbaWithAlpha(overlay.zeroLineColor, 1);
+	const bgRgba = hexToRgbaWithAlpha(overlay.plotBg, 1);
 
 	// Estimate vertex count and grow packed buffer as needed.
 	let est = overlay.estVertexCount;

--- a/src/components/Plot/__tests__/overlayAxes.test.ts
+++ b/src/components/Plot/__tests__/overlayAxes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { XAxisLayout, YAxisLayout } from "../chartTypes";
 import {
+	estimateOverlayVertexCount,
 	type OverlayXEntry,
 	type OverlayYEntry,
 	updateOverlayAxes,
@@ -177,5 +178,45 @@ describe("updateOverlayAxes", () => {
 		updateOverlayAxes(scratch, [makeNumericX("A", [0])], []);
 		expect(scratch.xAxes).toHaveLength(1);
 		expect(scratch.yAxes).toHaveLength(0);
+	});
+});
+
+describe("estimateOverlayVertexCount", () => {
+	it("returns the baseline vertex count for no axes", () => {
+		expect(estimateOverlayVertexCount([], [])).toBe(BASE_VERTEX_COUNT);
+	});
+
+	it("adds (ticks + 1) * 4 + 6 per x-axis", () => {
+		const x = { ticks: { length: 3 }, showGrid: false };
+		// (3 + 1) * 4 + 6 = 22
+		expect(estimateOverlayVertexCount([x], [])).toBe(BASE_VERTEX_COUNT + 22);
+	});
+
+	it("adds first-x grid contribution only once", () => {
+		const a = { ticks: { length: 3 }, showGrid: true };
+		const b = { ticks: { length: 3 }, showGrid: true };
+		// per axis 22 each, first-x grid 3*4 = 12, total 22 + 22 + 12
+		expect(estimateOverlayVertexCount([a, b], [])).toBe(
+			BASE_VERTEX_COUNT + 22 + 22 + 12,
+		);
+	});
+
+	it("adds per-axis grid for every gridded y-axis", () => {
+		const y1 = { ticks: { length: 3 }, showGrid: true };
+		const y2 = { ticks: { length: 5 }, showGrid: false };
+		// y1: 22 + 12 = 34, y2: (5+1)*4+6 = 30
+		expect(estimateOverlayVertexCount([], [y1, y2])).toBe(
+			BASE_VERTEX_COUNT + 34 + 30,
+		);
+	});
+
+	it("matches updateOverlayAxes' computed est for the same inputs", () => {
+		const scratch = makeScratch();
+		const xLayout = [makeNumericX("X", [0, 5, 10], true)];
+		const yLayout = [makeY("Y", [0, 50, 100], "left", true)];
+		updateOverlayAxes(scratch, xLayout, yLayout);
+		expect(scratch.estVertexCount).toBe(
+			estimateOverlayVertexCount(scratch.xAxes, scratch.yAxes),
+		);
 	});
 });

--- a/src/components/Plot/overlayAxes.ts
+++ b/src/components/Plot/overlayAxes.ts
@@ -35,13 +35,36 @@ interface OverlayScratch {
 // (plot border, zero-axis line, padding triangles).
 const BASE_VERTEX_COUNT = 12 + 12 + 32;
 
+interface VertexCountAxis {
+	ticks: { length: number };
+	showGrid: boolean;
+}
+
+/**
+ * Conservative upper bound on the vertices the overlay draw step will emit
+ * for the given axis set: baseline frame + per-axis label/tick + optional
+ * grid contributions (only the first x-axis carries vertical grid lines).
+ * Used to grow the renderer's packed buffer ahead of time.
+ */
+export function estimateOverlayVertexCount(
+	xAxes: readonly VertexCountAxis[],
+	yAxes: readonly VertexCountAxis[],
+): number {
+	let est = BASE_VERTEX_COUNT;
+	if (xAxes[0]?.showGrid) est += xAxes[0].ticks.length * 4;
+	for (const ax of xAxes) est += (ax.ticks.length + 1) * 4 + 6;
+	for (const ax of yAxes) {
+		if (ax.showGrid) est += ax.ticks.length * 4;
+		est += (ax.ticks.length + 1) * 4 + 6;
+	}
+	return est;
+}
+
 export function updateOverlayAxes(
 	scratch: OverlayScratch,
 	xLayout: XAxisLayout[],
 	yLayout: YAxisLayout[],
 ): void {
-	let est = BASE_VERTEX_COUNT;
-
 	const sx = scratch.xAxes;
 	sx.length = xLayout.length;
 	for (let i = 0; i < xLayout.length; i++) {
@@ -71,11 +94,6 @@ export function updateOverlayAxes(
 			const t = src[j];
 			dst[j] = typeof t === "number" ? t : t.timestamp;
 		}
-
-		est += (src.length + 1) * 4 + 6;
-		if (i === 0 && a.showGrid) {
-			est += src.length * 4;
-		}
 	}
 	const sy = scratch.yAxes;
 	sy.length = yLayout.length;
@@ -102,12 +120,7 @@ export function updateOverlayAxes(
 			entry.position = a.position;
 			entry.categoryLabels = a.categoryLabels;
 		}
-
-		est += (a.ticks.length + 1) * 4 + 6;
-		if (a.showGrid) {
-			est += a.ticks.length * 4;
-		}
 	}
 
-	scratch.estVertexCount = est;
+	scratch.estVertexCount = estimateOverlayVertexCount(sx, sy);
 }

--- a/src/hooks/__tests__/useContainerSize.test.tsx
+++ b/src/hooks/__tests__/useContainerSize.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useContainerSize } from "../useContainerSize";
+
+type ResizeCallback = (entries: { contentRect: DOMRectReadOnly }[]) => void;
+
+class MockResizeObserver {
+	cb: ResizeCallback;
+	target: Element | null = null;
+	disconnected = false;
+	static instances: MockResizeObserver[] = [];
+
+	constructor(cb: ResizeCallback) {
+		this.cb = cb;
+		MockResizeObserver.instances.push(this);
+	}
+	observe(el: Element) {
+		this.target = el;
+	}
+	disconnect() {
+		this.disconnected = true;
+	}
+	emit(width: number, height: number) {
+		this.cb([{ contentRect: { width, height } as DOMRectReadOnly }]);
+	}
+}
+
+function renderWithRef(initial?: { w?: number; h?: number }, rect?: DOMRect) {
+	return renderHook(() => {
+		const ref = useRef<HTMLDivElement | null>(null);
+		if (!ref.current && rect !== undefined) {
+			const el = document.createElement("div");
+			el.getBoundingClientRect = () => rect;
+			ref.current = el;
+		}
+		const size = useContainerSize(ref, initial?.w, initial?.h);
+		return { ref, size };
+	});
+}
+
+describe("useContainerSize", () => {
+	let origRO: typeof ResizeObserver;
+
+	beforeEach(() => {
+		MockResizeObserver.instances = [];
+		origRO = globalThis.ResizeObserver;
+		globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+	});
+
+	afterEach(() => {
+		globalThis.ResizeObserver = origRO;
+		vi.restoreAllMocks();
+	});
+
+	it("returns the supplied initial size when there is no element", () => {
+		const { result } = renderHook(() => {
+			const ref = useRef<HTMLDivElement | null>(null);
+			return useContainerSize(ref, 800, 600);
+		});
+		expect(result.current).toEqual({ width: 800, height: 600 });
+	});
+
+	it("reads the initial size from the element's bounding rect on mount", () => {
+		const rect = { width: 1024, height: 768 } as DOMRect;
+		const { result } = renderWithRef({ w: 0, h: 0 }, rect);
+		expect(result.current.size.width).toBe(1024);
+		expect(result.current.size.height).toBe(768);
+	});
+
+	it("updates when the ResizeObserver fires", () => {
+		const rect = { width: 100, height: 100 } as DOMRect;
+		const { result } = renderWithRef({ w: 0, h: 0 }, rect);
+
+		const observer = MockResizeObserver.instances[0];
+		expect(observer).toBeDefined();
+		act(() => observer.emit(500, 300));
+		expect(result.current.size).toEqual({ width: 500, height: 300 });
+	});
+
+	it("uses the last entry when the observer reports multiple", () => {
+		const rect = { width: 100, height: 100 } as DOMRect;
+		const { result } = renderWithRef({ w: 0, h: 0 }, rect);
+
+		const observer = MockResizeObserver.instances[0];
+		act(() =>
+			observer.cb([
+				{ contentRect: { width: 1, height: 2 } as DOMRectReadOnly },
+				{ contentRect: { width: 9, height: 8 } as DOMRectReadOnly },
+			]),
+		);
+		expect(result.current.size).toEqual({ width: 9, height: 8 });
+	});
+
+	it("disconnects the observer on unmount", () => {
+		const rect = { width: 50, height: 60 } as DOMRect;
+		const { unmount } = renderWithRef({ w: 0, h: 0 }, rect);
+
+		const observer = MockResizeObserver.instances[0];
+		expect(observer.disconnected).toBe(false);
+		unmount();
+		expect(observer.disconnected).toBe(true);
+	});
+});

--- a/src/hooks/useContainerSize.ts
+++ b/src/hooks/useContainerSize.ts
@@ -1,0 +1,39 @@
+// Tracks an element's width/height. Reads the initial size from
+// getBoundingClientRect on mount, then keeps it in sync via a ResizeObserver.
+// Both effects live here so callers don't have to wire them up by hand.
+
+import { useEffect, useState } from "react";
+
+export function useContainerSize(
+	ref: React.RefObject<HTMLElement | null>,
+	initialWidth = 0,
+	initialHeight = 0,
+): { width: number; height: number } {
+	const [width, setWidth] = useState(initialWidth);
+	const [height, setHeight] = useState(initialHeight);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const observer = new ResizeObserver((entries) => {
+			if (entries.length > 0) {
+				const e = entries[entries.length - 1];
+				setWidth(e.contentRect.width);
+				setHeight(e.contentRect.height);
+			}
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [ref]);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (el) {
+			const rect = el.getBoundingClientRect();
+			setWidth(rect.width);
+			setHeight(rect.height);
+		}
+	}, [ref]);
+
+	return { width, height };
+}

--- a/src/utils/__tests__/colors.test.ts
+++ b/src/utils/__tests__/colors.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { hexToRgb, hexToRgba, lchToRgb, rgbToHex, rgbToLch } from "../colors";
+import {
+	hexToRgb,
+	hexToRgba,
+	hexToRgbaWithAlpha,
+	lchToRgb,
+	rgbToHex,
+	rgbToLch,
+} from "../colors";
 
 describe("colors", () => {
 	describe("rgbToHex", () => {
@@ -372,6 +379,25 @@ describe("colors", () => {
 			// Blue produces a negative hue internally before wrap
 			expect(h).toBeGreaterThanOrEqual(0);
 			expect(h).toBeLessThan(360);
+		});
+	});
+
+	describe("hexToRgbaWithAlpha", () => {
+		it("appends the alpha to the normalised hex channels", () => {
+			expect(hexToRgbaWithAlpha("#FF0000", 0.5)).toEqual([1, 0, 0, 0.5]);
+			expect(hexToRgbaWithAlpha("#00FF00", 0.25)).toEqual([0, 1, 0, 0.25]);
+		});
+
+		it("defaults alpha to 1", () => {
+			expect(hexToRgbaWithAlpha("#0000FF")).toEqual([0, 0, 1, 1]);
+		});
+
+		it("falls back to opaque black for invalid hex, preserving the alpha argument", () => {
+			expect(hexToRgbaWithAlpha("not-a-color", 0.7)).toEqual([0, 0, 0, 0.7]);
+		});
+
+		it("supports #rgb shorthand", () => {
+			expect(hexToRgbaWithAlpha("#0f0", 0.4)).toEqual([0, 1, 0, 0.4]);
 		});
 	});
 });

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -25,6 +25,17 @@ export const hexToRgba = (hex: string): number[] => {
 	return c ? [c.r / 255, c.g / 255, c.b / 255] : [0, 0, 0];
 };
 
+/** Normalised RGB channels for a hex string with an explicit alpha. */
+export const hexToRgbaWithAlpha = (
+	hex: string,
+	alpha = 1,
+): [number, number, number, number] => {
+	const c = parseHexChannels(hex);
+	return c
+		? [c.r / 255, c.g / 255, c.b / 255, alpha]
+		: [0, 0, 0, alpha];
+};
+
 export const rgbToHex = (r: number, g: number, b: number): string => {
 	const toHex = (n: number) => {
 		const num = typeof n === "number" && !Number.isNaN(n) ? n : 0;


### PR DESCRIPTION
## Summary

Batch of three independent, behavior-preserving extractions for #509. Three separate commits so each step can be reviewed on its own.

### 1. `hexToRgbaWithAlpha` colour helper (commit `e423107`)
- Adds `hexToRgbaWithAlpha(hex, alpha)` to `utils/colors.ts` returning the normalised `[r, g, b, a]` tuple, with the same invalid-hex fallback as `hexToRgba`.
- `WebGLRenderer.buildOverlay` drops its inline `hexRgba` closure and uses the helper for grid/axis/zero/bg colours.
- 4 new tests in `colors.test.ts`.

### 2. Dedupe overlay vertex-count estimation (commit `b23b0a4`)
- `buildOverlay` and `updateOverlayAxes` were each computing the same overlay vertex-count estimate inline. Both now call a shared `estimateOverlayVertexCount(xAxes, yAxes)` on `overlayAxes.ts`.
- `updateOverlayAxes` reads cleaner: the per-axis side-effect copy is no longer interleaved with the estimator's running total; the count is computed once at the end from the populated scratch.
- 5 new tests covering the baseline, per-x and first-x-grid contributions, per-y grid contributions, and consistency with `updateOverlayAxes`.

### 3. `useContainerSize` hook (commit `60c3d93`)
- New `src/hooks/useContainerSize.ts` combining `ChartContainer`'s two dimension-tracking `useEffect`s (initial `getBoundingClientRect` read + `ResizeObserver` sync) into a single hook.
- `ChartContainer` declares its width/height via one `useContainerSize(containerRef, 800, 600)` call.
- 5 new tests (using a mock `ResizeObserver`) covering the no-element default, initial size from the bounding rect, observer updates, multi-entry handling, and observer disconnect on unmount.

## Test plan

- [x] `pnpm test` — 773 tests pass (67 files), 14 new across the three commits
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [ ] Browser check that the chart still renders identical overlay colours, the WebGL packed buffer still grows correctly under heavy axes, and the chart still resizes smoothly with the window (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_