### PR TITLE
🧪 Add test for AXIS_EPSILON constant

### DIFF
--- a/src/utils/__tests__/axisCalculations.test.ts
+++ b/src/utils/__tests__/axisCalculations.test.ts
@@ -1,6 +1,7 @@
 // src/utils/__tests__/axisCalculations.test.ts
 import { describe, expect, it } from "vitest";
 import {
+	AXIS_EPSILON,
 	calcCategoricalTicks,
 	calcNumericPrecision,
 	calcNumericStep,
@@ -9,6 +10,12 @@ import {
 	formatAxisLabel,
 	syncAxesWithTargets,
 } from "../axisCalculations";
+
+describe("Constants", () => {
+	it("exports AXIS_EPSILON correctly", () => {
+		expect(AXIS_EPSILON).toBe(1e-10);
+	});
+});
 
 describe("calcNumericStep", () => {
 	it("rounds to nice steps", () => {


### PR DESCRIPTION
🎯 **What:** Added tests for the previously untested AXIS_EPSILON constant in axisCalculations.ts.
📊 **Coverage:** The AXIS_EPSILON exported constant is now verified to be correctly set to 1e-10.
✨ **Result:** Improved test coverage for constants used in floating-point axis bounds comparisons.

---
*PR created automatically by Jules for task [6039448503014677365](https://jules.google.com/task/6039448503014677365) started by @michaelkrisper*