### PR TITLE
🧪 Add error path tests for evaluateFormulaInWorker

### DIFF
--- a/src/store/__tests__/useGraphStore.test.ts
+++ b/src/store/__tests__/useGraphStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Dataset } from "../../services/persistence";
 import { useGraphStore } from "../useGraphStore";
+import * as formulaClient from "../../workers/formulaClient";
 
 class MockWorker {
 	onmessage: ((ev: MessageEvent) => void) | null = null;
@@ -854,5 +855,83 @@ describe("useGraphStore", () => {
 		);
 		// Just to hit the !changed return path exactly
 		expect(useGraphStore.getState().xAxes[0].min).toBe(0);
+	});
+
+	it("should surface Error objects when evaluateFormulaInWorker throws", async () => {
+		const store = useGraphStore.getState();
+		const ds1: Dataset = {
+			id: "ds-1",
+			name: "D1",
+			columns: ["Time", "Val"],
+			data: [
+				{
+					isFloat64: true,
+					refPoint: 0,
+					data: new Float32Array([1]),
+					bounds: { min: 0, max: 1 },
+				},
+				{
+					isFloat64: true,
+					refPoint: 0,
+					data: new Float32Array([1]),
+					bounds: { min: 0, max: 1 },
+				},
+			],
+			rowCount: 1,
+			xAxisColumn: "Time",
+			xAxisId: "axis-1",
+		};
+		store.addDataset(ds1);
+
+		vi.spyOn(formulaClient, "evaluateFormulaInWorker").mockRejectedValueOnce(
+			new Error("Force failed"),
+		);
+
+		const result = await store.addCalculatedColumn(
+			"ds-1",
+			"ErrCol",
+			"[Val] * 5",
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("Force failed");
+	});
+
+	it("should surface stringified errors when evaluateFormulaInWorker throws non-Error", async () => {
+		const store = useGraphStore.getState();
+		const ds1: Dataset = {
+			id: "ds-1",
+			name: "D1",
+			columns: ["Time", "Val"],
+			data: [
+				{
+					isFloat64: true,
+					refPoint: 0,
+					data: new Float32Array([1]),
+					bounds: { min: 0, max: 1 },
+				},
+				{
+					isFloat64: true,
+					refPoint: 0,
+					data: new Float32Array([1]),
+					bounds: { min: 0, max: 1 },
+				},
+			],
+			rowCount: 1,
+			xAxisColumn: "Time",
+			xAxisId: "axis-1",
+		};
+		store.addDataset(ds1);
+
+		vi.spyOn(formulaClient, "evaluateFormulaInWorker").mockRejectedValueOnce(
+			"String error",
+		);
+
+		const result = await store.addCalculatedColumn(
+			"ds-1",
+			"ErrCol",
+			"[Val] * 5",
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("String error");
 	});
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added tests to explicitly cover the error paths in `useGraphStore.ts` when `evaluateFormulaInWorker` rejects or throws an error.

📊 **Coverage:** What scenarios are now tested
1. **Error Object Handling**: Tests that if the worker promise rejects with an `Error` instance, the store correctly returns a failed result object containing the `err.message`.
2. **String Error Handling**: Tests that if the worker promise rejects with a non-Error value (e.g., a primitive string), the store gracefully handles it and falls back to stringifying the error.

✨ **Result:** The improvement in test coverage
The catch block in `addCalculatedColumn` (specifically lines mapping the error message) is now fully covered by targeted, isolated unit tests, increasing the robustness and code coverage of `useGraphStore.ts`.

---
*PR created automatically by Jules for task [13822369488034799309](https://jules.google.com/task/13822369488034799309) started by @michaelkrisper*