### PR TITLE
🧪 [testing improvement] Add error path test for putAppState

### DIFF
--- a/src/services/__tests__/persistence.test.ts
+++ b/src/services/__tests__/persistence.test.ts
@@ -469,5 +469,24 @@ describe("persistence", () => {
 			);
 			consoleSpy.mockRestore();
 		});
+
+		it("should catch error when putAppState fails", async () => {
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			const error = new Error("Put failed");
+			const mockDb = {
+				put: vi.fn().mockRejectedValue(error),
+			};
+			openDBMock.mockResolvedValueOnce(mockDb);
+
+			await persistence.saveViewport({ xAxes: [], yAxes: [] });
+
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Failed to save viewport:",
+				expect.any(Error),
+			);
+			consoleSpy.mockRestore();
+		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** Added an error path test for `putAppState` in `persistence.ts`.
📊 **Coverage:** The catch block in `putAppState` when IndexedDB `put` operations fail.
✨ **Result:** Improved test coverage and ensured that failures in saving app state correctly log the error.

---
*PR created automatically by Jules for task [13790112296135108707](https://jules.google.com/task/13790112296135108707) started by @michaelkrisper*