### PR TITLE
🧪 Fix formula.worker tests to include id

### DIFF
--- a/src/workers/__tests__/formula.worker.test.ts
+++ b/src/workers/__tests__/formula.worker.test.ts
@@ -1,106 +1,113 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("../../utils/formula", () => ({
-	evaluateFormulaSync: vi.fn(),
+  evaluateFormulaSync: vi.fn(),
 }));
 
 describe("formula.worker", () => {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	let evaluateFormulaSyncMock: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let evaluateFormulaSyncMock: any;
 
-	beforeEach(async () => {
-		vi.resetModules();
-		evaluateFormulaSyncMock = (await import("../../utils/formula"))
-			.evaluateFormulaSync;
+  beforeEach(async () => {
+    vi.resetModules();
+    evaluateFormulaSyncMock = (await import("../../utils/formula"))
+      .evaluateFormulaSync;
 
-		// Setup global context for worker
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		globalThis.self = globalThis as any;
-		globalThis.postMessage = vi.fn();
-	});
+    // Setup global context for worker
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.self = globalThis as any;
+    globalThis.postMessage = vi.fn();
+  });
 
-	afterEach(() => {
-		vi.restoreAllMocks();
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		delete (globalThis as any).onmessage;
-	});
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).onmessage;
+  });
 
-	it("should process successful evaluation without transferables", async () => {
-		await import("../formula.worker");
+  it("should process successful evaluation without transferables", async () => {
+    await import("../formula.worker");
 
-		const mockResult = { type: "success" };
-		evaluateFormulaSyncMock.mockReturnValue(mockResult);
+    const mockResult = { type: "success" };
+    evaluateFormulaSyncMock.mockReturnValue(mockResult);
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const onmessage = (globalThis as any).onmessage;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		onmessage({ data: { formulaId: "test-id" } } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onmessage = (globalThis as any).onmessage;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onmessage({ data: { id: 123, formulaId: "test-id" } } as any);
 
-		expect(evaluateFormulaSyncMock).toHaveBeenCalledWith({
-			formulaId: "test-id",
-		});
-		expect(globalThis.postMessage).toHaveBeenCalledWith(mockResult, []);
-	});
+    expect(evaluateFormulaSyncMock).toHaveBeenCalledWith({
+      id: 123,
+      formulaId: "test-id",
+    });
+    expect(globalThis.postMessage).toHaveBeenCalledWith(
+      { ...mockResult, id: 123 },
+      [],
+    );
+  });
 
-	it("should process successful evaluation with transferables", async () => {
-		await import("../formula.worker");
+  it("should process successful evaluation with transferables", async () => {
+    await import("../formula.worker");
 
-		const buffer1 = new ArrayBuffer(8);
-		const buffer2 = new ArrayBuffer(8);
-		const mockResult = {
-			type: "success",
-			newColumn: { data: { buffer: buffer1 } },
-			sparseXColumn: { data: { buffer: buffer2 } },
-		};
-		evaluateFormulaSyncMock.mockReturnValue(mockResult);
+    const buffer1 = new ArrayBuffer(8);
+    const buffer2 = new ArrayBuffer(8);
+    const mockResult = {
+      type: "success",
+      newColumn: { data: { buffer: buffer1 } },
+      sparseXColumn: { data: { buffer: buffer2 } },
+    };
+    evaluateFormulaSyncMock.mockReturnValue(mockResult);
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const onmessage = (globalThis as any).onmessage;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		onmessage({ data: { formulaId: "test-id" } } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onmessage = (globalThis as any).onmessage;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onmessage({ data: { id: 123, formulaId: "test-id" } } as any);
 
-		expect(evaluateFormulaSyncMock).toHaveBeenCalledWith({
-			formulaId: "test-id",
-		});
-		expect(globalThis.postMessage).toHaveBeenCalledWith(mockResult, [
-			buffer1,
-			buffer2,
-		]);
-	});
+    expect(evaluateFormulaSyncMock).toHaveBeenCalledWith({
+      id: 123,
+      formulaId: "test-id",
+    });
+    expect(globalThis.postMessage).toHaveBeenCalledWith(
+      { ...mockResult, id: 123 },
+      [buffer1, buffer2],
+    );
+  });
 
-	it("should process error evaluation (Error object)", async () => {
-		await import("../formula.worker");
+  it("should process error evaluation (Error object)", async () => {
+    await import("../formula.worker");
 
-		evaluateFormulaSyncMock.mockImplementation(() => {
-			throw new Error("Test Error");
-		});
+    evaluateFormulaSyncMock.mockImplementation(() => {
+      throw new Error("Test Error");
+    });
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const onmessage = (globalThis as any).onmessage;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		onmessage({ data: { formulaId: "test-id" } } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onmessage = (globalThis as any).onmessage;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onmessage({ data: { id: 123, formulaId: "test-id" } } as any);
 
-		expect(globalThis.postMessage).toHaveBeenCalledWith({
-			type: "error",
-			error: "Test Error",
-		});
-	});
+    expect(globalThis.postMessage).toHaveBeenCalledWith({
+      id: 123,
+      type: "error",
+      error: "Test Error",
+    });
+  });
 
-	it("should process error evaluation (string)", async () => {
-		await import("../formula.worker");
+  it("should process error evaluation (string)", async () => {
+    await import("../formula.worker");
 
-		evaluateFormulaSyncMock.mockImplementation(() => {
-			throw "String Error";
-		});
+    evaluateFormulaSyncMock.mockImplementation(() => {
+      throw "String Error";
+    });
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const onmessage = (globalThis as any).onmessage;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		onmessage({ data: { formulaId: "test-id" } } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onmessage = (globalThis as any).onmessage;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onmessage({ data: { id: 123, formulaId: "test-id" } } as any);
 
-		expect(globalThis.postMessage).toHaveBeenCalledWith({
-			type: "error",
-			error: "String Error",
-		});
-	});
+    expect(globalThis.postMessage).toHaveBeenCalledWith({
+      id: 123,
+      type: "error",
+      error: "String Error",
+    });
+  });
 });


### PR DESCRIPTION
🎯 **What:** Updated tests in `formula.worker.ts` to correctly simulate and assert on the `id` field in the worker's message event payload, matching the exact behavior of the target source code.

📊 **Coverage:** Successfully verified both happy (with and without transferables) and error paths (handling full `Error` objects and generic strings), ensuring that request correlation IDs are faithfully extracted and sent back to the client application.

✨ **Result:** Improved test reliability by perfectly aligning the test mock data structures with the application's required, strictly-typed input/output schemas.

---
*PR created automatically by Jules for task [16442044885573897075](https://jules.google.com/task/16442044885573897075) started by @michaelkrisper*