### PR TITLE
🧪 Add error path testing for invalid data URLs in export.ts

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -577,6 +577,18 @@ describe("downloadFile", () => {
 		);
 	});
 
+	it("should throw an error if atob fails on invalid base64 data", () => {
+		expect(() =>
+			downloadFile("data:image/png;base64,invalid!base64", "test.png", "image/png"),
+		).toThrow("Unsafe data URL scheme detected");
+	});
+
+	it("should throw an error if decodeURIComponent fails on invalid data", () => {
+		expect(() =>
+			downloadFile("data:text/plain,%E0%A4%A", "test.txt", "text/plain"),
+		).toThrow("Unsafe data URL scheme detected");
+	});
+
 	it("should throw an error for implicit text/plain data URLs", () => {
 		expect(() => downloadFile("data:,1234", "test.html", "text/html")).toThrow(
 			"Unsafe data URL scheme detected",


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for the error path in `downloadFile` within `src/services/export.ts` when handling invalid data URLs.
📊 **Coverage:** Two specific edge cases are now tested:
1. `atob` failure due to invalid base64 strings.
2. `decodeURIComponent` failure due to invalid percent encoding.
✨ **Result:** Increased branch and statement coverage for `export.ts`, specifically ensuring the try-catch block for data URL decoding accurately throws the safe default error message.

---
*PR created automatically by Jules for task [9585165952029964481](https://jules.google.com/task/9585165952029964481) started by @michaelkrisper*