### PR TITLE
🧪 Add test for useFileDownload hook

### DIFF
--- a/src/hooks/__tests__/useFileDownload.test.tsx
+++ b/src/hooks/__tests__/useFileDownload.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useFileDownload } from "../useFileDownload";
+import { downloadFile } from "../../services/export";
+
+vi.mock("../../services/export", () => ({
+  downloadFile: vi.fn(),
+}));
+
+describe("useFileDownload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call downloadFile with correct arguments", () => {
+    const { result } = renderHook(() => useFileDownload());
+    result.current("content", "test.txt", "text/plain");
+    expect(downloadFile).toHaveBeenCalledWith(
+      "content",
+      "test.txt",
+      "text/plain",
+    );
+  });
+
+  it("should execute cleanup functions on unmount", () => {
+    const cleanupMock = vi.fn();
+    vi.mocked(downloadFile).mockReturnValue(cleanupMock);
+
+    const { result, unmount } = renderHook(() => useFileDownload());
+    result.current("content", "test.txt", "text/plain");
+
+    expect(cleanupMock).not.toHaveBeenCalled();
+    unmount();
+    expect(cleanupMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
- 🎯 **What:** The testing gap addressed for `useFileDownload` hook.
- 📊 **Coverage:** The scenarios covered are calling `downloadFile` correctly and tracking and executing object url cleanup on component unmount.
- ✨ **Result:** Added complete testing for the `useFileDownload` hook.

---
*PR created automatically by Jules for task [15495949233440898029](https://jules.google.com/task/15495949233440898029) started by @michaelkrisper*