### PR TITLE
🧪 Add missing test for generic calculation failure message

### DIFF
--- a/src/components/Layout/__tests__/CalculatedColumnModal.test.tsx
+++ b/src/components/Layout/__tests__/CalculatedColumnModal.test.tsx
@@ -7,301 +7,334 @@ import type { Dataset } from "../../../services/persistence";
 
 // Mock the graph store
 vi.mock("../../../store/useGraphStore", () => ({
-	useGraphStore: vi.fn(),
+  useGraphStore: vi.fn(),
 }));
 
 // Mock the formula utils (to simplify live validation)
 vi.mock("../../../utils/formula", () => ({
-	compileFormula: vi.fn().mockReturnValue({ error: null }),
+  compileFormula: vi.fn().mockReturnValue({ error: null }),
 }));
 
 describe("CalculatedColumnModal", () => {
-	const mockDataset = {
-		id: "dataset-1",
-		name: "Test Dataset",
-		columns: ["A", "B"],
-		data: [[1, 2]],
-	} as unknown as Dataset;
+  const mockDataset = {
+    id: "dataset-1",
+    name: "Test Dataset",
+    columns: ["A", "B"],
+    data: [[1, 2]],
+  } as unknown as Dataset;
 
-	const mockOnClose = vi.fn();
-	const mockAddCalculatedColumn = vi.fn();
-	const mockRemoveCalculatedColumn = vi.fn();
+  const mockOnClose = vi.fn();
+  const mockAddCalculatedColumn = vi.fn();
+  const mockRemoveCalculatedColumn = vi.fn();
 
-	beforeEach(() => {
-		vi.clearAllMocks();
+  beforeEach(() => {
+    vi.clearAllMocks();
 
-		// Setup useGraphStore mock implementation
-		type StoreState = {
-			addCalculatedColumn: typeof mockAddCalculatedColumn;
-			removeCalculatedColumn: typeof mockRemoveCalculatedColumn;
-		};
-		(useGraphStore as unknown as Mock).mockImplementation(
-			(selector: (state: StoreState) => unknown) => {
-				const state: StoreState = {
-					addCalculatedColumn: mockAddCalculatedColumn,
-					removeCalculatedColumn: mockRemoveCalculatedColumn,
-				};
-				return selector(state);
-			},
-		);
-	});
+    // Setup useGraphStore mock implementation
+    type StoreState = {
+      addCalculatedColumn: typeof mockAddCalculatedColumn;
+      removeCalculatedColumn: typeof mockRemoveCalculatedColumn;
+    };
+    (useGraphStore as unknown as Mock).mockImplementation(
+      (selector: (state: StoreState) => unknown) => {
+        const state: StoreState = {
+          addCalculatedColumn: mockAddCalculatedColumn,
+          removeCalculatedColumn: mockRemoveCalculatedColumn,
+        };
+        return selector(state);
+      },
+    );
+  });
 
-	it("renders correctly for adding a new column", () => {
-		render(
-			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
-		);
+  it("renders correctly for adding a new column", () => {
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
 
-		expect(screen.getByText("Add Calculated Series")).toBeDefined();
-		expect(screen.getByLabelText("Column Name")).toBeDefined();
-		expect(screen.getByLabelText("Formula")).toBeDefined();
-	});
+    expect(screen.getByText("Add Calculated Series")).toBeDefined();
+    expect(screen.getByLabelText("Column Name")).toBeDefined();
+    expect(screen.getByLabelText("Formula")).toBeDefined();
+  });
 
-	it("renders correctly for editing an existing column", () => {
-		render(
-			<CalculatedColumnModal
-				dataset={mockDataset}
-				onClose={mockOnClose}
-				initialName="Calc A"
-				initialFormula="[A] * 2"
-			/>
-		);
+  it("renders correctly for editing an existing column", () => {
+    render(
+      <CalculatedColumnModal
+        dataset={mockDataset}
+        onClose={mockOnClose}
+        initialName="Calc A"
+        initialFormula="[A] * 2"
+      />,
+    );
 
-		expect(screen.getByText("Edit Calculated Series")).toBeDefined();
-		expect(screen.getByDisplayValue("Calc A")).toBeDefined();
-		expect(screen.getByDisplayValue("[A] * 2")).toBeDefined();
-	});
+    expect(screen.getByText("Edit Calculated Series")).toBeDefined();
+    expect(screen.getByDisplayValue("Calc A")).toBeDefined();
+    expect(screen.getByDisplayValue("[A] * 2")).toBeDefined();
+  });
 
-	it("shows error if calculation fails during submit", async () => {
-		mockAddCalculatedColumn.mockResolvedValueOnce({
-			success: false,
-			error: "Formula compilation error",
-		});
-
-		render(
-			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
-		);
-
-		// Fill inputs
-		fireEvent.change(screen.getByLabelText("Column Name"), {
-			target: { value: "New Calc" },
-		});
-		fireEvent.change(screen.getByLabelText("Formula"), {
-			target: { value: "[A] + [B]" },
-		});
-
-		// Submit form
-		fireEvent.click(screen.getByText("Create Series"));
-
-		// Wait for error to display
-		await waitFor(() => {
-			expect(screen.getByText("Formula compilation error")).toBeDefined();
-		});
-
-		expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
-			"dataset-1",
-			"New Calc",
-			"[A] + [B]"
-		);
-		expect(mockOnClose).not.toHaveBeenCalled();
-	});
-
-    it("shows generic error if addCalculatedColumn throws", async () => {
-		mockAddCalculatedColumn.mockRejectedValueOnce(new Error("Network Error"));
-
-		render(
-			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
-		);
-
-		// Fill inputs
-		fireEvent.change(screen.getByLabelText("Column Name"), {
-			target: { value: "New Calc" },
-		});
-		fireEvent.change(screen.getByLabelText("Formula"), {
-			target: { value: "[A] + [B]" },
-		});
-
-		// Submit form
-		fireEvent.click(screen.getByText("Create Series"));
-
-		// Wait for error to display
-		await waitFor(() => {
-			expect(screen.getByText("Network Error")).toBeDefined();
-		});
-
-		expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
-			"dataset-1",
-			"New Calc",
-			"[A] + [B]"
-		);
-		expect(mockOnClose).not.toHaveBeenCalled();
-	});
-
-    it("handles unexpected non-Error throws", async () => {
-        mockAddCalculatedColumn.mockRejectedValueOnce("String error throw");
-
-		render(
-			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
-		);
-
-		// Fill inputs
-		fireEvent.change(screen.getByLabelText("Column Name"), {
-			target: { value: "New Calc" },
-		});
-		fireEvent.change(screen.getByLabelText("Formula"), {
-			target: { value: "[A] + [B]" },
-		});
-
-		// Submit form
-		fireEvent.click(screen.getByText("Create Series"));
-
-		// Wait for error to display
-		await waitFor(() => {
-			expect(screen.getByText("An unexpected error occurred")).toBeDefined();
-		});
-
-		expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
-			"dataset-1",
-			"New Calc",
-			"[A] + [B]"
-		);
-		expect(mockOnClose).not.toHaveBeenCalled();
+  it("shows error if calculation fails during submit", async () => {
+    mockAddCalculatedColumn.mockResolvedValueOnce({
+      success: false,
+      error: "Formula compilation error",
     });
 
-	it("calls onClose on successful calculation", async () => {
-		mockAddCalculatedColumn.mockResolvedValueOnce({ success: true });
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
 
-		render(
-			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
-		);
+    // Fill inputs
+    fireEvent.change(screen.getByLabelText("Column Name"), {
+      target: { value: "New Calc" },
+    });
+    fireEvent.change(screen.getByLabelText("Formula"), {
+      target: { value: "[A] + [B]" },
+    });
 
-		// Fill inputs
-		fireEvent.change(screen.getByLabelText("Column Name"), {
-			target: { value: "New Calc" },
-		});
-		fireEvent.change(screen.getByLabelText("Formula"), {
-			target: { value: "[A] + [B]" },
-		});
+    // Submit form
+    fireEvent.click(screen.getByText("Create Series"));
 
-		// Submit form
-		fireEvent.click(screen.getByText("Create Series"));
+    // Wait for error to display
+    await waitFor(() => {
+      expect(screen.getByText("Formula compilation error")).toBeDefined();
+    });
 
-		// Wait for close to be called
-		await waitFor(() => {
-			expect(mockOnClose).toHaveBeenCalled();
-		});
+    expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
+      "dataset-1",
+      "New Calc",
+      "[A] + [B]",
+    );
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
 
-		expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
-			"dataset-1",
-			"New Calc",
-			"[A] + [B]"
-		);
-	});
+  it("shows default error if calculation fails without error message", async () => {
+    mockAddCalculatedColumn.mockResolvedValueOnce({
+      success: false,
+    });
 
-	it("shows validation error for empty name", () => {
-		render(
-			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
-		);
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
 
-		fireEvent.click(screen.getByText("Create Series"));
+    // Fill inputs
+    fireEvent.change(screen.getByLabelText("Column Name"), {
+      target: { value: "New Calc" },
+    });
+    fireEvent.change(screen.getByLabelText("Formula"), {
+      target: { value: "[A] + [B]" },
+    });
 
-		expect(screen.getByText("Please enter a column name.")).toBeDefined();
-		expect(mockAddCalculatedColumn).not.toHaveBeenCalled();
-	});
+    // Submit form
+    fireEvent.click(screen.getByText("Create Series"));
 
-	it("shows validation error for empty formula", () => {
-		render(
-			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
-		);
+    // Wait for default error to display
+    await waitFor(() => {
+      expect(screen.getByText("Calculation failed")).toBeDefined();
+    });
 
-		fireEvent.change(screen.getByLabelText("Column Name"), {
-			target: { value: "New Calc" },
-		});
+    expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
+      "dataset-1",
+      "New Calc",
+      "[A] + [B]",
+    );
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
 
-		fireEvent.click(screen.getByText("Create Series"));
+  it("shows generic error if addCalculatedColumn throws", async () => {
+    mockAddCalculatedColumn.mockRejectedValueOnce(new Error("Network Error"));
 
-		expect(screen.getByText("Please enter a formula.")).toBeDefined();
-		expect(mockAddCalculatedColumn).not.toHaveBeenCalled();
-	});
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
 
-	it("calls removeCalculatedColumn before addCalculatedColumn in edit mode", async () => {
-		mockAddCalculatedColumn.mockResolvedValueOnce({ success: true });
+    // Fill inputs
+    fireEvent.change(screen.getByLabelText("Column Name"), {
+      target: { value: "New Calc" },
+    });
+    fireEvent.change(screen.getByLabelText("Formula"), {
+      target: { value: "[A] + [B]" },
+    });
 
-		render(
-			<CalculatedColumnModal
-				dataset={mockDataset}
-				onClose={mockOnClose}
-				initialName="Original Name"
-				initialFormula="[A] * 2"
-			/>
-		);
+    // Submit form
+    fireEvent.click(screen.getByText("Create Series"));
 
-		fireEvent.change(screen.getByLabelText("Column Name"), {
-			target: { value: "Updated Name" },
-		});
+    // Wait for error to display
+    await waitFor(() => {
+      expect(screen.getByText("Network Error")).toBeDefined();
+    });
 
-		fireEvent.click(screen.getByText("Create Series"));
+    expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
+      "dataset-1",
+      "New Calc",
+      "[A] + [B]",
+    );
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
 
-		await waitFor(() => {
-			expect(mockRemoveCalculatedColumn).toHaveBeenCalledWith(
-				"dataset-1",
-				"Original Name"
-			);
-			expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
-				"dataset-1",
-				"Updated Name",
-				"[A] * 2"
-			);
-			expect(mockOnClose).toHaveBeenCalled();
-		});
-	});
+  it("handles unexpected non-Error throws", async () => {
+    mockAddCalculatedColumn.mockRejectedValueOnce("String error throw");
 
-	it("auto-closes unbalanced brackets on submit", async () => {
-		mockAddCalculatedColumn.mockResolvedValueOnce({ success: true });
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
 
-		render(
-			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
-		);
+    // Fill inputs
+    fireEvent.change(screen.getByLabelText("Column Name"), {
+      target: { value: "New Calc" },
+    });
+    fireEvent.change(screen.getByLabelText("Formula"), {
+      target: { value: "[A] + [B]" },
+    });
 
-		fireEvent.change(screen.getByLabelText("Column Name"), {
-			target: { value: "Auto Close" },
-		});
-		fireEvent.change(screen.getByLabelText("Formula"), {
-			target: { value: "([A] * 2" },
-		});
+    // Submit form
+    fireEvent.click(screen.getByText("Create Series"));
 
-		fireEvent.click(screen.getByText("Create Series"));
+    // Wait for error to display
+    await waitFor(() => {
+      expect(screen.getByText("An unexpected error occurred")).toBeDefined();
+    });
 
-		await waitFor(() => {
-			expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
-				"dataset-1",
-				"Auto Close",
-				"([A] * 2)"
-			);
-		});
-	});
+    expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
+      "dataset-1",
+      "New Calc",
+      "[A] + [B]",
+    );
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
 
-	it("auto-closes multiple nested unbalanced brackets on submit", async () => {
-		mockAddCalculatedColumn.mockResolvedValueOnce({ success: true });
+  it("calls onClose on successful calculation", async () => {
+    mockAddCalculatedColumn.mockResolvedValueOnce({ success: true });
 
-		render(
-			<CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />
-		);
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
 
-		fireEvent.change(screen.getByLabelText("Column Name"), {
-			target: { value: "Nested Auto Close" },
-		});
-		fireEvent.change(screen.getByLabelText("Formula"), {
-			target: { value: "((([A" },
-		});
+    // Fill inputs
+    fireEvent.change(screen.getByLabelText("Column Name"), {
+      target: { value: "New Calc" },
+    });
+    fireEvent.change(screen.getByLabelText("Formula"), {
+      target: { value: "[A] + [B]" },
+    });
 
-		fireEvent.click(screen.getByText("Create Series"));
+    // Submit form
+    fireEvent.click(screen.getByText("Create Series"));
 
-		await waitFor(() => {
-			expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
-				"dataset-1",
-				"Nested Auto Close",
-				"((([A])))"
-			);
-		});
-	});
+    // Wait for close to be called
+    await waitFor(() => {
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
+      "dataset-1",
+      "New Calc",
+      "[A] + [B]",
+    );
+  });
+
+  it("shows validation error for empty name", () => {
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
+
+    fireEvent.click(screen.getByText("Create Series"));
+
+    expect(screen.getByText("Please enter a column name.")).toBeDefined();
+    expect(mockAddCalculatedColumn).not.toHaveBeenCalled();
+  });
+
+  it("shows validation error for empty formula", () => {
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Column Name"), {
+      target: { value: "New Calc" },
+    });
+
+    fireEvent.click(screen.getByText("Create Series"));
+
+    expect(screen.getByText("Please enter a formula.")).toBeDefined();
+    expect(mockAddCalculatedColumn).not.toHaveBeenCalled();
+  });
+
+  it("calls removeCalculatedColumn before addCalculatedColumn in edit mode", async () => {
+    mockAddCalculatedColumn.mockResolvedValueOnce({ success: true });
+
+    render(
+      <CalculatedColumnModal
+        dataset={mockDataset}
+        onClose={mockOnClose}
+        initialName="Original Name"
+        initialFormula="[A] * 2"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Column Name"), {
+      target: { value: "Updated Name" },
+    });
+
+    fireEvent.click(screen.getByText("Create Series"));
+
+    await waitFor(() => {
+      expect(mockRemoveCalculatedColumn).toHaveBeenCalledWith(
+        "dataset-1",
+        "Original Name",
+      );
+      expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
+        "dataset-1",
+        "Updated Name",
+        "[A] * 2",
+      );
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  it("auto-closes unbalanced brackets on submit", async () => {
+    mockAddCalculatedColumn.mockResolvedValueOnce({ success: true });
+
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Column Name"), {
+      target: { value: "Auto Close" },
+    });
+    fireEvent.change(screen.getByLabelText("Formula"), {
+      target: { value: "([A] * 2" },
+    });
+
+    fireEvent.click(screen.getByText("Create Series"));
+
+    await waitFor(() => {
+      expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
+        "dataset-1",
+        "Auto Close",
+        "([A] * 2)",
+      );
+    });
+  });
+
+  it("auto-closes multiple nested unbalanced brackets on submit", async () => {
+    mockAddCalculatedColumn.mockResolvedValueOnce({ success: true });
+
+    render(
+      <CalculatedColumnModal dataset={mockDataset} onClose={mockOnClose} />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Column Name"), {
+      target: { value: "Nested Auto Close" },
+    });
+    fireEvent.change(screen.getByLabelText("Formula"), {
+      target: { value: "((([A" },
+    });
+
+    fireEvent.click(screen.getByText("Create Series"));
+
+    await waitFor(() => {
+      expect(mockAddCalculatedColumn).toHaveBeenCalledWith(
+        "dataset-1",
+        "Nested Auto Close",
+        "((([A])))",
+      );
+    });
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing error path test to `CalculatedColumnModal.test.tsx` to handle generic calculation failures.
📊 **Coverage:** The test specifically covers the fallback branch (`result.error || "Calculation failed"`) when `addCalculatedColumn` returns `success: false` but provides no explicit `error` message.
✨ **Result:** Improved branch coverage and ensured the fallback error state is reliably tested and maintained, completing the requested testing improvement for `CalculatedColumnModal.tsx`.

---
*PR created automatically by Jules for task [4024449711269246678](https://jules.google.com/task/4024449711269246678) started by @michaelkrisper*