### PR TITLE
Extract buildOverlay geometry: bg quad + grid + zero lines (#509)

### DIFF
--- a/src/components/Plot/AxisInteractionZones.tsx
+++ b/src/components/Plot/AxisInteractionZones.tsx
@@ -1,0 +1,212 @@
+// Absolute-positioned interaction overlays for each x-axis row and y-axis
+// gutter. Each overlay forwards wheel/mouseDown/touchStart to the chart's
+// pan-zoom handlers scoped to its own axis, and reacts to double-click with
+// auto-scale (x and y) or inline title rename (x only). Extracted from
+// ChartContainer so the per-axis JSX stops drowning the render block.
+
+import { Fragment } from "react";
+import type { XAxisMetrics, XAxisLayout } from "./chartTypes";
+import { useGraphStore } from "../../store/useGraphStore";
+
+interface Padding {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
+}
+
+interface Theme {
+	fontFamily: string;
+	labelColor: string;
+	plotBg: string;
+	gridColor: string;
+}
+
+interface XInteractionProps {
+	xAxesMetrics: XAxisMetrics[];
+	xAxesLayout: XAxisLayout[];
+	padding: Padding;
+	editingXAxisId: string | null;
+	setEditingXAxisId: (id: string | null) => void;
+	themeColors: Theme;
+	onWheel: (e: React.WheelEvent, target: { xAxisId: string }) => void;
+	onMouseDown: (e: React.MouseEvent, target: { xAxisId: string }) => void;
+	onTouchStart: (e: React.TouchEvent, target: { xAxisId: string }) => void;
+	onAutoScaleX: (xAxisId: string) => void;
+}
+
+export function XAxisInteractionZones({
+	xAxesMetrics,
+	xAxesLayout,
+	padding,
+	editingXAxisId,
+	setEditingXAxisId,
+	themeColors,
+	onWheel,
+	onMouseDown,
+	onTouchStart,
+	onAutoScaleX,
+}: XInteractionProps) {
+	return (
+		<>
+			{xAxesMetrics.map((m) => {
+				const bY = padding.bottom - m.cumulativeOffset - m.height;
+				const title = xAxesLayout.find((a) => a.id === m.id)?.title || "";
+				return (
+					<Fragment key={`wheel-x-${m.id}`}>
+						<div
+							role="region"
+							aria-label={`X-Axis ${m.id} interaction area`}
+							onWheel={(e) => {
+								e.stopPropagation();
+								onWheel(e, { xAxisId: m.id });
+							}}
+							onMouseDown={(e) => {
+								e.stopPropagation();
+								onMouseDown(e, { xAxisId: m.id });
+							}}
+							onTouchStart={(e) => {
+								e.stopPropagation();
+								onTouchStart(e, { xAxisId: m.id });
+							}}
+							onDoubleClick={(e) => {
+								e.stopPropagation();
+								const rect = e.currentTarget.getBoundingClientRect();
+								const yInside = e.clientY - rect.top;
+								// Check if double click is in the title area (roughly bottom 30px)
+								if (yInside >= m.titleBottom - 30) {
+									setEditingXAxisId(m.id);
+								} else {
+									onAutoScaleX(m.id);
+								}
+							}}
+							style={{
+								position: "absolute",
+								bottom: bY,
+								left: padding.left,
+								right: padding.right,
+								height: m.height,
+								cursor: "ew-resize",
+								zIndex: 20,
+							}}
+						/>
+						{editingXAxisId === m.id && (
+							<input
+								defaultValue={title}
+								onBlur={(e) => {
+									const newName = e.target.value.trim();
+									useGraphStore
+										.getState()
+										.updateXAxis(m.id, { name: newName });
+									setEditingXAxisId(null);
+								}}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.currentTarget.blur();
+									} else if (e.key === "Escape") {
+										setEditingXAxisId(null);
+									}
+								}}
+								style={{
+									position: "absolute",
+									bottom: bY + m.height - m.titleBottom + 2,
+									left: "50%",
+									transform: "translateX(-50%)",
+									zIndex: 30,
+									textAlign: "center",
+									font: `bold 12px ${themeColors.fontFamily}`,
+									color: themeColors.labelColor,
+									background: themeColors.plotBg,
+									border: `1px solid ${themeColors.gridColor}`,
+									borderRadius: "4px",
+									padding: "2px 4px",
+									outline: "none",
+									width: "80%",
+									maxWidth: "300px",
+								}}
+							/>
+						)}
+					</Fragment>
+				);
+			})}
+		</>
+	);
+}
+
+interface YAxis {
+	id: string;
+	position: "left" | "right";
+}
+
+interface YInteractionProps {
+	axes: YAxis[];
+	axisLayout: Record<string, { total: number; label: number }>;
+	leftOffsets: Record<string, number>;
+	rightOffsets: Record<string, number>;
+	padding: Padding;
+	width: number;
+	containerRef: React.RefObject<HTMLDivElement | null>;
+	onWheel: (e: React.WheelEvent, target: { yAxisId: string }) => void;
+	onMouseDown: (e: React.MouseEvent, target: { yAxisId: string }) => void;
+	onTouchStart: (e: React.TouchEvent, target: { yAxisId: string }) => void;
+	onAutoScaleY: (yAxisId: string, mouseY?: number) => void;
+}
+
+export function YAxisInteractionZones({
+	axes,
+	axisLayout,
+	leftOffsets,
+	rightOffsets,
+	padding,
+	width,
+	containerRef,
+	onWheel,
+	onMouseDown,
+	onTouchStart,
+	onAutoScaleY,
+}: YInteractionProps) {
+	return (
+		<>
+			{axes.map((a) => {
+				const isL = a.position === "left";
+				const am = axisLayout[a.id] || { total: 40 };
+				const xP = isL
+					? padding.left - (leftOffsets[a.id] ?? 0) - am.total
+					: width - padding.right + (rightOffsets[a.id] ?? 0);
+				return (
+					<div
+						role="region"
+						aria-label={`Y-Axis ${a.id} interaction area`}
+						key={`wheel-${a.id}`}
+						onWheel={(e) => {
+							e.stopPropagation();
+							onWheel(e, { yAxisId: a.id });
+						}}
+						onMouseDown={(e) => {
+							e.stopPropagation();
+							onMouseDown(e, { yAxisId: a.id });
+						}}
+						onTouchStart={(e) => {
+							e.stopPropagation();
+							onTouchStart(e, { yAxisId: a.id });
+						}}
+						onDoubleClick={(e) => {
+							e.stopPropagation();
+							const rect = containerRef.current?.getBoundingClientRect();
+							onAutoScaleY(a.id, rect ? e.clientY - rect.top : undefined);
+						}}
+						style={{
+							position: "absolute",
+							left: xP,
+							top: padding.top,
+							width: am.total,
+							bottom: padding.bottom,
+							cursor: "ns-resize",
+							zIndex: 20,
+						}}
+					/>
+				);
+			})}
+		</>
+	);
+}

--- a/src/components/Plot/ChartActionButtons.tsx
+++ b/src/components/Plot/ChartActionButtons.tsx
@@ -1,0 +1,79 @@
+// Floating "Fit All" and "Stacked Fit" buttons docked in the plot's bottom-
+// left corner. Extracted from ChartContainer to keep the render block focused
+// on layout rather than per-button styling.
+
+import { ChartGantt, Expand } from "lucide-react";
+
+interface Padding {
+	bottom: number;
+	left: number;
+}
+
+interface Theme {
+	textMuted: string;
+}
+
+interface Props {
+	padding: Padding;
+	themeColors: Theme;
+	onStackedFit: () => void;
+	onFitAll: () => void;
+}
+
+const buttonStyle = (extraLeft: number, pad: Padding, color: string) =>
+	({
+		position: "absolute",
+		bottom: pad.bottom - 29,
+		left: pad.left - 29 - extraLeft,
+		zIndex: 100,
+		backgroundColor: "transparent",
+		border: "none",
+		borderRadius: "4px",
+		color,
+		padding: "4px",
+		cursor: "pointer",
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		opacity: 0.6,
+		transition: "opacity 0.2s",
+	}) as const;
+
+const handleEnter = (e: React.MouseEvent<HTMLButtonElement>) => {
+	e.currentTarget.style.opacity = "1";
+};
+const handleLeave = (e: React.MouseEvent<HTMLButtonElement>) => {
+	e.currentTarget.style.opacity = "0.6";
+};
+
+export function ChartActionButtons({
+	padding,
+	themeColors,
+	onStackedFit,
+	onFitAll,
+}: Props) {
+	return (
+		<>
+			<button
+				onClick={onStackedFit}
+				type="button"
+				title="Stacked Fit — each Y-axis fitted to its own slice"
+				style={buttonStyle(28, padding, themeColors.textMuted)}
+				onMouseEnter={handleEnter}
+				onMouseLeave={handleLeave}
+			>
+				<ChartGantt size={18} />
+			</button>
+			<button
+				onClick={onFitAll}
+				type="button"
+				title="Fit All"
+				style={buttonStyle(0, padding, themeColors.textMuted)}
+				onMouseEnter={handleEnter}
+				onMouseLeave={handleLeave}
+			>
+				<Expand size={18} />
+			</button>
+		</>
+	);
+}

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -35,6 +35,7 @@ import {
 	resetAxisTargets,
 } from "./buildLiveAxes";
 import { ChartLegend } from "./ChartLegend";
+import { PlotDragOverlay, ZoomBoxOverlay } from "./PlotOverlays";
 import {
 	type AxesLayoutCache,
 	buildXAxisLayoutFor,
@@ -553,31 +554,7 @@ export default function ChartContainer() {
 					userSelect: "none",
 				}}
 			>
-				{isDragOver && (
-					<div
-						style={{
-							position: "absolute",
-							inset: 0,
-							zIndex: 100,
-							display: "flex",
-							alignItems: "center",
-							justifyContent: "center",
-							backgroundColor: "rgba(0,0,0,0.35)",
-							pointerEvents: "none",
-						}}
-					>
-						<span
-							style={{
-								color: "#fff",
-								fontSize: "1.4rem",
-								fontWeight: 600,
-								letterSpacing: "0.02em",
-							}}
-						>
-							Drop to import
-						</span>
-					</div>
-				)}
+				<PlotDragOverlay visible={isDragOver} />
 				{datasets.length === 0 && (
 					<EmptyState width={width} height={height} padding={padding} />
 				)}
@@ -672,27 +649,11 @@ export default function ChartContainer() {
 						plotBg={themeColors.plotBg}
 					/>
 				)}
-				{isZooming && (
-					<svg
-						ref={zoomBoxSvgRef}
-						width="100%"
-						height="100%"
-						className="chart-abs-fill"
-						style={{ zIndex: 30 }}
-					>
-						<title>Zoom Selection Box</title>
-						<rect
-							ref={zoomBoxRectRef}
-							x={0}
-							y={0}
-							width={0}
-							height={0}
-							fill="rgba(0, 123, 255, 0.2)"
-							stroke="#007bff"
-							strokeWidth="1"
-						/>
-					</svg>
-				)}
+				<ZoomBoxOverlay
+					visible={isZooming}
+					svgRef={zoomBoxSvgRef}
+					rectRef={zoomBoxRectRef}
+				/>
 				{series.length > 0 && legendVisible && (
 					<ChartLegend
 						series={series}

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -35,6 +35,7 @@ import {
 	type LiveAxesScratch,
 	applyAxisUpdates,
 	createLiveAxesScratch,
+	resetAxisTargets,
 } from "./buildLiveAxes";
 import { ChartLegend } from "./ChartLegend";
 import {
@@ -467,19 +468,12 @@ export default function ChartContainer() {
 	// We update targets first to prevent syncAxesWithTargets from seeing "new" world
 	// changes if the update came from the store (e.g. undo/redo or sidebar).
 	useEffect(() => {
-		if (isLoaded) {
-			xAxes.forEach((axis) => {
-				targetXAxes.current[axis.id] = { min: axis.min, max: axis.max };
-			});
-			yAxes.forEach((axis) => {
-				targetYs.current[axis.id] = { min: axis.min, max: axis.max };
-			});
-
-			overlayInitRef.current = false;
-			// Use force=false to schedule via rAF, breaking synchronous render loops.
-			// Redraw is still forced because we set overlayInitRef.current = false above.
-			syncViewportRef.current(false);
-		}
+		if (!isLoaded) return;
+		resetAxisTargets(xAxes, yAxes, targetXAxes.current, targetYs.current);
+		overlayInitRef.current = false;
+		// Use force=false to schedule via rAF, breaking synchronous render loops.
+		// Redraw is still forced because we set overlayInitRef.current = false above.
+		syncViewportRef.current(false);
 	}, [isLoaded, xAxes, yAxes, series, datasets, themeColors, width, height]);
 
 	// 7. Memos for static rendering (JSX)

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -55,6 +55,7 @@ import type { XAxisLayout, XAxisMetrics, YAxisLayout } from "./chartTypes";
 import { EmptyState } from "./EmptyState";
 import { syncStoreUpdates } from "./syncStoreUpdates";
 import {
+	applyOverlayContext,
 	type OverlayXEntry,
 	type OverlayYEntry,
 	updateOverlayAxes,
@@ -412,14 +413,16 @@ export default function ChartContainer() {
 
 					const scratch = overlayScratchRef.current;
 					updateOverlayAxes(scratch, xLayout, yLayout);
-					scratch.xAxesMetrics = xAxesMetrics;
-					scratch.axisLayout = axisLayout;
-					scratch.leftOffsets = leftOffsets;
-					scratch.rightOffsets = rightOffsets;
-					scratch.axisColor = themeColors.axisColor;
-					scratch.zeroLineColor = themeColors.zeroLineColor;
-					scratch.gridColor = themeColors.gridColor;
-					scratch.plotBg = themeColors.plotBg;
+					applyOverlayContext(scratch, {
+						xAxesMetrics,
+						axisLayout,
+						leftOffsets,
+						rightOffsets,
+						axisColor: themeColors.axisColor,
+						zeroLineColor: themeColors.zeroLineColor,
+						gridColor: themeColors.gridColor,
+						plotBg: themeColors.plotBg,
+					});
 					webglRef.current?.setOverlay(scratch);
 					webglRef.current?.redraw(liveX, liveY);
 					axesLayerRef.current?.redraw(xLayout, yLayout);

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -1,6 +1,5 @@
 // src/components/Plot/ChartContainer.tsx
 
-import { ChartGantt, Expand } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAutoScale } from "../../hooks/useAutoScale";
 import { useContainerSize } from "../../hooks/useContainerSize";
@@ -19,6 +18,7 @@ import { applyKeyboardPan, applyKeyboardZoom } from "../../utils/keyboard";
 import ErrorBoundary from "../ErrorBoundary";
 import { ImportSettingsDialog } from "../Layout/ImportSettingsDialog";
 import { AxesLayer, type AxesLayerHandle } from "./AxesLayer";
+import { ChartActionButtons } from "./ChartActionButtons";
 import {
 	XAxisInteractionZones,
 	YAxisInteractionZones,
@@ -647,60 +647,12 @@ export default function ChartContainer() {
 					onAutoScaleY={handleAutoScaleY}
 				/>
 				{datasets.length > 0 && (
-					<>
-						<button
-							onClick={handleStackedFit}
-							type="button"
-							title="Stacked Fit — each Y-axis fitted to its own slice"
-							style={{
-								position: "absolute",
-								bottom: padding.bottom - 29,
-								left: padding.left - 29 - 28,
-								zIndex: 100,
-								backgroundColor: "transparent",
-								border: "none",
-								borderRadius: "4px",
-								color: themeColors.textMuted,
-								padding: "4px",
-								cursor: "pointer",
-								display: "flex",
-								alignItems: "center",
-								justifyContent: "center",
-								opacity: 0.6,
-								transition: "opacity 0.2s",
-							}}
-							onMouseEnter={(e) => (e.currentTarget.style.opacity = "1")}
-							onMouseLeave={(e) => (e.currentTarget.style.opacity = "0.6")}
-						>
-							<ChartGantt size={18} />
-						</button>
-						<button
-							onClick={handleFitAll}
-							type="button"
-							title="Fit All"
-							style={{
-								position: "absolute",
-								bottom: padding.bottom - 29,
-								left: padding.left - 29,
-								zIndex: 100,
-								backgroundColor: "transparent",
-								border: "none",
-								borderRadius: "4px",
-								color: themeColors.textMuted,
-								padding: "4px",
-								cursor: "pointer",
-								display: "flex",
-								alignItems: "center",
-								justifyContent: "center",
-								opacity: 0.6,
-								transition: "opacity 0.2s",
-							}}
-							onMouseEnter={(e) => (e.currentTarget.style.opacity = "1")}
-							onMouseLeave={(e) => (e.currentTarget.style.opacity = "0.6")}
-						>
-							<Expand size={18} />
-						</button>
-					</>
+					<ChartActionButtons
+						padding={padding}
+						themeColors={themeColors}
+						onStackedFit={handleStackedFit}
+						onFitAll={handleFitAll}
+					/>
 				)}
 				{crosshairVisible && (
 					<Crosshair

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -1,14 +1,7 @@
 // src/components/Plot/ChartContainer.tsx
 
 import { ChartGantt, Expand } from "lucide-react";
-import {
-	Fragment,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAutoScale } from "../../hooks/useAutoScale";
 import { useContainerSize } from "../../hooks/useContainerSize";
 import { useDataImport } from "../../hooks/useDataImport";
@@ -26,6 +19,10 @@ import { applyKeyboardPan, applyKeyboardZoom } from "../../utils/keyboard";
 import ErrorBoundary from "../ErrorBoundary";
 import { ImportSettingsDialog } from "../Layout/ImportSettingsDialog";
 import { AxesLayer, type AxesLayerHandle } from "./AxesLayer";
+import {
+	XAxisInteractionZones,
+	YAxisInteractionZones,
+} from "./AxisInteractionZones";
 import {
 	computeAxisOffsets,
 	measureYAxisGutter,
@@ -624,126 +621,31 @@ export default function ChartContainer() {
 					fontFamily={themeColors.fontFamily}
 					isInteracting={isInteracting}
 				/>
-				{xAxesMetrics.map((m) => {
-					const bY = padding.bottom - m.cumulativeOffset - m.height;
-					const title = xAxesLayout.find((a) => a.id === m.id)?.title || "";
-					return (
-						<Fragment key={`wheel-x-${m.id}`}>
-							<div
-								role="region"
-								aria-label={`X-Axis ${m.id} interaction area`}
-								onWheel={(e) => {
-									e.stopPropagation();
-									handleWheel(e, { xAxisId: m.id });
-								}}
-								onMouseDown={(e) => {
-									e.stopPropagation();
-									handleMouseDown(e, { xAxisId: m.id });
-								}}
-								onTouchStart={(e) => {
-									e.stopPropagation();
-									handleTouchStart(e, { xAxisId: m.id });
-								}}
-								onDoubleClick={(e) => {
-									e.stopPropagation();
-									const rect = e.currentTarget.getBoundingClientRect();
-									const yInside = e.clientY - rect.top;
-									// Check if double click is in the title area (roughly bottom 30px)
-									if (yInside >= m.titleBottom - 30) {
-										setEditingXAxisId(m.id);
-									} else {
-										handleAutoScaleX(m.id);
-									}
-								}}
-								style={{
-									position: "absolute",
-									bottom: bY,
-									left: padding.left,
-									right: padding.right,
-									height: m.height,
-									cursor: "ew-resize",
-									zIndex: 20,
-								}}
-							/>
-							{editingXAxisId === m.id && (
-								<input
-									defaultValue={title}
-									onBlur={(e) => {
-										const newName = e.target.value.trim();
-										useGraphStore
-											.getState()
-											.updateXAxis(m.id, { name: newName });
-										setEditingXAxisId(null);
-									}}
-									onKeyDown={(e) => {
-										if (e.key === "Enter") {
-											e.currentTarget.blur();
-										} else if (e.key === "Escape") {
-											setEditingXAxisId(null);
-										}
-									}}
-									style={{
-										position: "absolute",
-										bottom: bY + m.height - m.titleBottom + 2,
-										left: "50%",
-										transform: "translateX(-50%)",
-										zIndex: 30,
-										textAlign: "center",
-										font: `bold 12px ${themeColors.fontFamily}`,
-										color: themeColors.labelColor,
-										background: themeColors.plotBg,
-										border: `1px solid ${themeColors.gridColor}`,
-										borderRadius: "4px",
-										padding: "2px 4px",
-										outline: "none",
-										width: "80%",
-										maxWidth: "300px",
-									}}
-								/>
-							)}
-						</Fragment>
-					);
-				})}
-				{activeYAxes.map((a) => {
-					const isL = a.position === "left",
-						am = axisLayout[a.id] || { total: 40 };
-					const xP = isL
-						? padding.left - (leftOffsets[a.id] ?? 0) - am.total
-						: width - padding.right + (rightOffsets[a.id] ?? 0);
-					return (
-						<div
-							role="region"
-							aria-label={`Y-Axis ${a.id} interaction area`}
-							key={`wheel-${a.id}`}
-							onWheel={(e) => {
-								e.stopPropagation();
-								handleWheel(e, { yAxisId: a.id });
-							}}
-							onMouseDown={(e) => {
-								e.stopPropagation();
-								handleMouseDown(e, { yAxisId: a.id });
-							}}
-							onTouchStart={(e) => {
-								e.stopPropagation();
-								handleTouchStart(e, { yAxisId: a.id });
-							}}
-							onDoubleClick={(e) => {
-								e.stopPropagation();
-								const rect = containerRef.current?.getBoundingClientRect();
-								handleAutoScaleY(a.id, rect ? e.clientY - rect.top : undefined);
-							}}
-							style={{
-								position: "absolute",
-								left: xP,
-								top: padding.top,
-								width: am.total,
-								bottom: padding.bottom,
-								cursor: "ns-resize",
-								zIndex: 20,
-							}}
-						/>
-					);
-				})}
+				<XAxisInteractionZones
+					xAxesMetrics={xAxesMetrics}
+					xAxesLayout={xAxesLayout}
+					padding={padding}
+					editingXAxisId={editingXAxisId}
+					setEditingXAxisId={setEditingXAxisId}
+					themeColors={themeColors}
+					onWheel={handleWheel}
+					onMouseDown={handleMouseDown}
+					onTouchStart={handleTouchStart}
+					onAutoScaleX={handleAutoScaleX}
+				/>
+				<YAxisInteractionZones
+					axes={activeYAxes}
+					axisLayout={axisLayout}
+					leftOffsets={leftOffsets}
+					rightOffsets={rightOffsets}
+					padding={padding}
+					width={width}
+					containerRef={containerRef}
+					onWheel={handleWheel}
+					onMouseDown={handleMouseDown}
+					onTouchStart={handleTouchStart}
+					onAutoScaleY={handleAutoScaleY}
+				/>
 				{datasets.length > 0 && (
 					<>
 						<button

--- a/src/components/Plot/PlotOverlays.tsx
+++ b/src/components/Plot/PlotOverlays.tsx
@@ -1,0 +1,68 @@
+// Small JSX overlays the plot area shows on top of the WebGL canvas:
+// a "drop to import" curtain while a file is being dragged in, and the
+// blue SVG zoom-box that follows a ctrl-drag selection. Both are
+// presentational so they're trivial to test by render.
+
+interface DragOverlayProps {
+	visible: boolean;
+}
+
+export function PlotDragOverlay({ visible }: DragOverlayProps) {
+	if (!visible) return null;
+	return (
+		<div
+			style={{
+				position: "absolute",
+				inset: 0,
+				zIndex: 100,
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				backgroundColor: "rgba(0,0,0,0.35)",
+				pointerEvents: "none",
+			}}
+		>
+			<span
+				style={{
+					color: "#fff",
+					fontSize: "1.4rem",
+					fontWeight: 600,
+					letterSpacing: "0.02em",
+				}}
+			>
+				Drop to import
+			</span>
+		</div>
+	);
+}
+
+interface ZoomBoxOverlayProps {
+	visible: boolean;
+	svgRef: React.RefObject<SVGSVGElement | null>;
+	rectRef: React.RefObject<SVGRectElement | null>;
+}
+
+export function ZoomBoxOverlay({ visible, svgRef, rectRef }: ZoomBoxOverlayProps) {
+	if (!visible) return null;
+	return (
+		<svg
+			ref={svgRef}
+			width="100%"
+			height="100%"
+			className="chart-abs-fill"
+			style={{ zIndex: 30 }}
+		>
+			<title>Zoom Selection Box</title>
+			<rect
+				ref={rectRef}
+				x={0}
+				y={0}
+				width={0}
+				height={0}
+				fill="rgba(0, 123, 255, 0.2)"
+				stroke="#007bff"
+				strokeWidth="1"
+			/>
+		</svg>
+	);
+}

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -27,6 +27,10 @@ import {
 import { GLStateCache, type WebGLLocations } from "./GLStateCache";
 import { estimateOverlayVertexCount } from "./overlayAxes";
 import {
+	MAX_PIXEL_BUDGET_MULT,
+	updatePixelBudget,
+} from "./pixelBudget";
+import {
 	writeAxisArrows,
 	writeBackgroundQuad,
 	writeFramePlotBorder,
@@ -392,35 +396,6 @@ function buildOverlay(
 		});
 
 	ov.packedLen = p;
-}
-
-// The renderer adapts its decimation pixel budget between these bounds based on
-// measured frame time to keep pan/zoom responsive.
-const MIN_PIXEL_BUDGET_MULT = 32;
-const MAX_PIXEL_BUDGET_MULT = 64;
-
-function updatePixelBudget(
-	frameTime: number,
-	now: number,
-	lastBudgetUpdateRef: { current: number },
-	pixelBudgetMultRef: { current: number },
-): void {
-	const TARGET_MS = 20;
-	const BUDGET_UPDATE_INTERVAL = 33;
-	if (now - lastBudgetUpdateRef.current >= BUDGET_UPDATE_INTERVAL) {
-		lastBudgetUpdateRef.current = now;
-		if (frameTime > TARGET_MS) {
-			pixelBudgetMultRef.current = Math.max(
-				MIN_PIXEL_BUDGET_MULT,
-				pixelBudgetMultRef.current * 0.8,
-			);
-		} else if (frameTime < TARGET_MS * 0.5) {
-			pixelBudgetMultRef.current = Math.min(
-				MAX_PIXEL_BUDGET_MULT,
-				pixelBudgetMultRef.current * 1.2,
-			);
-		}
-	}
 }
 
 export const WebGLRenderer = React.memo(

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -12,7 +12,6 @@ import type {
 	YAxisConfig,
 } from "../../services/persistence";
 import { useGraphStore } from "../../store/useGraphStore";
-import { findSegmentStartIndex } from "../../utils/binarySearch";
 import { DEFAULT_X_AXIS_ID, getAxisById } from "../../utils/axisCalculations";
 import { hexToRgba, hexToRgbaWithAlpha } from "../../utils/colors";
 import { getColumnIndex } from "../../utils/columns";
@@ -41,6 +40,7 @@ import {
 } from "./overlayGeometry";
 import {
 	computeDataSlice,
+	computeDrawRanges,
 	getOrComputeMonotonicity,
 	getOrComputeSegments,
 } from "./seriesPrep";
@@ -392,41 +392,6 @@ function buildOverlay(
 		});
 
 	ov.packedLen = p;
-}
-
-function computeDrawRanges(
-	cachedSegments: { start: number; end: number }[],
-	isMonotonic: boolean,
-	sliceStart: number,
-	sliceEnd: number,
-	drawRangesScratch: { start: number; count: number }[],
-): void {
-	let drCount = 0;
-	const pushRange = (start: number, count: number) => {
-		if (drCount < drawRangesScratch.length) {
-			drawRangesScratch[drCount].start = start;
-			drawRangesScratch[drCount].count = count;
-		} else {
-			drawRangesScratch.push({ start, count });
-		}
-		drCount++;
-	};
-
-	if (isMonotonic) {
-		const startSegIdx = findSegmentStartIndex(cachedSegments, sliceStart);
-		for (let i = startSegIdx; i < cachedSegments.length; i++) {
-			const seg = cachedSegments[i];
-			if (seg.start > sliceEnd) break;
-			const segS = Math.max(seg.start, sliceStart);
-			const segE = Math.min(seg.end, sliceEnd);
-			if (segE >= segS) pushRange(segS, segE - segS + 1);
-		}
-	} else {
-		for (const seg of cachedSegments) {
-			pushRange(seg.start, seg.end - seg.start + 1);
-		}
-	}
-	drawRangesScratch.length = drCount;
 }
 
 // The renderer adapts its decimation pixel budget between these bounds based on

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -27,6 +27,7 @@ import {
 } from "./drawSeries";
 import { GLStateCache, type WebGLLocations } from "./GLStateCache";
 import { estimateOverlayVertexCount } from "./overlayAxes";
+import { writeBackgroundQuad } from "./overlayGeometry";
 import {
 	computeDataSlice,
 	getOrComputeMonotonicity,
@@ -251,23 +252,8 @@ function buildOverlay(
 	ov.groups.length = 0;
 
 	// --- Background quad (TRIANGLES) ---
-	const x0 = pad.left * dpr,
-		y0 = pad.top * dpr,
-		x1 = (pad.left + cw) * dpr,
-		y1 = (pad.top + ch) * dpr;
 	const bgStart = p / 2;
-	buf[p++] = x0;
-	buf[p++] = y0;
-	buf[p++] = x1;
-	buf[p++] = y0;
-	buf[p++] = x0;
-	buf[p++] = y1;
-	buf[p++] = x1;
-	buf[p++] = y0;
-	buf[p++] = x1;
-	buf[p++] = y1;
-	buf[p++] = x0;
-	buf[p++] = y1;
+	p = writeBackgroundQuad(buf, p, pad, cw, ch, dpr);
 	ov.groups.push({
 		topology: "TRIANGLES",
 		rgba: bgRgba,

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -28,6 +28,7 @@ import {
 import { GLStateCache, type WebGLLocations } from "./GLStateCache";
 import { estimateOverlayVertexCount } from "./overlayAxes";
 import {
+	writeAxisArrows,
 	writeBackgroundQuad,
 	writeFramePlotBorder,
 	writeXAxisLines,
@@ -36,6 +37,7 @@ import {
 	writeYAxisLines,
 	writeYGridLines,
 	writeYZeroLines,
+	writeZeroLineArrows,
 } from "./overlayGeometry";
 import {
 	computeDataSlice,
@@ -342,45 +344,17 @@ function buildOverlay(
 
 	// Zero-line arrow triangles.
 	const zeroTriStart = p / 2;
-	for (const ax of overlay.yAxes) {
-		if (ax.categoryLabels) continue;
-		if (!ax.showGrid) continue;
-		if (ax.min <= 0 && ax.max >= 0 && ax.max > ax.min) {
-			const range = ax.max - ax.min;
-			const norm = (0 - ax.min) / range;
-			const sy = (pad.top + (1 - norm) * ch) * dpr;
-			const arrowTipX = (w - pad.right + 8) * dpr;
-			const aSize = 6 * dpr;
-			buf[p++] = arrowTipX;
-			buf[p++] = sy;
-			buf[p++] = arrowTipX - aSize;
-			buf[p++] = sy - aSize / 2;
-			buf[p++] = arrowTipX - aSize;
-			buf[p++] = sy + aSize / 2;
-		}
-	}
-	if (overlay.xAxes.length > 0) {
-		const ax = overlay.xAxes[0];
-		if (
-			ax.showGrid &&
-			!ax.categoryLabels &&
-			ax.min <= 0 &&
-			ax.max >= 0 &&
-			ax.max > ax.min
-		) {
-			const range = ax.max - ax.min;
-			const norm = (0 - ax.min) / range;
-			const sx = (pad.left + norm * cw) * dpr;
-			const tipY = (pad.top - 8) * dpr;
-			const aSize = 6 * dpr;
-			buf[p++] = sx;
-			buf[p++] = tipY;
-			buf[p++] = sx - aSize / 2;
-			buf[p++] = tipY + aSize;
-			buf[p++] = sx + aSize / 2;
-			buf[p++] = tipY + aSize;
-		}
-	}
+	p = writeZeroLineArrows(
+		buf,
+		p,
+		overlay.yAxes,
+		overlay.xAxes[0],
+		pad,
+		w,
+		cw,
+		ch,
+		dpr,
+	);
 	const zeroTriCount = p / 2 - zeroTriStart;
 	if (zeroTriCount > 0)
 		ov.groups.push({
@@ -393,37 +367,20 @@ function buildOverlay(
 
 	// Axis arrow triangles (x/y).
 	const axisTriStart = p / 2;
-	overlay.xAxes.forEach((_, idx) => {
-		const m = overlay.xAxesMetrics[idx];
-		if (!m) return;
-		const yL = (h - pad.bottom + m.cumulativeOffset) * dpr;
-		const aSize = 6 * dpr;
-		buf[p++] = (w - pad.right + 8) * dpr;
-		buf[p++] = yL;
-		buf[p++] = (w - pad.right + 8 - 6) * dpr;
-		buf[p++] = yL - aSize / 2;
-		buf[p++] = (w - pad.right + 8 - 6) * dpr;
-		buf[p++] = yL + aSize / 2;
-	});
-	for (const ax of overlay.yAxes) {
-		const isLeft = ax.position === "left";
-		const metrics = overlay.axisLayout[ax.id] || {
-			total: 40,
-			label: 30,
-		};
-		const xPos = isLeft
-			? pad.left - (overlay.leftOffsets[ax.id] ?? 0) - metrics.total
-			: w - pad.right + (overlay.rightOffsets[ax.id] ?? 0);
-		const lineX = isLeft ? xPos + metrics.total : xPos;
-		const tipY = (pad.top - 8) * dpr;
-		const aSize = 6 * dpr;
-		buf[p++] = lineX * dpr;
-		buf[p++] = tipY;
-		buf[p++] = (lineX - 3) * dpr;
-		buf[p++] = tipY + aSize;
-		buf[p++] = (lineX + 3) * dpr;
-		buf[p++] = tipY + aSize;
-	}
+	p = writeAxisArrows(
+		buf,
+		p,
+		overlay.xAxes,
+		overlay.xAxesMetrics,
+		overlay.yAxes,
+		overlay.axisLayout,
+		overlay.leftOffsets,
+		overlay.rightOffsets,
+		pad,
+		w,
+		h,
+		dpr,
+	);
 	const axisTriCount = p / 2 - axisTriStart;
 	if (axisTriCount > 0)
 		ov.groups.push({

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -30,7 +30,9 @@ import { estimateOverlayVertexCount } from "./overlayAxes";
 import {
 	writeBackgroundQuad,
 	writeXGridLines,
+	writeXZeroLine,
 	writeYGridLines,
+	writeYZeroLines,
 } from "./overlayGeometry";
 import {
 	computeDataSlice,
@@ -284,38 +286,9 @@ function buildOverlay(
 
 	// Zero lines (horizontal for y-axes, vertical for first x-axis).
 	const zeroLineStart = p / 2;
-	for (const ax of overlay.yAxes) {
-		if (ax.categoryLabels) continue;
-		if (!ax.showGrid) continue;
-		if (ax.min <= 0 && ax.max >= 0 && ax.max > ax.min) {
-			const range = ax.max - ax.min;
-			const norm = (0 - ax.min) / range;
-			const sy = (pad.top + (1 - norm) * ch) * dpr;
-			const arrowTipX = (w - pad.right + 8) * dpr;
-			buf[p++] = pad.left * dpr;
-			buf[p++] = sy;
-			buf[p++] = arrowTipX;
-			buf[p++] = sy;
-		}
-	}
+	p = writeYZeroLines(buf, p, overlay.yAxes, pad, w, ch, dpr);
 	if (overlay.xAxes.length > 0) {
-		const ax = overlay.xAxes[0];
-		if (
-			ax.showGrid &&
-			!ax.categoryLabels &&
-			ax.min <= 0 &&
-			ax.max >= 0 &&
-			ax.max > ax.min
-		) {
-			const range = ax.max - ax.min;
-			const norm = (0 - ax.min) / range;
-			const sx = (pad.left + norm * cw) * dpr;
-			const tipY = (pad.top - 8) * dpr;
-			buf[p++] = sx;
-			buf[p++] = (h - pad.bottom) * dpr;
-			buf[p++] = sx;
-			buf[p++] = tipY;
-		}
+		p = writeXZeroLine(buf, p, overlay.xAxes[0], pad, cw, h, dpr);
 	}
 	const zeroLineCount = p / 2 - zeroLineStart;
 	if (zeroLineCount > 0)

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -30,8 +30,10 @@ import { estimateOverlayVertexCount } from "./overlayAxes";
 import {
 	writeBackgroundQuad,
 	writeFramePlotBorder,
+	writeXAxisLines,
 	writeXGridLines,
 	writeXZeroLine,
+	writeYAxisLines,
 	writeYGridLines,
 	writeYZeroLines,
 } from "./overlayGeometry";
@@ -304,56 +306,30 @@ function buildOverlay(
 	// Axis lines: frame spines + x/y axis lines + tick marks.
 	const axisLineStart = p / 2;
 	p = writeFramePlotBorder(buf, p, pad, w, ch, dpr);
-	overlay.xAxes.forEach((ax, idx) => {
-		const m = overlay.xAxesMetrics[idx];
-		if (!m) return;
-		const yL = (h - pad.bottom + m.cumulativeOffset) * dpr;
-		buf[p++] = pad.left * dpr;
-		buf[p++] = yL;
-		buf[p++] = (w - pad.right + 8) * dpr;
-		buf[p++] = yL;
-		if (ax.max <= ax.min) return;
-		const range = ax.max - ax.min;
-		const tickEnd = yL + 6 * dpr;
-		for (const t of ax.ticks) {
-			const norm = (t - ax.min) / range;
-			if (norm < 0 || norm > 1) continue;
-			const sx = (pad.left + norm * cw) * dpr;
-			buf[p++] = sx;
-			buf[p++] = yL;
-			buf[p++] = sx;
-			buf[p++] = tickEnd;
-		}
-	});
-	for (const ax of overlay.yAxes) {
-		const isLeft = ax.position === "left";
-		const metrics = overlay.axisLayout[ax.id] || {
-			total: 40,
-			label: 30,
-		};
-		const xPos = isLeft
-			? pad.left - (overlay.leftOffsets[ax.id] ?? 0) - metrics.total
-			: w - pad.right + (overlay.rightOffsets[ax.id] ?? 0);
-		const lineX = isLeft ? xPos + metrics.total : xPos;
-		const tipY = (pad.top - 8) * dpr;
-		buf[p++] = lineX * dpr;
-		buf[p++] = (h - pad.bottom) * dpr;
-		buf[p++] = lineX * dpr;
-		buf[p++] = tipY;
-		if (ax.max <= ax.min) continue;
-		const range = ax.max - ax.min;
-		const xa = (isLeft ? lineX - 5 : lineX) * dpr;
-		const xb = (isLeft ? lineX : lineX + 5) * dpr;
-		for (const t of ax.ticks) {
-			const norm = (t - ax.min) / range;
-			if (norm < 0 || norm > 1) continue;
-			const sy = (pad.top + (1 - norm) * ch) * dpr;
-			buf[p++] = xa;
-			buf[p++] = sy;
-			buf[p++] = xb;
-			buf[p++] = sy;
-		}
-	}
+	p = writeXAxisLines(
+		buf,
+		p,
+		overlay.xAxes,
+		overlay.xAxesMetrics,
+		pad,
+		w,
+		h,
+		cw,
+		dpr,
+	);
+	p = writeYAxisLines(
+		buf,
+		p,
+		overlay.yAxes,
+		overlay.axisLayout,
+		overlay.leftOffsets,
+		overlay.rightOffsets,
+		pad,
+		w,
+		h,
+		ch,
+		dpr,
+	);
 	const axisLineCount = p / 2 - axisLineStart;
 	if (axisLineCount > 0)
 		ov.groups.push({

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -29,6 +29,7 @@ import { GLStateCache, type WebGLLocations } from "./GLStateCache";
 import { estimateOverlayVertexCount } from "./overlayAxes";
 import {
 	writeBackgroundQuad,
+	writeFramePlotBorder,
 	writeXGridLines,
 	writeXZeroLine,
 	writeYGridLines,
@@ -302,18 +303,7 @@ function buildOverlay(
 
 	// Axis lines: frame spines + x/y axis lines + tick marks.
 	const axisLineStart = p / 2;
-	buf[p++] = pad.left * dpr;
-	buf[p++] = pad.top * dpr;
-	buf[p++] = pad.left * dpr;
-	buf[p++] = (pad.top + ch) * dpr;
-	buf[p++] = pad.left * dpr;
-	buf[p++] = pad.top * dpr;
-	buf[p++] = (w - pad.right) * dpr;
-	buf[p++] = pad.top * dpr;
-	buf[p++] = (w - pad.right) * dpr;
-	buf[p++] = pad.top * dpr;
-	buf[p++] = (w - pad.right) * dpr;
-	buf[p++] = (pad.top + ch) * dpr;
+	p = writeFramePlotBorder(buf, p, pad, w, ch, dpr);
 	overlay.xAxes.forEach((ax, idx) => {
 		const m = overlay.xAxesMetrics[idx];
 		if (!m) return;

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -27,7 +27,11 @@ import {
 } from "./drawSeries";
 import { GLStateCache, type WebGLLocations } from "./GLStateCache";
 import { estimateOverlayVertexCount } from "./overlayAxes";
-import { writeBackgroundQuad } from "./overlayGeometry";
+import {
+	writeBackgroundQuad,
+	writeXGridLines,
+	writeYGridLines,
+} from "./overlayGeometry";
 import {
 	computeDataSlice,
 	getOrComputeMonotonicity,
@@ -265,37 +269,9 @@ function buildOverlay(
 	// Grid: vertical (first x axis) + horizontal (y axes that show grid).
 	const gridStart = p / 2;
 	if (overlay.xAxes.length > 0) {
-		const ax = overlay.xAxes[0];
-		if (ax.showGrid && ax.max > ax.min) {
-			const range = ax.max - ax.min;
-			const yTop = pad.top * dpr;
-			const yBot = (pad.top + ch) * dpr;
-			for (const t of ax.ticks) {
-				const norm = (t - ax.min) / range;
-				if (norm < 0 || norm > 1) continue;
-				const sx = (pad.left + norm * cw) * dpr;
-				buf[p++] = sx;
-				buf[p++] = yTop;
-				buf[p++] = sx;
-				buf[p++] = yBot;
-			}
-		}
+		p = writeXGridLines(buf, p, overlay.xAxes[0], pad, cw, ch, dpr);
 	}
-	for (const ax of overlay.yAxes) {
-		if (!ax.showGrid || ax.max <= ax.min) continue;
-		const range = ax.max - ax.min;
-		const xL = pad.left * dpr;
-		const xR = (w - pad.right) * dpr;
-		for (const t of ax.ticks) {
-			const norm = (t - ax.min) / range;
-			if (norm < 0 || norm > 1) continue;
-			const sy = (pad.top + (1 - norm) * ch) * dpr;
-			buf[p++] = xL;
-			buf[p++] = sy;
-			buf[p++] = xR;
-			buf[p++] = sy;
-		}
-	}
+	p = writeYGridLines(buf, p, overlay.yAxes, pad, w, ch, dpr);
 	const gridCount = p / 2 - gridStart;
 	if (gridCount > 0)
 		ov.groups.push({

--- a/src/components/Plot/__tests__/buildLiveAxes.test.ts
+++ b/src/components/Plot/__tests__/buildLiveAxes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	applyAxisUpdates,
 	createLiveAxesScratch,
+	resetAxisTargets,
 } from "../buildLiveAxes";
 
 interface Axis {
@@ -127,5 +128,55 @@ describe("applyAxisUpdates", () => {
 			{},
 		);
 		expect(liveX[0].name).toBe("X-label");
+	});
+});
+
+describe("resetAxisTargets", () => {
+	it("writes each axis' min/max into the supplied target records", () => {
+		const targetX: Record<string, { min: number; max: number }> = {};
+		const targetY: Record<string, { min: number; max: number }> = {};
+		resetAxisTargets(
+			[
+				{ id: "X1", min: 0, max: 10 },
+				{ id: "X2", min: -5, max: 5 },
+			],
+			[{ id: "Y", min: 0, max: 100 }],
+			targetX,
+			targetY,
+		);
+		expect(targetX).toEqual({
+			X1: { min: 0, max: 10 },
+			X2: { min: -5, max: 5 },
+		});
+		expect(targetY).toEqual({ Y: { min: 0, max: 100 } });
+	});
+
+	it("overwrites existing target entries", () => {
+		const targetX: Record<string, { min: number; max: number }> = {
+			X: { min: 99, max: 99 },
+		};
+		resetAxisTargets(
+			[{ id: "X", min: 0, max: 10 }],
+			[],
+			targetX,
+			{},
+		);
+		expect(targetX.X).toEqual({ min: 0, max: 10 });
+	});
+
+	it("leaves the target record unchanged when given empty axis arrays", () => {
+		const targetX: Record<string, { min: number; max: number }> = {
+			X: { min: 1, max: 2 },
+		};
+		resetAxisTargets([], [], targetX, {});
+		expect(targetX).toEqual({ X: { min: 1, max: 2 } });
+	});
+
+	it("stores fresh objects (not references to the source axes)", () => {
+		const axis = { id: "X", min: 0, max: 10 };
+		const targetX: Record<string, { min: number; max: number }> = {};
+		resetAxisTargets([axis], [], targetX, {});
+		expect(targetX.X).not.toBe(axis);
+		expect(targetX.X).toEqual({ min: 0, max: 10 });
 	});
 });

--- a/src/components/Plot/__tests__/overlayAxes.test.ts
+++ b/src/components/Plot/__tests__/overlayAxes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { XAxisLayout, YAxisLayout } from "../chartTypes";
 import {
+	applyOverlayContext,
 	estimateOverlayVertexCount,
 	type OverlayXEntry,
 	type OverlayYEntry,
@@ -218,5 +219,70 @@ describe("estimateOverlayVertexCount", () => {
 		expect(scratch.estVertexCount).toBe(
 			estimateOverlayVertexCount(scratch.xAxes, scratch.yAxes),
 		);
+	});
+});
+
+describe("applyOverlayContext", () => {
+	it("copies every context field onto the scratch object", () => {
+		const scratch = {
+			xAxesMetrics: [],
+			axisLayout: {},
+			leftOffsets: {},
+			rightOffsets: {},
+			axisColor: "",
+			zeroLineColor: "",
+			gridColor: "",
+			plotBg: "",
+		};
+		const xAxesMetrics = [
+			{ id: "X", cumulativeOffset: 0, height: 30 },
+		];
+		const axisLayout = { Y: { total: 40, label: 20 } };
+		const leftOffsets = { Y: 0 };
+		const rightOffsets = {};
+		applyOverlayContext(scratch, {
+			xAxesMetrics,
+			axisLayout,
+			leftOffsets,
+			rightOffsets,
+			axisColor: "#111",
+			zeroLineColor: "#222",
+			gridColor: "#333",
+			plotBg: "#444",
+		});
+		expect(scratch.xAxesMetrics).toBe(xAxesMetrics);
+		expect(scratch.axisLayout).toBe(axisLayout);
+		expect(scratch.leftOffsets).toBe(leftOffsets);
+		expect(scratch.rightOffsets).toBe(rightOffsets);
+		expect(scratch.axisColor).toBe("#111");
+		expect(scratch.zeroLineColor).toBe("#222");
+		expect(scratch.gridColor).toBe("#333");
+		expect(scratch.plotBg).toBe("#444");
+	});
+
+	it("replaces previous context references on subsequent calls", () => {
+		const scratch = {
+			xAxesMetrics: [{ id: "OLD", cumulativeOffset: 0, height: 0 }],
+			axisLayout: { OLD: { total: 1, label: 1 } },
+			leftOffsets: { OLD: 9 },
+			rightOffsets: { OLD: 9 },
+			axisColor: "#OLD",
+			zeroLineColor: "#OLD",
+			gridColor: "#OLD",
+			plotBg: "#OLD",
+		};
+		applyOverlayContext(scratch, {
+			xAxesMetrics: [],
+			axisLayout: {},
+			leftOffsets: {},
+			rightOffsets: {},
+			axisColor: "#aaa",
+			zeroLineColor: "#bbb",
+			gridColor: "#ccc",
+			plotBg: "#ddd",
+		});
+		expect(scratch.xAxesMetrics).toEqual([]);
+		expect(scratch.axisLayout).toEqual({});
+		expect(scratch.axisColor).toBe("#aaa");
 	});
 });

--- a/src/components/Plot/__tests__/overlayGeometry.test.ts
+++ b/src/components/Plot/__tests__/overlayGeometry.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { writeBackgroundQuad } from "../overlayGeometry";
+import {
+	writeBackgroundQuad,
+	writeXGridLines,
+	writeYGridLines,
+} from "../overlayGeometry";
 
 const pad = { left: 20, right: 10, top: 5, bottom: 30 };
 
@@ -52,5 +56,122 @@ describe("writeBackgroundQuad", () => {
 		expect(buf[1]).toBe(888);
 		expect(buf[2]).toBe(777);
 		expect(buf[3]).toBe(666);
+	});
+});
+
+describe("writeXGridLines", () => {
+	const axis = {
+		ticks: [0, 50, 100],
+		min: 0,
+		max: 100,
+		showGrid: true,
+	};
+
+	it("writes one vertical line per visible tick", () => {
+		const buf = new Float32Array(20);
+		const next = writeXGridLines(buf, 0, axis, pad, 100, 50, 1);
+		// 3 ticks * 4 floats (two endpoints) = 12 floats
+		expect(next).toBe(12);
+	});
+
+	it("emits no vertices when showGrid is false", () => {
+		const buf = new Float32Array(20);
+		const next = writeXGridLines(
+			buf,
+			0,
+			{ ...axis, showGrid: false },
+			pad,
+			100,
+			50,
+			1,
+		);
+		expect(next).toBe(0);
+	});
+
+	it("emits no vertices for a zero or inverted range", () => {
+		const buf = new Float32Array(20);
+		expect(
+			writeXGridLines(buf, 0, { ...axis, min: 5, max: 5 }, pad, 100, 50, 1),
+		).toBe(0);
+		expect(
+			writeXGridLines(buf, 0, { ...axis, min: 100, max: 0 }, pad, 100, 50, 1),
+		).toBe(0);
+	});
+
+	it("skips ticks outside the [min,max] range", () => {
+		const buf = new Float32Array(20);
+		const next = writeXGridLines(
+			buf,
+			0,
+			{ ...axis, ticks: [-10, 50, 200] },
+			pad,
+			100,
+			50,
+			1,
+		);
+		expect(next).toBe(4); // only tick 50 inside
+	});
+
+	it("scales coordinates by dpr", () => {
+		const buf1 = new Float32Array(12);
+		const buf2 = new Float32Array(12);
+		writeXGridLines(buf1, 0, axis, pad, 100, 50, 1);
+		writeXGridLines(buf2, 0, axis, pad, 100, 50, 2);
+		for (let i = 0; i < 12; i++) expect(buf2[i]).toBe(buf1[i] * 2);
+	});
+});
+
+describe("writeYGridLines", () => {
+	const axisA = {
+		ticks: [0, 50, 100],
+		min: 0,
+		max: 100,
+		showGrid: true,
+	};
+	const axisB = {
+		ticks: [0, 10],
+		min: 0,
+		max: 10,
+		showGrid: false,
+	};
+
+	it("writes one horizontal line per gridded axis tick", () => {
+		const buf = new Float32Array(20);
+		const next = writeYGridLines(buf, 0, [axisA], pad, 130, 50, 1);
+		expect(next).toBe(12); // 3 ticks * 4 floats
+	});
+
+	it("skips axes whose showGrid is false", () => {
+		const buf = new Float32Array(20);
+		expect(writeYGridLines(buf, 0, [axisB], pad, 130, 50, 1)).toBe(0);
+	});
+
+	it("combines contributions across multiple gridded axes", () => {
+		const buf = new Float32Array(40);
+		const next = writeYGridLines(
+			buf,
+			0,
+			[axisA, { ...axisA, ticks: [25, 75] }],
+			pad,
+			130,
+			50,
+			1,
+		);
+		// (3 + 2) ticks * 4 floats
+		expect(next).toBe(20);
+	});
+
+	it("skips ticks outside [min,max]", () => {
+		const buf = new Float32Array(20);
+		const next = writeYGridLines(
+			buf,
+			0,
+			[{ ...axisA, ticks: [-5, 50, 105] }],
+			pad,
+			130,
+			50,
+			1,
+		);
+		expect(next).toBe(4);
 	});
 });

--- a/src/components/Plot/__tests__/overlayGeometry.test.ts
+++ b/src/components/Plot/__tests__/overlayGeometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	writeBackgroundQuad,
+	writeFramePlotBorder,
 	writeXGridLines,
 	writeXZeroLine,
 	writeYGridLines,
@@ -274,5 +275,35 @@ describe("writeXZeroLine", () => {
 		expect(
 			writeXZeroLine(buf, 0, { ...straddling, showGrid: false }, pad, 100, 90, 1),
 		).toBe(0);
+	});
+});
+
+describe("writeFramePlotBorder", () => {
+	it("writes the left/top/right spines as 6 vertices (12 floats)", () => {
+		const buf = new Float32Array(20);
+		const next = writeFramePlotBorder(buf, 0, pad, 130, 50, 1);
+		expect(next).toBe(12);
+	});
+
+	it("produces a 'U' (top-open) frame", () => {
+		const buf = new Float32Array(12);
+		writeFramePlotBorder(buf, 0, pad, 130, 50, 1);
+		const xL = 20;
+		const xR = 120;
+		const yT = 5;
+		const yB = 55;
+		expect(Array.from(buf)).toEqual([
+			xL, yT, xL, yB, // left spine
+			xL, yT, xR, yT, // top spine
+			xR, yT, xR, yB, // right spine
+		]);
+	});
+
+	it("scales coordinates by dpr", () => {
+		const buf1 = new Float32Array(12);
+		const buf2 = new Float32Array(12);
+		writeFramePlotBorder(buf1, 0, pad, 130, 50, 1);
+		writeFramePlotBorder(buf2, 0, pad, 130, 50, 3);
+		for (let i = 0; i < 12; i++) expect(buf2[i]).toBe(buf1[i] * 3);
 	});
 });

--- a/src/components/Plot/__tests__/overlayGeometry.test.ts
+++ b/src/components/Plot/__tests__/overlayGeometry.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
 	writeBackgroundQuad,
 	writeFramePlotBorder,
+	writeXAxisLines,
 	writeXGridLines,
 	writeXZeroLine,
+	writeYAxisLines,
 	writeYGridLines,
 	writeYZeroLines,
 } from "../overlayGeometry";
@@ -305,5 +307,154 @@ describe("writeFramePlotBorder", () => {
 		writeFramePlotBorder(buf1, 0, pad, 130, 50, 1);
 		writeFramePlotBorder(buf2, 0, pad, 130, 50, 3);
 		for (let i = 0; i < 12; i++) expect(buf2[i]).toBe(buf1[i] * 3);
+	});
+});
+
+describe("writeXAxisLines", () => {
+	const axis = { ticks: [0, 50, 100], min: 0, max: 100 };
+	const metric = { cumulativeOffset: 0 };
+
+	it("writes the axis spine (4 floats) plus 4 floats per visible tick", () => {
+		const buf = new Float32Array(40);
+		const next = writeXAxisLines(
+			buf,
+			0,
+			[axis],
+			[metric],
+			pad,
+			130,
+			90,
+			100,
+			1,
+		);
+		// 4 spine + 3 ticks * 4 = 16
+		expect(next).toBe(16);
+	});
+
+	it("skips an axis when no metric is supplied at that index", () => {
+		const buf = new Float32Array(20);
+		const next = writeXAxisLines(buf, 0, [axis], [], pad, 130, 90, 100, 1);
+		expect(next).toBe(0);
+	});
+
+	it("emits only the spine for a zero-range axis", () => {
+		const buf = new Float32Array(20);
+		const next = writeXAxisLines(
+			buf,
+			0,
+			[{ ...axis, min: 5, max: 5 }],
+			[metric],
+			pad,
+			130,
+			90,
+			100,
+			1,
+		);
+		expect(next).toBe(4);
+	});
+
+	it("stacks multiple axes by their cumulativeOffset", () => {
+		const buf = new Float32Array(80);
+		const next = writeXAxisLines(
+			buf,
+			0,
+			[axis, axis],
+			[metric, { cumulativeOffset: 30 }],
+			pad,
+			130,
+			90,
+			100,
+			1,
+		);
+		// 16 per axis = 32
+		expect(next).toBe(32);
+	});
+});
+
+describe("writeYAxisLines", () => {
+	const axis = {
+		id: "Y",
+		ticks: [0, 50, 100],
+		min: 0,
+		max: 100,
+		position: "left" as const,
+	};
+	const layout = { Y: { total: 50 } };
+	const lOff = { Y: 0 };
+	const rOff = {};
+
+	it("writes the spine (4 floats) plus 4 floats per visible tick", () => {
+		const buf = new Float32Array(40);
+		const next = writeYAxisLines(
+			buf,
+			0,
+			[axis],
+			layout,
+			lOff,
+			rOff,
+			pad,
+			130,
+			90,
+			50,
+			1,
+		);
+		// spine + 3 ticks * 4 = 16
+		expect(next).toBe(16);
+	});
+
+	it("uses the default gutter width when axisLayout lacks an entry", () => {
+		const buf = new Float32Array(40);
+		const next = writeYAxisLines(
+			buf,
+			0,
+			[axis],
+			{},
+			lOff,
+			rOff,
+			pad,
+			130,
+			90,
+			50,
+			1,
+		);
+		// Still writes 16 floats; layout fallback is internal
+		expect(next).toBe(16);
+	});
+
+	it("emits only the spine for a zero-range axis", () => {
+		const buf = new Float32Array(20);
+		const next = writeYAxisLines(
+			buf,
+			0,
+			[{ ...axis, min: 5, max: 5 }],
+			layout,
+			lOff,
+			rOff,
+			pad,
+			130,
+			90,
+			50,
+			1,
+		);
+		expect(next).toBe(4);
+	});
+
+	it("handles right-positioned axes", () => {
+		const ax = { ...axis, position: "right" as const };
+		const buf = new Float32Array(40);
+		const next = writeYAxisLines(
+			buf,
+			0,
+			[ax],
+			layout,
+			lOff,
+			{ Y: 0 },
+			pad,
+			130,
+			90,
+			50,
+			1,
+		);
+		expect(next).toBe(16);
 	});
 });

--- a/src/components/Plot/__tests__/overlayGeometry.test.ts
+++ b/src/components/Plot/__tests__/overlayGeometry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	writeAxisArrows,
 	writeBackgroundQuad,
 	writeFramePlotBorder,
 	writeXAxisLines,
@@ -8,6 +9,7 @@ import {
 	writeYAxisLines,
 	writeYGridLines,
 	writeYZeroLines,
+	writeZeroLineArrows,
 } from "../overlayGeometry";
 
 const pad = { left: 20, right: 10, top: 5, bottom: 30 };
@@ -456,5 +458,128 @@ describe("writeYAxisLines", () => {
 			1,
 		);
 		expect(next).toBe(16);
+	});
+});
+
+describe("writeZeroLineArrows", () => {
+	const yStraddling = { min: -10, max: 10, showGrid: true };
+	const xStraddling = { min: -1, max: 1, showGrid: true };
+
+	it("writes one 6-float arrow per qualifying y-axis plus first-x-axis arrow", () => {
+		const buf = new Float32Array(20);
+		const next = writeZeroLineArrows(
+			buf,
+			0,
+			[yStraddling],
+			xStraddling,
+			pad,
+			130,
+			100,
+			50,
+			1,
+		);
+		// 6 floats per arrow * 2 arrows = 12
+		expect(next).toBe(12);
+	});
+
+	it("skips axes that fail straddle/grid/categorical guards", () => {
+		const buf = new Float32Array(20);
+		const next = writeZeroLineArrows(
+			buf,
+			0,
+			[{ ...yStraddling, showGrid: false }],
+			undefined,
+			pad,
+			130,
+			100,
+			50,
+			1,
+		);
+		expect(next).toBe(0);
+	});
+
+	it("emits nothing when no x-axis is supplied and y-axes do not qualify", () => {
+		const buf = new Float32Array(20);
+		const next = writeZeroLineArrows(
+			buf,
+			0,
+			[{ ...yStraddling, categoryLabels: ["a"] }],
+			undefined,
+			pad,
+			130,
+			100,
+			50,
+			1,
+		);
+		expect(next).toBe(0);
+	});
+});
+
+describe("writeAxisArrows", () => {
+	const xAxis = { ticks: [], min: 0, max: 1 };
+	const xMetric = { cumulativeOffset: 0 };
+	const yAxis = {
+		id: "Y",
+		ticks: [],
+		min: 0,
+		max: 1,
+		position: "left" as const,
+	};
+
+	it("writes one 6-float arrow per x-axis and per y-axis", () => {
+		const buf = new Float32Array(40);
+		const next = writeAxisArrows(
+			buf,
+			0,
+			[xAxis],
+			[xMetric],
+			[yAxis],
+			{ Y: { total: 50 } },
+			{ Y: 0 },
+			{},
+			pad,
+			130,
+			90,
+			1,
+		);
+		expect(next).toBe(12);
+	});
+
+	it("skips an x-axis without a metric entry", () => {
+		const buf = new Float32Array(40);
+		const next = writeAxisArrows(
+			buf,
+			0,
+			[xAxis],
+			[],
+			[yAxis],
+			{ Y: { total: 50 } },
+			{ Y: 0 },
+			{},
+			pad,
+			130,
+			90,
+			1,
+		);
+		expect(next).toBe(6);
+	});
+
+	it("falls back to default gutter width when layout entry is missing", () => {
+		const buf = new Float32Array(20);
+		const next = writeAxisArrows(
+			buf,
+			0,
+			[],
+			[],
+			[yAxis],
+			{},
+			{ Y: 0 },
+			{},
+			pad,
+			130,
+			90,
+			1,
+		);
+		expect(next).toBe(6);
 	});
 });

--- a/src/components/Plot/__tests__/overlayGeometry.test.ts
+++ b/src/components/Plot/__tests__/overlayGeometry.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { writeBackgroundQuad } from "../overlayGeometry";
+
+const pad = { left: 20, right: 10, top: 5, bottom: 30 };
+
+describe("writeBackgroundQuad", () => {
+	it("writes 12 floats and returns the advanced write index", () => {
+		const buf = new Float32Array(20);
+		const next = writeBackgroundQuad(buf, 0, pad, 100, 50, 1);
+		expect(next).toBe(12);
+	});
+
+	it("emits two triangles covering the plot area at dpr 1", () => {
+		const buf = new Float32Array(12);
+		writeBackgroundQuad(buf, 0, pad, 100, 50, 1);
+		// expected corners
+		const x0 = 20;
+		const y0 = 5;
+		const x1 = 120;
+		const y1 = 55;
+		// Triangle 1: (x0,y0) (x1,y0) (x0,y1)
+		// Triangle 2: (x1,y0) (x1,y1) (x0,y1)
+		expect(Array.from(buf)).toEqual([
+			x0, y0,
+			x1, y0,
+			x0, y1,
+			x1, y0,
+			x1, y1,
+			x0, y1,
+		]);
+	});
+
+	it("multiplies all coordinates by the device pixel ratio", () => {
+		const buf = new Float32Array(12);
+		writeBackgroundQuad(buf, 0, pad, 100, 50, 2);
+		// All entries should be twice the dpr-1 values
+		const ref = new Float32Array(12);
+		writeBackgroundQuad(ref, 0, pad, 100, 50, 1);
+		for (let i = 0; i < 12; i++) expect(buf[i]).toBe(ref[i] * 2);
+	});
+
+	it("appends from the supplied write index without touching earlier slots", () => {
+		const buf = new Float32Array(16);
+		buf[0] = 999;
+		buf[1] = 888;
+		buf[2] = 777;
+		buf[3] = 666;
+		const next = writeBackgroundQuad(buf, 4, pad, 100, 50, 1);
+		expect(next).toBe(16);
+		// Untouched prefix
+		expect(buf[0]).toBe(999);
+		expect(buf[1]).toBe(888);
+		expect(buf[2]).toBe(777);
+		expect(buf[3]).toBe(666);
+	});
+});

--- a/src/components/Plot/__tests__/overlayGeometry.test.ts
+++ b/src/components/Plot/__tests__/overlayGeometry.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
 	writeBackgroundQuad,
 	writeXGridLines,
+	writeXZeroLine,
 	writeYGridLines,
+	writeYZeroLines,
 } from "../overlayGeometry";
 
 const pad = { left: 20, right: 10, top: 5, bottom: 30 };
@@ -173,5 +175,104 @@ describe("writeYGridLines", () => {
 			1,
 		);
 		expect(next).toBe(4);
+	});
+});
+
+describe("writeYZeroLines", () => {
+	const straddling = { min: -10, max: 10, showGrid: true };
+	const onlyPositive = { min: 5, max: 10, showGrid: true };
+
+	it("emits one line per straddling, gridded, non-categorical axis", () => {
+		const buf = new Float32Array(20);
+		const next = writeYZeroLines(buf, 0, [straddling], pad, 130, 50, 1);
+		expect(next).toBe(4);
+	});
+
+	it("skips axes that do not straddle 0", () => {
+		const buf = new Float32Array(20);
+		expect(writeYZeroLines(buf, 0, [onlyPositive], pad, 130, 50, 1)).toBe(0);
+	});
+
+	it("skips axes without grid", () => {
+		const buf = new Float32Array(20);
+		expect(
+			writeYZeroLines(
+				buf,
+				0,
+				[{ ...straddling, showGrid: false }],
+				pad,
+				130,
+				50,
+				1,
+			),
+		).toBe(0);
+	});
+
+	it("skips categorical axes", () => {
+		const buf = new Float32Array(20);
+		expect(
+			writeYZeroLines(
+				buf,
+				0,
+				[{ ...straddling, categoryLabels: ["a", "b"] }],
+				pad,
+				130,
+				50,
+				1,
+			),
+		).toBe(0);
+	});
+
+	it("aggregates contributions from multiple straddling axes", () => {
+		const buf = new Float32Array(20);
+		const next = writeYZeroLines(
+			buf,
+			0,
+			[straddling, { ...straddling, min: -1, max: 5 }],
+			pad,
+			130,
+			50,
+			1,
+		);
+		expect(next).toBe(8);
+	});
+});
+
+describe("writeXZeroLine", () => {
+	const straddling = { min: -10, max: 10, showGrid: true };
+
+	it("emits a single 2-vertex line when the first x-axis straddles 0", () => {
+		const buf = new Float32Array(20);
+		const next = writeXZeroLine(buf, 0, straddling, pad, 100, 90, 1);
+		expect(next).toBe(4);
+	});
+
+	it("returns the unchanged write index when min > 0", () => {
+		const buf = new Float32Array(20);
+		expect(
+			writeXZeroLine(buf, 7, { ...straddling, min: 1 }, pad, 100, 90, 1),
+		).toBe(7);
+	});
+
+	it("returns the unchanged write index when categorical", () => {
+		const buf = new Float32Array(20);
+		expect(
+			writeXZeroLine(
+				buf,
+				0,
+				{ ...straddling, categoryLabels: ["A"] },
+				pad,
+				100,
+				90,
+				1,
+			),
+		).toBe(0);
+	});
+
+	it("returns the unchanged write index when showGrid is false", () => {
+		const buf = new Float32Array(20);
+		expect(
+			writeXZeroLine(buf, 0, { ...straddling, showGrid: false }, pad, 100, 90, 1),
+		).toBe(0);
 	});
 });

--- a/src/components/Plot/__tests__/pixelBudget.test.ts
+++ b/src/components/Plot/__tests__/pixelBudget.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+	MAX_PIXEL_BUDGET_MULT,
+	MIN_PIXEL_BUDGET_MULT,
+	updatePixelBudget,
+} from "../pixelBudget";
+
+const ref = (current: number) => ({ current });
+
+describe("updatePixelBudget", () => {
+	it("waits at least 33ms between updates", () => {
+		const lastUpdate = ref(0);
+		const budget = ref(48);
+		// frame time is well above target but only 10ms since last update
+		updatePixelBudget(100, 10, lastUpdate, budget);
+		expect(budget.current).toBe(48);
+		expect(lastUpdate.current).toBe(0);
+	});
+
+	it("scales the budget down by 20% when the frame time exceeds the target", () => {
+		const lastUpdate = ref(0);
+		const budget = ref(50);
+		updatePixelBudget(25, 33, lastUpdate, budget); // > 20ms target
+		expect(budget.current).toBeCloseTo(40, 10);
+		expect(lastUpdate.current).toBe(33);
+	});
+
+	it("clamps the down-scale at MIN_PIXEL_BUDGET_MULT", () => {
+		const lastUpdate = ref(0);
+		const budget = ref(MIN_PIXEL_BUDGET_MULT);
+		updatePixelBudget(100, 33, lastUpdate, budget);
+		expect(budget.current).toBe(MIN_PIXEL_BUDGET_MULT);
+	});
+
+	it("scales the budget up by 20% when the frame time is well under half the target", () => {
+		const lastUpdate = ref(0);
+		const budget = ref(40);
+		updatePixelBudget(5, 33, lastUpdate, budget); // < 10ms (half target)
+		expect(budget.current).toBeCloseTo(48, 10);
+	});
+
+	it("clamps the up-scale at MAX_PIXEL_BUDGET_MULT", () => {
+		const lastUpdate = ref(0);
+		const budget = ref(MAX_PIXEL_BUDGET_MULT);
+		updatePixelBudget(1, 33, lastUpdate, budget);
+		expect(budget.current).toBe(MAX_PIXEL_BUDGET_MULT);
+	});
+
+	it("leaves the budget unchanged in the comfortable middle band", () => {
+		const lastUpdate = ref(0);
+		const budget = ref(50);
+		updatePixelBudget(15, 33, lastUpdate, budget); // between half-target and target
+		expect(budget.current).toBe(50);
+		// lastUpdate is still advanced
+		expect(lastUpdate.current).toBe(33);
+	});
+});

--- a/src/components/Plot/__tests__/seriesPrep.test.ts
+++ b/src/components/Plot/__tests__/seriesPrep.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	computeDataSlice,
+	computeDrawRanges,
 	getOrComputeMonotonicity,
 	getOrComputeSegments,
 } from "../seriesPrep";
@@ -116,5 +117,74 @@ describe("computeDataSlice", () => {
 		// findLastLE(1001) -> idx 1, -1 padding -> 0
 		// findFirstGE(1002) -> idx 2, +1 padding -> 3
 		expect(r).toEqual({ sliceStart: 0, sliceEnd: 3 });
+	});
+});
+
+describe("computeDrawRanges", () => {
+	it("emits every segment unchanged for non-monotonic data", () => {
+		const segments = [
+			{ start: 0, end: 3 },
+			{ start: 7, end: 9 },
+		];
+		const out: { start: number; count: number }[] = [];
+		computeDrawRanges(segments, false, 0, 0, out);
+		expect(out).toEqual([
+			{ start: 0, count: 4 },
+			{ start: 7, count: 3 },
+		]);
+	});
+
+	it("clips segments to the visible slice for monotonic data", () => {
+		const segments = [{ start: 0, end: 10 }];
+		const out: { start: number; count: number }[] = [];
+		computeDrawRanges(segments, true, 3, 7, out);
+		expect(out).toEqual([{ start: 3, count: 5 }]);
+	});
+
+	it("skips segments entirely before the slice", () => {
+		const segments = [
+			{ start: 0, end: 2 },
+			{ start: 5, end: 10 },
+		];
+		const out: { start: number; count: number }[] = [];
+		computeDrawRanges(segments, true, 5, 10, out);
+		expect(out).toEqual([{ start: 5, count: 6 }]);
+	});
+
+	it("stops scanning after a segment starts past the slice end", () => {
+		const segments = [
+			{ start: 0, end: 5 },
+			{ start: 6, end: 10 },
+			{ start: 20, end: 30 },
+		];
+		const out: { start: number; count: number }[] = [];
+		computeDrawRanges(segments, true, 0, 15, out);
+		expect(out).toEqual([
+			{ start: 0, count: 6 },
+			{ start: 6, count: 5 },
+		]);
+	});
+
+	it("reuses existing scratch slots and truncates trailing entries", () => {
+		const out = [
+			{ start: 999, count: 999 },
+			{ start: 999, count: 999 },
+			{ start: 999, count: 999 },
+		];
+		computeDrawRanges(
+			[{ start: 0, end: 5 }],
+			true,
+			0,
+			10,
+			out,
+		);
+		// One range written; scratch truncated to length 1.
+		expect(out).toEqual([{ start: 0, count: 6 }]);
+	});
+
+	it("returns an empty result when no segments overlap the slice", () => {
+		const out: { start: number; count: number }[] = [{ start: 1, count: 1 }];
+		computeDrawRanges([{ start: 100, end: 200 }], true, 0, 10, out);
+		expect(out).toEqual([]);
 	});
 });

--- a/src/components/Plot/buildLiveAxes.ts
+++ b/src/components/Plot/buildLiveAxes.ts
@@ -6,6 +6,31 @@
 
 export type AxisRangeUpdate = Record<string, { min: number; max: number }>;
 
+interface AxisRange {
+	id: string;
+	min: number;
+	max: number;
+}
+
+/**
+ * Snapshot each persisted axis' current [min,max] into the supplied target
+ * record, mutating in place. Used to seed the interactive target buffers
+ * after the store ranges change (load, undo/redo, sidebar edit).
+ */
+export function resetAxisTargets(
+	xAxes: readonly AxisRange[],
+	yAxes: readonly AxisRange[],
+	targetXAxes: Record<string, { min: number; max: number }>,
+	targetYs: Record<string, { min: number; max: number }>,
+): void {
+	for (const axis of xAxes) {
+		targetXAxes[axis.id] = { min: axis.min, max: axis.max };
+	}
+	for (const axis of yAxes) {
+		targetYs[axis.id] = { min: axis.min, max: axis.max };
+	}
+}
+
 export interface LiveAxesScratch<X, Y> {
 	liveX: X[];
 	liveY: Y[];

--- a/src/components/Plot/overlayAxes.ts
+++ b/src/components/Plot/overlayAxes.ts
@@ -124,3 +124,50 @@ export function updateOverlayAxes(
 
 	scratch.estVertexCount = estimateOverlayVertexCount(sx, sy);
 }
+
+interface XAxisMetricsEntry {
+	id: string;
+	cumulativeOffset: number;
+	height: number;
+}
+
+interface OverlayContextScratch {
+	xAxesMetrics: XAxisMetricsEntry[];
+	axisLayout: Record<string, { total: number; label: number }>;
+	leftOffsets: Record<string, number>;
+	rightOffsets: Record<string, number>;
+	axisColor: string;
+	zeroLineColor: string;
+	gridColor: string;
+	plotBg: string;
+}
+
+interface OverlayContext {
+	xAxesMetrics: XAxisMetricsEntry[];
+	axisLayout: Record<string, { total: number; label: number }>;
+	leftOffsets: Record<string, number>;
+	rightOffsets: Record<string, number>;
+	axisColor: string;
+	zeroLineColor: string;
+	gridColor: string;
+	plotBg: string;
+}
+
+/**
+ * Copy the per-frame "static" overlay context (axis metrics, gutter layout,
+ * left/right offsets, theme colours) onto the long-lived scratch buffer that
+ * the WebGL renderer reads each frame. Mutates the scratch in place.
+ */
+export function applyOverlayContext(
+	scratch: OverlayContextScratch,
+	ctx: OverlayContext,
+): void {
+	scratch.xAxesMetrics = ctx.xAxesMetrics;
+	scratch.axisLayout = ctx.axisLayout;
+	scratch.leftOffsets = ctx.leftOffsets;
+	scratch.rightOffsets = ctx.rightOffsets;
+	scratch.axisColor = ctx.axisColor;
+	scratch.zeroLineColor = ctx.zeroLineColor;
+	scratch.gridColor = ctx.gridColor;
+	scratch.plotBg = ctx.plotBg;
+}

--- a/src/components/Plot/overlayGeometry.ts
+++ b/src/components/Plot/overlayGeometry.ts
@@ -47,6 +47,8 @@ interface YAxisGutter {
 	readonly total: number;
 }
 
+const ARROW_SIZE = 6;
+
 /**
  * Append the plot-background quad (two triangles, 6 vertices) covering the
  * plot area, with all coordinates pre-multiplied by `dpr` so the renderer
@@ -325,6 +327,108 @@ export function writeYAxisLines(
 			buf[p++] = xb;
 			buf[p++] = sy;
 		}
+	}
+	return p;
+}
+
+/**
+ * Append zero-line arrow tips (TRIANGLES) for every straddling y-axis and
+ * the first x-axis. Mirrors the predicate of writeYZeroLines/writeXZeroLine.
+ */
+export function writeZeroLineArrows(
+	buf: Float32Array,
+	p: number,
+	yAxes: readonly ZeroLineAxis[],
+	xAxis: ZeroLineAxis | undefined,
+	pad: Padding,
+	w: number,
+	cw: number,
+	ch: number,
+	dpr: number,
+): number {
+	const aSize = ARROW_SIZE * dpr;
+	for (const ax of yAxes) {
+		if (ax.categoryLabels) continue;
+		if (!ax.showGrid) continue;
+		if (!(ax.min <= 0 && ax.max >= 0 && ax.max > ax.min)) continue;
+		const range = ax.max - ax.min;
+		const norm = (0 - ax.min) / range;
+		const sy = (pad.top + (1 - norm) * ch) * dpr;
+		const tipX = (w - pad.right + 8) * dpr;
+		buf[p++] = tipX;
+		buf[p++] = sy;
+		buf[p++] = tipX - aSize;
+		buf[p++] = sy - aSize / 2;
+		buf[p++] = tipX - aSize;
+		buf[p++] = sy + aSize / 2;
+	}
+	if (
+		xAxis &&
+		xAxis.showGrid &&
+		!xAxis.categoryLabels &&
+		xAxis.min <= 0 &&
+		xAxis.max >= 0 &&
+		xAxis.max > xAxis.min
+	) {
+		const range = xAxis.max - xAxis.min;
+		const norm = (0 - xAxis.min) / range;
+		const sx = (pad.left + norm * cw) * dpr;
+		const tipY = (pad.top - 8) * dpr;
+		buf[p++] = sx;
+		buf[p++] = tipY;
+		buf[p++] = sx - aSize / 2;
+		buf[p++] = tipY + aSize;
+		buf[p++] = sx + aSize / 2;
+		buf[p++] = tipY + aSize;
+	}
+	return p;
+}
+
+/**
+ * Append axis arrow tips (TRIANGLES) for every x-axis row and every y-axis.
+ * No straddle/grid guards — these arrows belong to the axis frame itself.
+ */
+export function writeAxisArrows(
+	buf: Float32Array,
+	p: number,
+	xAxes: readonly XAxisLine[],
+	xAxesMetrics: readonly XAxisMetric[],
+	yAxes: readonly YAxisLine[],
+	axisLayout: Record<string, YAxisGutter | undefined>,
+	leftOffsets: Record<string, number | undefined>,
+	rightOffsets: Record<string, number | undefined>,
+	pad: Padding,
+	w: number,
+	h: number,
+	dpr: number,
+): number {
+	const aSize = ARROW_SIZE * dpr;
+	for (let idx = 0; idx < xAxes.length; idx++) {
+		const m = xAxesMetrics[idx];
+		if (!m) continue;
+		const yL = (h - pad.bottom + m.cumulativeOffset) * dpr;
+		const tipX = (w - pad.right + 8) * dpr;
+		buf[p++] = tipX;
+		buf[p++] = yL;
+		buf[p++] = (w - pad.right + 8 - 6) * dpr;
+		buf[p++] = yL - aSize / 2;
+		buf[p++] = (w - pad.right + 8 - 6) * dpr;
+		buf[p++] = yL + aSize / 2;
+	}
+	const tipY = (pad.top - 8) * dpr;
+	for (const ax of yAxes) {
+		const isLeft = ax.position === "left";
+		const total = axisLayout[ax.id]?.total ?? DEFAULT_GUTTER_TOTAL;
+		const xPos = isLeft
+			? pad.left - (leftOffsets[ax.id] ?? 0) - total
+			: w - pad.right + (rightOffsets[ax.id] ?? 0);
+		const lineX = isLeft ? xPos + total : xPos;
+		buf[p++] = lineX * dpr;
+		buf[p++] = tipY;
+		buf[p++] = (lineX - 3) * dpr;
+		buf[p++] = tipY + aSize;
+		buf[p++] = (lineX + 3) * dpr;
+		buf[p++] = tipY + aSize;
 	}
 	return p;
 }

--- a/src/components/Plot/overlayGeometry.ts
+++ b/src/components/Plot/overlayGeometry.ts
@@ -11,6 +11,13 @@ interface Padding {
 	bottom: number;
 }
 
+interface GridAxis {
+	readonly ticks: readonly number[];
+	readonly min: number;
+	readonly max: number;
+	readonly showGrid: boolean;
+}
+
 /**
  * Append the plot-background quad (two triangles, 6 vertices) covering the
  * plot area, with all coordinates pre-multiplied by `dpr` so the renderer
@@ -40,5 +47,67 @@ export function writeBackgroundQuad(
 	buf[p++] = y1;
 	buf[p++] = x0;
 	buf[p++] = y1;
+	return p;
+}
+
+/**
+ * Append the vertical grid lines for the first x-axis (drawn full-height
+ * across the plot). Ticks outside the visible range are skipped. Returns
+ * the advanced write index.
+ */
+export function writeXGridLines(
+	buf: Float32Array,
+	p: number,
+	axis: GridAxis,
+	pad: Padding,
+	cw: number,
+	ch: number,
+	dpr: number,
+): number {
+	if (!axis.showGrid || axis.max <= axis.min) return p;
+	const range = axis.max - axis.min;
+	const yTop = pad.top * dpr;
+	const yBot = (pad.top + ch) * dpr;
+	for (const t of axis.ticks) {
+		const norm = (t - axis.min) / range;
+		if (norm < 0 || norm > 1) continue;
+		const sx = (pad.left + norm * cw) * dpr;
+		buf[p++] = sx;
+		buf[p++] = yTop;
+		buf[p++] = sx;
+		buf[p++] = yBot;
+	}
+	return p;
+}
+
+/**
+ * Append the horizontal grid lines for every y-axis that opts in. Each
+ * gridded axis adds a full-width line per visible tick. Returns the
+ * advanced write index.
+ */
+export function writeYGridLines(
+	buf: Float32Array,
+	p: number,
+	axes: readonly GridAxis[],
+	pad: Padding,
+	w: number,
+	ch: number,
+	dpr: number,
+): number {
+	const xL = pad.left * dpr;
+	const xR = (w - pad.right) * dpr;
+	for (const ax of axes) {
+		if (!ax.showGrid || ax.max <= ax.min) continue;
+		const range = ax.max - ax.min;
+		for (const t of ax.ticks) {
+			const norm = (t - ax.min) / range;
+			if (norm < 0 || norm > 1) continue;
+			const sy = (pad.top + (1 - norm) * ch) * dpr;
+			buf[p++] = xL;
+			buf[p++] = sy;
+			buf[p++] = xR;
+			buf[p++] = sy;
+		}
+	}
 	return p;
 }

--- a/src/components/Plot/overlayGeometry.ts
+++ b/src/components/Plot/overlayGeometry.ts
@@ -1,0 +1,44 @@
+// Pure vertex-buffer writers for the overlay primitives drawn by
+// WebGLRenderer.buildOverlay. Each helper appends its geometry to a packed
+// Float32Array starting at the supplied write index and returns the next
+// write index, so the caller can sum vertex counts and push draw groups
+// while the geometry itself stays testable in isolation.
+
+interface Padding {
+	left: number;
+	right: number;
+	top: number;
+	bottom: number;
+}
+
+/**
+ * Append the plot-background quad (two triangles, 6 vertices) covering the
+ * plot area, with all coordinates pre-multiplied by `dpr` so the renderer
+ * can blit straight to the device pixel grid.
+ */
+export function writeBackgroundQuad(
+	buf: Float32Array,
+	p: number,
+	pad: Padding,
+	cw: number,
+	ch: number,
+	dpr: number,
+): number {
+	const x0 = pad.left * dpr;
+	const y0 = pad.top * dpr;
+	const x1 = (pad.left + cw) * dpr;
+	const y1 = (pad.top + ch) * dpr;
+	buf[p++] = x0;
+	buf[p++] = y0;
+	buf[p++] = x1;
+	buf[p++] = y0;
+	buf[p++] = x0;
+	buf[p++] = y1;
+	buf[p++] = x1;
+	buf[p++] = y0;
+	buf[p++] = x1;
+	buf[p++] = y1;
+	buf[p++] = x0;
+	buf[p++] = y1;
+	return p;
+}

--- a/src/components/Plot/overlayGeometry.ts
+++ b/src/components/Plot/overlayGeometry.ts
@@ -18,6 +18,13 @@ interface GridAxis {
 	readonly showGrid: boolean;
 }
 
+interface ZeroLineAxis {
+	readonly min: number;
+	readonly max: number;
+	readonly showGrid: boolean;
+	readonly categoryLabels?: readonly string[];
+}
+
 /**
  * Append the plot-background quad (two triangles, 6 vertices) covering the
  * plot area, with all coordinates pre-multiplied by `dpr` so the renderer
@@ -109,5 +116,67 @@ export function writeYGridLines(
 			buf[p++] = sy;
 		}
 	}
+	return p;
+}
+
+/**
+ * Append horizontal zero lines for every y-axis whose visible range straddles
+ * 0 (skipping categorical axes and ones without grid). Each line extends from
+ * the plot's left edge to a small arrow-tip stub on the right.
+ */
+export function writeYZeroLines(
+	buf: Float32Array,
+	p: number,
+	axes: readonly ZeroLineAxis[],
+	pad: Padding,
+	w: number,
+	ch: number,
+	dpr: number,
+): number {
+	const xL = pad.left * dpr;
+	const xTip = (w - pad.right + 8) * dpr;
+	for (const ax of axes) {
+		if (ax.categoryLabels) continue;
+		if (!ax.showGrid) continue;
+		if (!(ax.min <= 0 && ax.max >= 0 && ax.max > ax.min)) continue;
+		const range = ax.max - ax.min;
+		const norm = (0 - ax.min) / range;
+		const sy = (pad.top + (1 - norm) * ch) * dpr;
+		buf[p++] = xL;
+		buf[p++] = sy;
+		buf[p++] = xTip;
+		buf[p++] = sy;
+	}
+	return p;
+}
+
+/**
+ * Append the vertical zero line for the first x-axis when its visible range
+ * straddles 0 and it is non-categorical with grid enabled. Drawn from the
+ * plot's bottom up to a small arrow-tip stub above the plot.
+ */
+export function writeXZeroLine(
+	buf: Float32Array,
+	p: number,
+	axis: ZeroLineAxis,
+	pad: Padding,
+	cw: number,
+	h: number,
+	dpr: number,
+): number {
+	if (
+		!axis.showGrid ||
+		axis.categoryLabels ||
+		!(axis.min <= 0 && axis.max >= 0 && axis.max > axis.min)
+	)
+		return p;
+	const range = axis.max - axis.min;
+	const norm = (0 - axis.min) / range;
+	const sx = (pad.left + norm * cw) * dpr;
+	const tipY = (pad.top - 8) * dpr;
+	buf[p++] = sx;
+	buf[p++] = (h - pad.bottom) * dpr;
+	buf[p++] = sx;
+	buf[p++] = tipY;
 	return p;
 }

--- a/src/components/Plot/overlayGeometry.ts
+++ b/src/components/Plot/overlayGeometry.ts
@@ -25,6 +25,28 @@ interface ZeroLineAxis {
 	readonly categoryLabels?: readonly string[];
 }
 
+interface XAxisLine {
+	readonly ticks: readonly number[];
+	readonly min: number;
+	readonly max: number;
+}
+
+interface XAxisMetric {
+	readonly cumulativeOffset: number;
+}
+
+interface YAxisLine {
+	readonly id: string;
+	readonly ticks: readonly number[];
+	readonly min: number;
+	readonly max: number;
+	readonly position: "left" | "right";
+}
+
+interface YAxisGutter {
+	readonly total: number;
+}
+
 /**
  * Append the plot-background quad (two triangles, 6 vertices) covering the
  * plot area, with all coordinates pre-multiplied by `dpr` so the renderer
@@ -212,5 +234,97 @@ export function writeFramePlotBorder(
 	buf[p++] = yT;
 	buf[p++] = xR;
 	buf[p++] = yB;
+	return p;
+}
+
+const DEFAULT_GUTTER_TOTAL = 40;
+
+/**
+ * Append every x-axis horizontal line plus its tick marks, stacked below the
+ * plot by each axis' cumulative offset. Returns the advanced write index.
+ */
+export function writeXAxisLines(
+	buf: Float32Array,
+	p: number,
+	axes: readonly XAxisLine[],
+	metrics: readonly XAxisMetric[],
+	pad: Padding,
+	w: number,
+	h: number,
+	cw: number,
+	dpr: number,
+): number {
+	for (let idx = 0; idx < axes.length; idx++) {
+		const ax = axes[idx];
+		const m = metrics[idx];
+		if (!m) continue;
+		const yL = (h - pad.bottom + m.cumulativeOffset) * dpr;
+		// Axis spine: left edge to right tip
+		buf[p++] = pad.left * dpr;
+		buf[p++] = yL;
+		buf[p++] = (w - pad.right + 8) * dpr;
+		buf[p++] = yL;
+		if (ax.max <= ax.min) continue;
+		const range = ax.max - ax.min;
+		const tickEnd = yL + 6 * dpr;
+		for (const t of ax.ticks) {
+			const norm = (t - ax.min) / range;
+			if (norm < 0 || norm > 1) continue;
+			const sx = (pad.left + norm * cw) * dpr;
+			buf[p++] = sx;
+			buf[p++] = yL;
+			buf[p++] = sx;
+			buf[p++] = tickEnd;
+		}
+	}
+	return p;
+}
+
+/**
+ * Append every y-axis vertical line plus its tick marks, placed left or right
+ * of the plot per `position` and stacked outwards by `leftOffsets` /
+ * `rightOffsets`. Returns the advanced write index.
+ */
+export function writeYAxisLines(
+	buf: Float32Array,
+	p: number,
+	axes: readonly YAxisLine[],
+	axisLayout: Record<string, YAxisGutter | undefined>,
+	leftOffsets: Record<string, number | undefined>,
+	rightOffsets: Record<string, number | undefined>,
+	pad: Padding,
+	w: number,
+	h: number,
+	ch: number,
+	dpr: number,
+): number {
+	const tipY = (pad.top - 8) * dpr;
+	const yBot = (h - pad.bottom) * dpr;
+	for (const ax of axes) {
+		const isLeft = ax.position === "left";
+		const total = axisLayout[ax.id]?.total ?? DEFAULT_GUTTER_TOTAL;
+		const xPos = isLeft
+			? pad.left - (leftOffsets[ax.id] ?? 0) - total
+			: w - pad.right + (rightOffsets[ax.id] ?? 0);
+		const lineX = isLeft ? xPos + total : xPos;
+		// Axis spine: bottom of plot up to arrow tip
+		buf[p++] = lineX * dpr;
+		buf[p++] = yBot;
+		buf[p++] = lineX * dpr;
+		buf[p++] = tipY;
+		if (ax.max <= ax.min) continue;
+		const range = ax.max - ax.min;
+		const xa = (isLeft ? lineX - 5 : lineX) * dpr;
+		const xb = (isLeft ? lineX : lineX + 5) * dpr;
+		for (const t of ax.ticks) {
+			const norm = (t - ax.min) / range;
+			if (norm < 0 || norm > 1) continue;
+			const sy = (pad.top + (1 - norm) * ch) * dpr;
+			buf[p++] = xa;
+			buf[p++] = sy;
+			buf[p++] = xb;
+			buf[p++] = sy;
+		}
+	}
 	return p;
 }

--- a/src/components/Plot/overlayGeometry.ts
+++ b/src/components/Plot/overlayGeometry.ts
@@ -180,3 +180,37 @@ export function writeXZeroLine(
 	buf[p++] = tipY;
 	return p;
 }
+
+/**
+ * Append the plot's "U" frame border: left spine, top spine, and right
+ * spine (the bottom is drawn by the x-axis line). 12 floats / 6 vertices.
+ */
+export function writeFramePlotBorder(
+	buf: Float32Array,
+	p: number,
+	pad: Padding,
+	w: number,
+	ch: number,
+	dpr: number,
+): number {
+	const xL = pad.left * dpr;
+	const xR = (w - pad.right) * dpr;
+	const yT = pad.top * dpr;
+	const yB = (pad.top + ch) * dpr;
+	// Left spine
+	buf[p++] = xL;
+	buf[p++] = yT;
+	buf[p++] = xL;
+	buf[p++] = yB;
+	// Top spine
+	buf[p++] = xL;
+	buf[p++] = yT;
+	buf[p++] = xR;
+	buf[p++] = yT;
+	// Right spine
+	buf[p++] = xR;
+	buf[p++] = yT;
+	buf[p++] = xR;
+	buf[p++] = yB;
+	return p;
+}

--- a/src/components/Plot/pixelBudget.ts
+++ b/src/components/Plot/pixelBudget.ts
@@ -1,0 +1,44 @@
+// Adaptive decimation budget for WebGLRenderer.
+//
+// The decimation pixel budget controls how many M4-aggregated points the
+// renderer hands to the line shader per frame. Larger = sharper but slower.
+// The renderer measures the previous frame's draw time and nudges the
+// budget multiplier between MIN and MAX so pan/zoom stays interactive.
+
+export const MIN_PIXEL_BUDGET_MULT = 32;
+export const MAX_PIXEL_BUDGET_MULT = 64;
+
+const TARGET_MS = 20;
+const BUDGET_UPDATE_INTERVAL = 33;
+
+/**
+ * Adjust the pixel-budget multiplier in place based on the last frame time.
+ *
+ * - If the frame missed the target by a wide margin, scale the budget down
+ *   by 20% (clamped at MIN_PIXEL_BUDGET_MULT).
+ * - If the frame ran in under half the target, scale up by 20% (clamped at
+ *   MAX_PIXEL_BUDGET_MULT).
+ * - Otherwise leave the budget untouched.
+ *
+ * Rate-limited: at most one adjustment per BUDGET_UPDATE_INTERVAL ms.
+ */
+export function updatePixelBudget(
+	frameTime: number,
+	now: number,
+	lastBudgetUpdateRef: { current: number },
+	pixelBudgetMultRef: { current: number },
+): void {
+	if (now - lastBudgetUpdateRef.current < BUDGET_UPDATE_INTERVAL) return;
+	lastBudgetUpdateRef.current = now;
+	if (frameTime > TARGET_MS) {
+		pixelBudgetMultRef.current = Math.max(
+			MIN_PIXEL_BUDGET_MULT,
+			pixelBudgetMultRef.current * 0.8,
+		);
+	} else if (frameTime < TARGET_MS * 0.5) {
+		pixelBudgetMultRef.current = Math.min(
+			MAX_PIXEL_BUDGET_MULT,
+			pixelBudgetMultRef.current * 1.2,
+		);
+	}
+}

--- a/src/components/Plot/seriesPrep.ts
+++ b/src/components/Plot/seriesPrep.ts
@@ -3,7 +3,11 @@
 // Float32Array identity) and have no GL/state dependencies, so they can be
 // unit-tested in isolation.
 
-import { findFirstGE, findLastLE } from "../../utils/binarySearch";
+import {
+	findFirstGE,
+	findLastLE,
+	findSegmentStartIndex,
+} from "../../utils/binarySearch";
 
 /**
  * Returns true when `xData` is monotonically non-decreasing. Each call shares
@@ -92,4 +96,52 @@ export function computeDataSlice(
 		: xDataLen - 1;
 
 	return { sliceStart, sliceEnd };
+}
+
+/**
+ * Intersect a series' cached segments with the visible slice and write the
+ * resulting draw ranges into `drawRangesScratch` in place, reusing existing
+ * slots and truncating to the new length so per-frame allocation stays at
+ * zero.
+ *
+ * For non-monotonic data every segment is emitted as-is; for monotonic data
+ * segments are clipped to `[sliceStart, sliceEnd]` and scanned starting from
+ * the first segment whose `end >= sliceStart` (via binary search).
+ */
+export function computeDrawRanges(
+	cachedSegments: readonly { start: number; end: number }[],
+	isMonotonic: boolean,
+	sliceStart: number,
+	sliceEnd: number,
+	drawRangesScratch: { start: number; count: number }[],
+): void {
+	let drCount = 0;
+	const pushRange = (start: number, count: number) => {
+		if (drCount < drawRangesScratch.length) {
+			drawRangesScratch[drCount].start = start;
+			drawRangesScratch[drCount].count = count;
+		} else {
+			drawRangesScratch.push({ start, count });
+		}
+		drCount++;
+	};
+
+	if (isMonotonic) {
+		const startSegIdx = findSegmentStartIndex(
+			cachedSegments as { start: number; end: number }[],
+			sliceStart,
+		);
+		for (let i = startSegIdx; i < cachedSegments.length; i++) {
+			const seg = cachedSegments[i];
+			if (seg.start > sliceEnd) break;
+			const segS = Math.max(seg.start, sliceStart);
+			const segE = Math.min(seg.end, sliceEnd);
+			if (segE >= segS) pushRange(segS, segE - segS + 1);
+		}
+	} else {
+		for (const seg of cachedSegments) {
+			pushRange(seg.start, seg.end - seg.start + 1);
+		}
+	}
+	drawRangesScratch.length = drCount;
 }

--- a/src/hooks/__tests__/panZoomMath.test.ts
+++ b/src/hooks/__tests__/panZoomMath.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { applyZoomToRange, panRangeByPixels } from "../panZoomMath";
+import {
+	applyZoomBoxToAxes,
+	applyZoomToRange,
+	panRangeByPixels,
+} from "../panZoomMath";
 
 describe("applyZoomToRange", () => {
 	it("keeps the range unchanged at zoom factor 1", () => {
@@ -81,5 +85,106 @@ describe("panRangeByPixels", () => {
 
 	it("supports non-zero range offsets", () => {
 		expect(panRangeByPixels(200, 400, 25, 100)).toEqual({ min: 250, max: 450 });
+	});
+});
+
+describe("applyZoomBoxToAxes", () => {
+	const padding = { top: 0, right: 0, bottom: 0, left: 0 };
+	const width = 100;
+	const height = 100;
+	const xAxis = { id: "X", min: 0, max: 100 };
+	const yAxis = { id: "Y", min: 0, max: 100 };
+
+	it("converts a screen box into per-axis ranges for X and Y by default", () => {
+		const tx: Record<string, { min: number; max: number }> = {};
+		const ty: Record<string, { min: number; max: number }> = {};
+		applyZoomBoxToAxes(
+			{ minX: 25, maxX: 75, minY: 25, maxY: 75 },
+			[xAxis],
+			[yAxis],
+			width,
+			height,
+			padding,
+			tx,
+			ty,
+			false,
+		);
+		expect(tx.X).toEqual({ min: 25, max: 75 });
+		expect(ty.Y).toEqual({ min: 25, max: 75 });
+	});
+
+	it("skips Y axes when xOnly is true (shift-drag)", () => {
+		const tx: Record<string, { min: number; max: number }> = {};
+		const ty: Record<string, { min: number; max: number }> = {};
+		applyZoomBoxToAxes(
+			{ minX: 25, maxX: 75, minY: 25, maxY: 75 },
+			[xAxis],
+			[yAxis],
+			width,
+			height,
+			padding,
+			tx,
+			ty,
+			true,
+		);
+		expect(tx.X).toEqual({ min: 25, max: 75 });
+		expect(ty.Y).toBeUndefined();
+	});
+
+	it("writes a target entry for every supplied axis", () => {
+		const x2 = { id: "X2", min: 0, max: 1000 };
+		const y2 = { id: "Y2", min: 0, max: 500 };
+		const tx: Record<string, { min: number; max: number }> = {};
+		const ty: Record<string, { min: number; max: number }> = {};
+		applyZoomBoxToAxes(
+			{ minX: 50, maxX: 50, minY: 50, maxY: 50 },
+			[xAxis, x2],
+			[yAxis, y2],
+			width,
+			height,
+			padding,
+			tx,
+			ty,
+			false,
+		);
+		expect(Object.keys(tx).sort()).toEqual(["X", "X2"]);
+		expect(Object.keys(ty).sort()).toEqual(["Y", "Y2"]);
+	});
+
+	it("leaves Y targets untouched when no x-axes are supplied", () => {
+		const tx: Record<string, { min: number; max: number }> = {};
+		const ty: Record<string, { min: number; max: number }> = {};
+		applyZoomBoxToAxes(
+			{ minX: 25, maxX: 75, minY: 25, maxY: 75 },
+			[],
+			[yAxis],
+			width,
+			height,
+			padding,
+			tx,
+			ty,
+			false,
+		);
+		expect(ty.Y).toBeUndefined();
+	});
+
+	it("uses each axis' own min/max as the screen-to-world viewport", () => {
+		const ax = { id: "A", min: 100, max: 200 };
+		const tx: Record<string, { min: number; max: number }> = {};
+		const ty: Record<string, { min: number; max: number }> = {};
+		applyZoomBoxToAxes(
+			{ minX: 25, maxX: 75, minY: 0, maxY: 0 },
+			[ax],
+			[],
+			width,
+			height,
+			padding,
+			tx,
+			ty,
+			false,
+		);
+		// box covers 25%..75% of the chart width -> 25% and 75% of [100,200] => [125,175]
+		expect(tx.A.min).toBeCloseTo(125, 5);
+		expect(tx.A.max).toBeCloseTo(175, 5);
 	});
 });

--- a/src/hooks/__tests__/panZoomMath.test.ts
+++ b/src/hooks/__tests__/panZoomMath.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	applyZoomBoxToAxes,
 	applyZoomToRange,
+	computePinchGesture,
 	panRangeByPixels,
 } from "../panZoomMath";
 
@@ -186,5 +187,65 @@ describe("applyZoomBoxToAxes", () => {
 		// box covers 25%..75% of the chart width -> 25% and 75% of [100,200] => [125,175]
 		expect(tx.A.min).toBeCloseTo(125, 5);
 		expect(tx.A.max).toBeCloseTo(175, 5);
+	});
+});
+
+describe("computePinchGesture", () => {
+	it("returns null when the touches coincide", () => {
+		expect(
+			computePinchGesture({ clientX: 100, clientY: 100 }, { clientX: 100, clientY: 100 }, 50),
+		).toBeNull();
+	});
+
+	it("reports the midpoint as the gesture centre", () => {
+		const g = computePinchGesture(
+			{ clientX: 0, clientY: 0 },
+			{ clientX: 100, clientY: 100 },
+			Math.hypot(100, 100),
+		);
+		expect(g?.cx).toBe(50);
+		expect(g?.cy).toBe(50);
+	});
+
+	it("uses lastDist / dist as the uniform zoom factor for a diagonal", () => {
+		// 45° diagonal so neither axis is locked
+		const dist = Math.hypot(100, 100);
+		const g = computePinchGesture(
+			{ clientX: 0, clientY: 0 },
+			{ clientX: 100, clientY: 100 },
+			dist / 2,
+		);
+		expect(g?.zfX).toBeCloseTo(0.5, 10);
+		expect(g?.zfY).toBeCloseTo(0.5, 10);
+	});
+
+	it("locks Y at 1 for a strongly horizontal gesture (dx > 1.5 * dy)", () => {
+		const g = computePinchGesture(
+			{ clientX: 0, clientY: 0 },
+			{ clientX: 100, clientY: 10 }, // dx 100, dy 10
+			60,
+		);
+		expect(g?.zfY).toBe(1);
+		expect(g?.zfX).not.toBe(1);
+	});
+
+	it("locks X at 1 for a strongly vertical gesture (dy > 1.5 * dx)", () => {
+		const g = computePinchGesture(
+			{ clientX: 0, clientY: 0 },
+			{ clientX: 10, clientY: 100 },
+			60,
+		);
+		expect(g?.zfX).toBe(1);
+		expect(g?.zfY).not.toBe(1);
+	});
+
+	it("does not lock either axis for a diagonal gesture", () => {
+		const g = computePinchGesture(
+			{ clientX: 0, clientY: 0 },
+			{ clientX: 100, clientY: 100 },
+			Math.hypot(100, 100),
+		);
+		expect(g?.zfX).toBeCloseTo(1, 10);
+		expect(g?.zfY).toBeCloseTo(1, 10);
 	});
 });

--- a/src/hooks/__tests__/usePanZoomKeyboard.test.tsx
+++ b/src/hooks/__tests__/usePanZoomKeyboard.test.tsx
@@ -1,0 +1,109 @@
+import { act, renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePanZoomKeyboard } from "../usePanZoomKeyboard";
+
+function setupHook() {
+	const syncViewport = vi.fn();
+	const setIsCtrlPressed = vi.fn();
+	const setIsShiftPressed = vi.fn();
+	const { result, unmount } = renderHook(() => {
+		const pressedKeys = useRef<Set<string>>(new Set());
+		usePanZoomKeyboard({
+			pressedKeys,
+			syncViewport,
+			setIsCtrlPressed,
+			setIsShiftPressed,
+		});
+		return pressedKeys;
+	});
+	return {
+		pressedKeys: result.current.current,
+		syncViewport,
+		setIsCtrlPressed,
+		setIsShiftPressed,
+		unmount,
+	};
+}
+
+function dispatchKey(
+	type: "keydown" | "keyup",
+	key: string,
+	opts: { ctrl?: boolean; target?: HTMLElement } = {},
+) {
+	const ev = new KeyboardEvent(type, {
+		key,
+		ctrlKey: !!opts.ctrl,
+		bubbles: true,
+		cancelable: true,
+	});
+	if (opts.target) {
+		Object.defineProperty(ev, "target", { value: opts.target });
+	}
+	window.dispatchEvent(ev);
+	return ev;
+}
+
+describe("usePanZoomKeyboard", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("reports Control and Shift modifier state", () => {
+		const { setIsCtrlPressed, setIsShiftPressed } = setupHook();
+		act(() => {
+			dispatchKey("keydown", "Control");
+			dispatchKey("keydown", "Shift");
+			dispatchKey("keyup", "Control");
+		});
+		expect(setIsCtrlPressed).toHaveBeenCalledWith(true);
+		expect(setIsShiftPressed).toHaveBeenCalledWith(true);
+		expect(setIsCtrlPressed).toHaveBeenLastCalledWith(false);
+	});
+
+	it("kicks syncViewport on arrow keys and +/-", () => {
+		const { syncViewport } = setupHook();
+		act(() => {
+			dispatchKey("keydown", "ArrowLeft");
+			dispatchKey("keydown", "+");
+		});
+		expect(syncViewport).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not kick syncViewport on unrelated keys", () => {
+		const { syncViewport } = setupHook();
+		act(() => dispatchKey("keydown", "a"));
+		expect(syncViewport).not.toHaveBeenCalled();
+	});
+
+	it("ignores key events from editable targets", () => {
+		const { syncViewport, pressedKeys } = setupHook();
+		const input = document.createElement("input");
+		act(() => dispatchKey("keydown", "ArrowLeft", { target: input }));
+		expect(syncViewport).not.toHaveBeenCalled();
+		expect(pressedKeys.has("ArrowLeft")).toBe(false);
+	});
+
+	it("removes keys from pressedKeys on keyup", () => {
+		const { pressedKeys } = setupHook();
+		act(() => dispatchKey("keydown", "ArrowRight"));
+		expect(pressedKeys.has("ArrowRight")).toBe(true);
+		act(() => dispatchKey("keyup", "ArrowRight"));
+		expect(pressedKeys.has("ArrowRight")).toBe(false);
+	});
+
+	it("calls preventDefault on Ctrl+= and Ctrl+- so the browser does not zoom", () => {
+		setupHook();
+		let ev: KeyboardEvent;
+		act(() => {
+			ev = dispatchKey("keydown", "=", { ctrl: true });
+		});
+		// biome-ignore lint/style/noNonNullAssertion: assigned in act
+		expect(ev!.defaultPrevented).toBe(true);
+	});
+
+	it("unregisters listeners on unmount", () => {
+		const { syncViewport, unmount } = setupHook();
+		unmount();
+		act(() => dispatchKey("keydown", "ArrowLeft"));
+		expect(syncViewport).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/panZoomMath.ts
+++ b/src/hooks/panZoomMath.ts
@@ -120,3 +120,49 @@ export function applyZoomBoxToAxes(
 		targetYs[axis.id] = { min: a1.y, max: a2.y };
 	}
 }
+
+interface TouchPoint {
+	clientX: number;
+	clientY: number;
+}
+
+export interface PinchGesture {
+	zfX: number;
+	zfY: number;
+	cx: number;
+	cy: number;
+	dist: number;
+}
+
+/**
+ * Derive a per-axis zoom factor and centre point from a two-touch pinch.
+ *
+ * Compares the touches' current distance to the previous frame's distance
+ * to compute a uniform zoom factor, then locks one axis at 1 when the
+ * gesture is strongly horizontal or strongly vertical (`dy/dx > 1.5`) so
+ * the user can pinch along a single axis without disturbing the other.
+ *
+ * Returns null when the touches coincide (degenerate gesture).
+ */
+export function computePinchGesture(
+	t1: TouchPoint,
+	t2: TouchPoint,
+	lastDist: number,
+): PinchGesture | null {
+	const dx = Math.abs(t1.clientX - t2.clientX);
+	const dy = Math.abs(t1.clientY - t2.clientY);
+	const dist = Math.hypot(dx, dy);
+	if (dist === 0) return null;
+	const zf = lastDist / dist;
+	let zfX = zf;
+	let zfY = zf;
+	if (dx > dy * 1.5) zfY = 1;
+	else if (dy > dx * 1.5) zfX = 1;
+	return {
+		zfX,
+		zfY,
+		cx: (t1.clientX + t2.clientX) / 2,
+		cy: (t1.clientY + t2.clientY) / 2,
+		dist,
+	};
+}

--- a/src/hooks/panZoomMath.ts
+++ b/src/hooks/panZoomMath.ts
@@ -2,9 +2,18 @@
 // unit-tested in isolation. These helpers operate purely on axis ranges
 // and never touch DOM, refs, or React state.
 
+import { screenToWorld } from "../utils/coords";
+
 export interface Range {
 	min: number;
 	max: number;
+}
+
+interface Padding {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
 }
 
 /**
@@ -45,4 +54,69 @@ export function panRangeByPixels(
 ): Range {
 	const worldShift = (deltaPx * (max - min)) / chartSpanPx;
 	return { min: min + worldShift, max: max + worldShift };
+}
+
+interface AxisRange {
+	id: string;
+	min: number;
+	max: number;
+}
+
+interface ZoomBox {
+	minX: number;
+	maxX: number;
+	minY: number;
+	maxY: number;
+}
+
+/**
+ * Convert a screen-space drag selection box into per-axis world ranges and
+ * write them into the supplied interactive target buffers.
+ *
+ * Each x-axis maps the box's x-extent through its own axis-viewport. Y-axes
+ * are mapped from the box's y-extent unless `xOnly` is set (shift-drag), in
+ * which case the Y targets are left unchanged.
+ */
+export function applyZoomBoxToAxes(
+	box: ZoomBox,
+	xAxes: readonly AxisRange[],
+	yAxes: readonly AxisRange[],
+	width: number,
+	height: number,
+	padding: Padding,
+	targetXAxes: Record<string, { min: number; max: number }>,
+	targetYs: Record<string, { min: number; max: number }>,
+	xOnly: boolean,
+): void {
+	const { minX, maxX, minY, maxY } = box;
+	for (const axis of xAxes) {
+		const vp = {
+			xMin: axis.min,
+			xMax: axis.max,
+			yMin: 0,
+			yMax: 100,
+			width,
+			height,
+			padding,
+		};
+		const w1 = screenToWorld(minX, maxY, vp);
+		const w2 = screenToWorld(maxX, minY, vp);
+		targetXAxes[axis.id] = { min: w1.x, max: w2.x };
+	}
+	if (xOnly || xAxes.length === 0) return;
+	const xRef = xAxes[0];
+	for (const axis of yAxes) {
+		const avp = {
+			xMin: xRef.min,
+			xMax: xRef.max,
+			yMin: axis.min,
+			yMax: axis.max,
+			width,
+			height,
+			padding,
+		};
+		const a1 = screenToWorld(minX, maxY, avp);
+		const a2 = screenToWorld(maxX, minY, avp);
+		targetYs[axis.id] = { min: a1.y, max: a2.y };
+	}
 }

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -12,6 +12,7 @@ import { screenToWorld } from "../utils/coords";
 import {
 	applyZoomBoxToAxes,
 	applyZoomToRange,
+	computePinchGesture,
 	panRangeByPixels,
 } from "./panZoomMath";
 
@@ -499,30 +500,14 @@ export function usePanZoom({
 				containerRectRef.current ||
 				containerRef.current?.getBoundingClientRect();
 			if (!rect) return;
-			const t1 = e.touches[0],
-				t2 = e.touches[1];
-			const dx = Math.abs(t1.clientX - t2.clientX);
-			const dy = Math.abs(t1.clientY - t2.clientY);
-			const dist = Math.hypot(dx, dy);
-			if (dist === 0) return;
-
 			if (!lastPinchDist.current) return;
-			const zf = lastPinchDist.current.dist / dist;
-
-			let zfX = zf;
-			let zfY = zf;
-
-			// If the gesture is mostly horizontal, don't zoom vertically
-			if (dx > dy * 1.5) {
-				zfY = 1;
-			}
-			// If the gesture is mostly vertical, don't zoom horizontally
-			else if (dy > dx * 1.5) {
-				zfX = 1;
-			}
-
-			const cx = (t1.clientX + t2.clientX) / 2;
-			const cy = (t1.clientY + t2.clientY) / 2;
+			const gesture = computePinchGesture(
+				e.touches[0],
+				e.touches[1],
+				lastPinchDist.current.dist,
+			);
+			if (!gesture) return;
+			const { zfX, zfY, cx, cy, dist } = gesture;
 
 			// Apply pan
 			const panDx = cx - lastPinchDist.current.cx;

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -15,6 +15,7 @@ import {
 	computePinchGesture,
 	panRangeByPixels,
 } from "./panZoomMath";
+import { usePanZoomKeyboard } from "./usePanZoomKeyboard";
 
 interface UsePanZoomOptions {
 	containerRef: React.RefObject<HTMLDivElement | null>;
@@ -700,38 +701,12 @@ export function usePanZoom({
 			chartHeight,
 		]);
 
-	useEffect(() => {
-		const handleKey = (e: KeyboardEvent) => {
-			if (e.key === "Control") setIsCtrlPressed(e.type === "keydown");
-			if (e.key === "Shift") setIsShiftPressed(e.type === "keydown");
-			if (e.type === "keyup") {
-				pressedKeys.current.delete(e.key);
-			} else {
-				if (
-					e.target instanceof HTMLInputElement ||
-					e.target instanceof HTMLSelectElement ||
-					e.target instanceof HTMLTextAreaElement
-				)
-					return;
-				if (e.ctrlKey && ["+", "-", "=", "_"].includes(e.key))
-					e.preventDefault();
-				pressedKeys.current.add(e.key);
-				if (
-					["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key)
-				) {
-					syncViewport();
-				} else if (["+", "-"].includes(e.key)) {
-					syncViewport();
-				}
-			}
-		};
-		window.addEventListener("keydown", handleKey);
-		window.addEventListener("keyup", handleKey);
-		return () => {
-			window.removeEventListener("keydown", handleKey);
-			window.removeEventListener("keyup", handleKey);
-		};
-	}, [syncViewport, pressedKeys]);
+	usePanZoomKeyboard({
+		pressedKeys,
+		syncViewport,
+		setIsCtrlPressed,
+		setIsShiftPressed,
+	});
 
 	return {
 		panTarget,

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -9,7 +9,11 @@ import {
 import type { XAxisConfig, YAxisConfig } from "../services/persistence";
 import { getAxisById } from "../utils/axisCalculations";
 import { screenToWorld } from "../utils/coords";
-import { applyZoomToRange, panRangeByPixels } from "./panZoomMath";
+import {
+	applyZoomBoxToAxes,
+	applyZoomToRange,
+	panRangeByPixels,
+} from "./panZoomMath";
 
 interface UsePanZoomOptions {
 	containerRef: React.RefObject<HTMLDivElement | null>;
@@ -647,42 +651,22 @@ export function usePanZoom({
 				const box = zoomBoxStartRef.current;
 				zoomBoxStartRef.current = null;
 				setIsZooming(false);
-				const minX = Math.min(box.startX, box.endX),
-					maxX = Math.max(box.startX, box.endX);
-				const minY = Math.min(box.startY, box.endY),
-					maxY = Math.max(box.startY, box.endY);
+				const minX = Math.min(box.startX, box.endX);
+				const maxX = Math.max(box.startX, box.endX);
+				const minY = Math.min(box.startY, box.endY);
+				const maxY = Math.max(box.startY, box.endY);
 				if (maxX - minX > 5 && maxY - minY > 5) {
-					activeXAxes.forEach((axis) => {
-						const vp = {
-							xMin: axis.min,
-							xMax: axis.max,
-							yMin: 0,
-							yMax: 100,
-							width,
-							height,
-							padding,
-						};
-						const w1 = screenToWorld(minX, maxY, vp),
-							w2 = screenToWorld(maxX, minY, vp);
-						targetXAxes.current[axis.id] = { min: w1.x, max: w2.x };
-					});
-					if (!isShiftPressedRef.current) {
-						activeYAxes.forEach((axis) => {
-							const mx2 = activeXAxes[0];
-							const avp = {
-								xMin: mx2.min,
-								xMax: mx2.max,
-								yMin: axis.min,
-								yMax: axis.max,
-								width,
-								height,
-								padding,
-							};
-							const a1 = screenToWorld(minX, maxY, avp),
-								a2 = screenToWorld(maxX, minY, avp);
-							targetYs.current[axis.id] = { min: a1.y, max: a2.y };
-						});
-					}
+					applyZoomBoxToAxes(
+						{ minX, maxX, minY, maxY },
+						activeXAxes,
+						activeYAxes,
+						width,
+						height,
+						padding,
+						targetXAxes.current,
+						targetYs.current,
+						isShiftPressedRef.current,
+					);
 					syncViewport();
 				}
 			}

--- a/src/hooks/usePanZoomKeyboard.ts
+++ b/src/hooks/usePanZoomKeyboard.ts
@@ -1,0 +1,61 @@
+// Global keyboard listener for the chart pan/zoom hook. Tracks the live
+// Ctrl/Shift modifier state (so cursors and SVG overlays can react), keeps a
+// shared `pressedKeys` set in sync, and kicks syncViewport whenever an
+// arrow or +/- key is pressed (the per-frame loop reads from `pressedKeys`
+// to apply continuous keyboard pan/zoom).
+
+import { useEffect } from "react";
+
+const PAN_KEYS = new Set([
+	"ArrowLeft",
+	"ArrowRight",
+	"ArrowUp",
+	"ArrowDown",
+]);
+const ZOOM_KEYS = new Set(["+", "-"]);
+const ZOOM_PREVENT_DEFAULT_KEYS = new Set(["+", "-", "=", "_"]);
+
+function isEditableTarget(target: EventTarget | null): boolean {
+	return (
+		target instanceof HTMLInputElement ||
+		target instanceof HTMLSelectElement ||
+		target instanceof HTMLTextAreaElement
+	);
+}
+
+interface Options {
+	pressedKeys: React.MutableRefObject<Set<string>>;
+	syncViewport: () => void;
+	setIsCtrlPressed: (pressed: boolean) => void;
+	setIsShiftPressed: (pressed: boolean) => void;
+}
+
+export function usePanZoomKeyboard({
+	pressedKeys,
+	syncViewport,
+	setIsCtrlPressed,
+	setIsShiftPressed,
+}: Options): void {
+	useEffect(() => {
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === "Control") setIsCtrlPressed(e.type === "keydown");
+			if (e.key === "Shift") setIsShiftPressed(e.type === "keydown");
+			if (e.type === "keyup") {
+				pressedKeys.current.delete(e.key);
+				return;
+			}
+			if (isEditableTarget(e.target)) return;
+			if (e.ctrlKey && ZOOM_PREVENT_DEFAULT_KEYS.has(e.key)) e.preventDefault();
+			pressedKeys.current.add(e.key);
+			if (PAN_KEYS.has(e.key) || ZOOM_KEYS.has(e.key)) {
+				syncViewport();
+			}
+		};
+		window.addEventListener("keydown", handleKey);
+		window.addEventListener("keyup", handleKey);
+		return () => {
+			window.removeEventListener("keydown", handleKey);
+			window.removeEventListener("keyup", handleKey);
+		};
+	}, [pressedKeys, syncViewport, setIsCtrlPressed, setIsShiftPressed]);
+}


### PR DESCRIPTION
## Summary

Continuing the #509 god-component decomposition by pulling pure vertex-buffer writers out of `WebGLRenderer.buildOverlay` (~150 lines, untouched by earlier steps). Three commits, one per logical block, into a new `overlayGeometry` module.

### 1. `writeBackgroundQuad` — plot background two-triangle quad
### 2. `writeXGridLines` + `writeYGridLines` — full-plot grid for the first x-axis and gridded y-axes
### 3. `writeYZeroLines` + `writeXZeroLine` — the straddle-0 emphasis lines (with arrow stubs)

Each helper takes the packed Float32Array, the current write index, and the geometry inputs; appends its vertices; returns the new index. The draw-group push (offset + count + colour + topology) stays inline in `buildOverlay` so vertex ordering remains explicit. All guards (`showGrid`, range > 0, non-categorical, visible-tick filter, dpr scaling) move with the geometry.

## Test plan

- [x] `pnpm test` — full suite green, 22 new tests in `overlayGeometry.test.ts`
- [x] `pnpm build` — succeeds
- [ ] Browser check that the overlay still renders identical background colour, grid lines on each gridded axis, and zero-emphasis lines/arrows when axes straddle 0 (recommended before merge)

https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDL5mo7GHaeHK6PFgL14em)_