### PR TITLE
test: salvage lint-clean AxisInteractionZones + buildXAxisLayout tests

### DIFF
--- a/src/components/Plot/__tests__/AxisInteractionZones.test.tsx
+++ b/src/components/Plot/__tests__/AxisInteractionZones.test.tsx
@@ -1,0 +1,311 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { XAxisInteractionZones, YAxisInteractionZones } from "../AxisInteractionZones";
+import { useGraphStore } from "../../../store/useGraphStore";
+import type { XAxisLayout } from "../chartTypes";
+
+vi.mock("../../../store/useGraphStore", () => ({
+	useGraphStore: {
+		getState: vi.fn(),
+	},
+}));
+
+describe("XAxisInteractionZones", () => {
+	const defaultProps = {
+		xAxesMetrics: [
+			{
+				id: "x1",
+				cumulativeOffset: 0,
+				height: 50,
+				titleBottom: 40,
+				labelBottom: 10,
+				secLabelBottom: 25,
+				total: 50,
+			},
+		],
+		xAxesLayout: [{ id: "x1", title: "Test X Axis" } as unknown as XAxisLayout],
+		padding: { top: 10, right: 20, bottom: 30, left: 40 },
+		editingXAxisId: null,
+		setEditingXAxisId: vi.fn(),
+		themeColors: {
+			fontFamily: "sans-serif",
+			labelColor: "#000",
+			plotBg: "#fff",
+			gridColor: "#ccc",
+		},
+		onWheel: vi.fn(),
+		onMouseDown: vi.fn(),
+		onTouchStart: vi.fn(),
+		onAutoScaleX: vi.fn(),
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders X axis interaction zones", () => {
+		render(<XAxisInteractionZones {...defaultProps} />);
+		expect(screen.getByRole("region", { name: "X-Axis x1 interaction area" })).toBeInTheDocument();
+	});
+
+	it("calls onWheel when wheel event occurs", () => {
+		render(<XAxisInteractionZones {...defaultProps} />);
+		const zone = screen.getByRole("region", { name: "X-Axis x1 interaction area" });
+		fireEvent.wheel(zone);
+		expect(defaultProps.onWheel).toHaveBeenCalledTimes(1);
+		expect(defaultProps.onWheel).toHaveBeenCalledWith(expect.any(Object), { xAxisId: "x1" });
+	});
+
+	it("calls onMouseDown when mouse down event occurs", () => {
+		render(<XAxisInteractionZones {...defaultProps} />);
+		const zone = screen.getByRole("region", { name: "X-Axis x1 interaction area" });
+		fireEvent.mouseDown(zone);
+		expect(defaultProps.onMouseDown).toHaveBeenCalledTimes(1);
+		expect(defaultProps.onMouseDown).toHaveBeenCalledWith(expect.any(Object), { xAxisId: "x1" });
+	});
+
+	it("calls onTouchStart when touch start event occurs", () => {
+		render(<XAxisInteractionZones {...defaultProps} />);
+		const zone = screen.getByRole("region", { name: "X-Axis x1 interaction area" });
+		fireEvent.touchStart(zone);
+		expect(defaultProps.onTouchStart).toHaveBeenCalledTimes(1);
+		expect(defaultProps.onTouchStart).toHaveBeenCalledWith(expect.any(Object), { xAxisId: "x1" });
+	});
+
+	it("calls setEditingXAxisId when double clicking title area", () => {
+		render(<XAxisInteractionZones {...defaultProps} />);
+		const zone = screen.getByRole("region", { name: "X-Axis x1 interaction area" });
+
+		// titleBottom is 40. Bottom 30px is title area.
+		// So yInside >= 40 - 30 = 10.
+		// getBoundingClientRect returns top=0 by default in JSDOM
+		// e.clientY = 15 -> yInside = 15 (>= 10, should edit title)
+		fireEvent.doubleClick(zone, { clientY: 15 });
+		expect(defaultProps.setEditingXAxisId).toHaveBeenCalledWith("x1");
+		expect(defaultProps.onAutoScaleX).not.toHaveBeenCalled();
+	});
+
+	it("calls onAutoScaleX when double clicking outside title area", () => {
+		render(<XAxisInteractionZones {...defaultProps} />);
+		const zone = screen.getByRole("region", { name: "X-Axis x1 interaction area" });
+
+		// yInside < 10 (e.g., 5) should trigger auto scale
+		fireEvent.doubleClick(zone, { clientY: 5 });
+		expect(defaultProps.onAutoScaleX).toHaveBeenCalledWith("x1");
+		expect(defaultProps.setEditingXAxisId).not.toHaveBeenCalled();
+	});
+
+	it("renders input when editingXAxisId matches", () => {
+		render(<XAxisInteractionZones {...defaultProps} editingXAxisId="x1" />);
+		const input = screen.getByDisplayValue("Test X Axis");
+		expect(input).toBeInTheDocument();
+	});
+
+	it("updates X axis name on input blur", () => {
+		const updateXAxisMock = vi.fn();
+		vi.mocked(useGraphStore.getState).mockReturnValue({
+			updateXAxis: updateXAxisMock,
+		} as unknown as ReturnType<typeof useGraphStore.getState>);
+
+		render(<XAxisInteractionZones {...defaultProps} editingXAxisId="x1" />);
+		const input = screen.getByDisplayValue("Test X Axis");
+
+		fireEvent.change(input, { target: { value: "New X Axis Title" } });
+		fireEvent.blur(input);
+
+		expect(updateXAxisMock).toHaveBeenCalledWith("x1", { name: "New X Axis Title" });
+		expect(defaultProps.setEditingXAxisId).toHaveBeenCalledWith(null);
+	});
+
+	it("cancels editing on Escape key", () => {
+		render(<XAxisInteractionZones {...defaultProps} editingXAxisId="x1" />);
+		const input = screen.getByDisplayValue("Test X Axis");
+
+		fireEvent.keyDown(input, { key: "Escape" });
+		expect(defaultProps.setEditingXAxisId).toHaveBeenCalledWith(null);
+	});
+
+	it("blurs input on Enter key", () => {
+		render(<XAxisInteractionZones {...defaultProps} editingXAxisId="x1" />);
+		const input = screen.getByDisplayValue("Test X Axis");
+
+		const blurSpy = vi.spyOn(input, 'blur');
+		fireEvent.keyDown(input, { key: "Enter" });
+
+		expect(blurSpy).toHaveBeenCalled();
+	});
+});
+
+describe("YAxisInteractionZones", () => {
+	const defaultProps = {
+		axes: [
+			{ id: "y1", position: "left" as const },
+			{ id: "y2", position: "right" as const },
+		],
+		axisLayout: {
+			y1: { total: 40, label: 30 },
+			y2: { total: 50, label: 40 },
+		},
+		leftOffsets: { y1: 0 },
+		rightOffsets: { y2: 0 },
+		padding: { top: 10, right: 20, bottom: 30, left: 40 },
+		width: 800,
+		containerRef: {
+			current: { getBoundingClientRect: () => ({ top: 100 }) },
+		} as unknown as React.RefObject<HTMLDivElement | null>,
+		onWheel: vi.fn(),
+		onMouseDown: vi.fn(),
+		onTouchStart: vi.fn(),
+		onAutoScaleY: vi.fn(),
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders Y axis interaction zones", () => {
+		render(<YAxisInteractionZones {...defaultProps} />);
+		expect(screen.getByRole("region", { name: "Y-Axis y1 interaction area" })).toBeInTheDocument();
+		expect(screen.getByRole("region", { name: "Y-Axis y2 interaction area" })).toBeInTheDocument();
+	});
+
+	it("calls onWheel when wheel event occurs", () => {
+		render(<YAxisInteractionZones {...defaultProps} />);
+		const zone = screen.getByRole("region", { name: "Y-Axis y1 interaction area" });
+		fireEvent.wheel(zone);
+		expect(defaultProps.onWheel).toHaveBeenCalledTimes(1);
+		expect(defaultProps.onWheel).toHaveBeenCalledWith(expect.any(Object), { yAxisId: "y1" });
+	});
+
+	it("calls onMouseDown when mouse down event occurs", () => {
+		render(<YAxisInteractionZones {...defaultProps} />);
+		const zone = screen.getByRole("region", { name: "Y-Axis y1 interaction area" });
+		fireEvent.mouseDown(zone);
+		expect(defaultProps.onMouseDown).toHaveBeenCalledTimes(1);
+		expect(defaultProps.onMouseDown).toHaveBeenCalledWith(expect.any(Object), { yAxisId: "y1" });
+	});
+
+	it("calls onTouchStart when touch start event occurs", () => {
+		render(<YAxisInteractionZones {...defaultProps} />);
+		const zone = screen.getByRole("region", { name: "Y-Axis y1 interaction area" });
+		fireEvent.touchStart(zone);
+		expect(defaultProps.onTouchStart).toHaveBeenCalledTimes(1);
+		expect(defaultProps.onTouchStart).toHaveBeenCalledWith(expect.any(Object), { yAxisId: "y1" });
+	});
+
+	it("calls onAutoScaleY when double clicking", () => {
+		render(<YAxisInteractionZones {...defaultProps} />);
+		const zone = screen.getByRole("region", { name: "Y-Axis y1 interaction area" });
+
+		// clientY = 150, container top = 100 -> mouseY = 50
+		fireEvent.doubleClick(zone, { clientY: 150 });
+		expect(defaultProps.onAutoScaleY).toHaveBeenCalledWith("y1", 50);
+	});
+
+	it("falls back to default total width when axisLayout[a.id] is missing", () => {
+		const customProps = {
+			...defaultProps,
+			axes: [{ id: "y3", position: "left" as const }],
+			axisLayout: {}, // missing y3
+			leftOffsets: { y3: 5 },
+		};
+		render(<YAxisInteractionZones {...customProps} />);
+		const zone = screen.getByRole("region", { name: "Y-Axis y3 interaction area" });
+		// xP = padding.left (40) - leftOffsets[a.id] (5) - am.total (40 default) = -5
+		expect(zone).toHaveStyle({ left: "-5px" });
+	});
+
+	it("falls back to 0 when leftOffsets[a.id] is missing", () => {
+		const customProps = {
+			...defaultProps,
+			axes: [{ id: "y4", position: "left" as const }],
+			axisLayout: { y4: { total: 20, label: 10 } },
+			leftOffsets: {}, // missing y4
+		};
+		render(<YAxisInteractionZones {...customProps} />);
+		const zone = screen.getByRole("region", { name: "Y-Axis y4 interaction area" });
+		// xP = padding.left (40) - leftOffsets (0) - total (20) = 20
+		expect(zone).toHaveStyle({ left: "20px" });
+	});
+
+	it("falls back to 0 when rightOffsets[a.id] is missing for right-positioned axis", () => {
+		const customProps = {
+			...defaultProps,
+			axes: [{ id: "y5", position: "right" as const }],
+			axisLayout: { y5: { total: 30, label: 15 } },
+			rightOffsets: {}, // missing y5
+		};
+		render(<YAxisInteractionZones {...customProps} />);
+		const zone = screen.getByRole("region", { name: "Y-Axis y5 interaction area" });
+		// xP = width (800) - padding.right (20) + rightOffsets (0) = 780
+		expect(zone).toHaveStyle({ left: "780px" });
+	});
+
+	it("handles auto-scale when containerRef is null", () => {
+		const customProps = {
+			...defaultProps,
+			containerRef: { current: null },
+		};
+		render(<YAxisInteractionZones {...customProps} />);
+		const zone = screen.getByRole("region", { name: "Y-Axis y1 interaction area" });
+		fireEvent.doubleClick(zone, { clientY: 150 });
+		expect(customProps.onAutoScaleY).toHaveBeenCalledWith("y1", undefined);
+	});
+});
+
+describe("XAxisInteractionZones additional branches", () => {
+	const defaultProps = {
+		xAxesMetrics: [
+			{
+				id: "x2",
+				cumulativeOffset: 0,
+				height: 50,
+				titleBottom: 40,
+				labelBottom: 10,
+				secLabelBottom: 25,
+				total: 50,
+			},
+		],
+		xAxesLayout: [
+			{ id: "x1", title: "Should Not Find Me" } as unknown as XAxisLayout,
+		],
+		padding: { top: 10, right: 20, bottom: 30, left: 40 },
+		editingXAxisId: null,
+		setEditingXAxisId: vi.fn(),
+		themeColors: {
+			fontFamily: "sans-serif",
+			labelColor: "#000",
+			plotBg: "#fff",
+			gridColor: "#ccc",
+		},
+		onWheel: vi.fn(),
+		onMouseDown: vi.fn(),
+		onTouchStart: vi.fn(),
+		onAutoScaleX: vi.fn(),
+	};
+
+	it("falls back to empty string when title is undefined", () => {
+		// xAxesLayout does not have x2, so title fallback "" should hit
+		const customProps = {
+			...defaultProps,
+			editingXAxisId: "x2",
+		};
+		render(<XAxisInteractionZones {...customProps} />);
+		const input = screen.getByRole("textbox");
+		expect(input).toHaveValue("");
+	});
+
+	it("ignores unrelated keys in keydown when editing", () => {
+		const customProps = {
+			...defaultProps,
+			editingXAxisId: "x2",
+		};
+		render(<XAxisInteractionZones {...customProps} />);
+		const input = screen.getByRole("textbox");
+
+		fireEvent.keyDown(input, { key: "Shift" });
+		expect(defaultProps.setEditingXAxisId).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/Plot/buildXAxisLayout.test.ts
+++ b/src/components/Plot/buildXAxisLayout.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildXAxisLayout } from "./buildXAxisLayout";
+import type { Dataset, XAxisConfig } from "../../services/persistence";
+import { calcNumericStep } from "../../utils/axisCalculations";
+
+vi.mock("../../utils/axisCalculations", () => ({
+	calcCategoricalTicks: vi.fn(() => [1, 2, 3]),
+	calcNumericStep: vi.fn(() => 10),
+	calcNumericPrecision: vi.fn(() => 1),
+	calcNumericTicks: vi.fn(() => [0, 10, 20]),
+}));
+
+vi.mock("../../utils/time", () => ({
+	getTimeStep: vi.fn(() => ({ unit: "hour", step: 1 })),
+	generateTimeTicks: vi.fn(() => [{ value: 0, label: "12:00" }]),
+	generateSecondaryLabels: vi.fn(() => [{ value: 0, label: "Jan 1" }]),
+}));
+
+describe("buildXAxisLayout", () => {
+	const defaultAxis: XAxisConfig = {
+		id: "x-axis-1",
+		min: 0,
+		max: 100,
+		xMode: "numeric",
+		showGrid: true,
+		name: "",
+	};
+
+	const defaultDatasets = [
+		{ xAxisColumn: "time" } as Dataset,
+	];
+
+	it("handles zero range or zero width", () => {
+		const result1 = buildXAxisLayout({ ...defaultAxis, min: 100, max: 100 }, 500, "red", undefined, undefined, defaultDatasets);
+		expect(result1.ticks.result).toEqual([]);
+
+		const result2 = buildXAxisLayout(defaultAxis, 0, "red", undefined, undefined, defaultDatasets);
+		expect(result2.ticks.result).toEqual([]);
+	});
+
+	it("handles categorical labels with provided ticks", () => {
+		const result = buildXAxisLayout(defaultAxis, 500, "red", ["A", "B", "C"], [0, 50, 150], defaultDatasets);
+		expect(result.ticks.result).toEqual([0, 50]); // 150 is filtered out
+		expect(result.categoryLabels).toEqual(["A", "B", "C"]);
+	});
+
+	it("handles categorical labels without provided ticks", () => {
+		const result = buildXAxisLayout(defaultAxis, 500, "red", ["A", "B", "C"], undefined, defaultDatasets);
+		expect(result.ticks.result).toEqual([1, 2, 3]); // from mock
+	});
+
+	it("handles numeric layout", () => {
+		const result = buildXAxisLayout(defaultAxis, 500, "red", undefined, undefined, defaultDatasets);
+		expect(result.ticks.result).toEqual([0, 10, 20]); // from mock
+		expect(result.ticks.isXDate).toBe(false);
+	});
+
+	it("handles date layout", () => {
+		const result = buildXAxisLayout({ ...defaultAxis, xMode: "date" }, 500, "red", undefined, undefined, defaultDatasets);
+		expect(result.ticks.result).toEqual([{ value: 0, label: "12:00" }]); // from mock
+		expect(result.ticks.isXDate).toBe(true);
+	});
+
+    it("handles explicit axis name", () => {
+        const result = buildXAxisLayout({ ...defaultAxis, name: "Custom Name" }, 500, "red", undefined, undefined, defaultDatasets);
+        expect(result.title).toBe("Custom Name");
+    });
+
+    it("handles multiple unique columns for default title", () => {
+        const datasets = [
+            { xAxisColumn: "col1" } as Dataset,
+            { xAxisColumn: "col2" } as Dataset,
+            { xAxisColumn: "col1" } as Dataset,
+        ];
+        const result = buildXAxisLayout(defaultAxis, 500, "red", undefined, undefined, datasets);
+        expect(result.title).toBe("col1 / col2");
+    });
+
+	it("handles non-date layout with step <= 0", () => {
+		vi.mocked(calcNumericStep).mockReturnValueOnce(0);
+		const result = buildXAxisLayout(defaultAxis, 500, "red", undefined, undefined, defaultDatasets);
+		expect(result.ticks.result).toEqual([]);
+		expect(result.ticks.step).toBe(1);
+	});
+
+	it("handles fallback to empty title when no columns exist", () => {
+		const result = buildXAxisLayout(defaultAxis, 500, "red", undefined, undefined, []);
+		expect(result.title).toBe("");
+	});
+});


### PR DESCRIPTION
## What

Re-adds the test coverage from #556 (`AxisInteractionZones`) and #554 (`buildXAxisLayout`) in a lint-clean form. Both original PRs were closed because their test files failed `pnpm lint`, which would have broken the lint gate on `master`:

- **#556** — 4× `@typescript-eslint/no-explicit-any`
- **#554** — 2× `@typescript-eslint/no-unused-vars`

## Changes

- `AxisInteractionZones.test.tsx`: replaced the four `as any` casts with typed `as unknown as XAxisLayout` / `as unknown as React.RefObject<HTMLDivElement | null>` casts, and swapped `(useGraphStore.getState as any)` for `vi.mocked(useGraphStore.getState)`.
- `buildXAxisLayout.test.ts`: dropped the unused `(r, w)` params from the `calcNumericStep` mock.

No production code is touched — tests only.

## Verification

- `pnpm lint` — clean (0 errors)
- `tsc -b` — clean
- `vitest run` (both files) — 30 tests pass

This is the "take over the reasonable parts" follow-up to the PR triage of #551–#576.

https://claude.ai/code/session_01SXfXTGYp98P5ukZhQs6GhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXfXTGYp98P5ukZhQs6GhT)_