### PR TITLE
🧹 Refactor unused xAxisId selection logic

### DIFF
--- a/src/store/useGraphStore.ts
+++ b/src/store/useGraphStore.ts
@@ -269,13 +269,10 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
 		let xAxisId = dataset.xAxisId;
 		if (!xAxisId) {
-			const usedXAxisIds = state.datasets.reduce(
-				(acc, d) => (d.xAxisId ? acc.add(d.xAxisId) : acc),
-				new Set<string>(),
-			);
-			const unusedAxis =
-				state.xAxes.find((a) => !usedXAxisIds.has(a.id)) || state.xAxes[0];
-			xAxisId = unusedAxis.id;
+			xAxisId =
+				state.xAxes.find(
+					(a) => !state.datasets.some((d) => d.xAxisId === a.id),
+				)?.id || state.xAxes[0].id;
 		}
 
 		const newDataset: Dataset = { ...dataset, xAxisColumn, xAxisId };


### PR DESCRIPTION
🎯 **What:** Refactored the unused `xAxisId` selection logic in `useGraphStore.ts` to use a more direct and concise approach without intermediate `Set` allocations.
💡 **Why:** The previous logic over-allocated memory by creating a new `Set` to track used axes on every dataset addition when `xAxisId` was not provided. The updated logic accomplishes the exact same fallback behavior cleanly and efficiently using `Array.prototype.find` and `Array.prototype.some`.
✅ **Verification:** Verified that existing test coverage, especially around assigning unique axes correctly (`should assign unique X-axis IDs to new datasets automatically`), continues to pass successfully. Ran the full `vitest` suite, and all 848 tests pass.
✨ **Result:** Improved codebase readability, removed an unnecessary memory allocation, and eliminated a code health warning while preserving correctness.

---
*PR created automatically by Jules for task [3240116137752176245](https://jules.google.com/task/3240116137752176245) started by @michaelkrisper*