### PR TITLE
🧪 Add test for DEFAULT_X_AXIS_ID

### DIFF
--- a/src/utils/__tests__/axisCalculations.test.ts
+++ b/src/utils/__tests__/axisCalculations.test.ts
@@ -8,7 +8,14 @@ import {
 	calcYAxisTicks,
 	formatAxisLabel,
 	syncAxesWithTargets,
+	DEFAULT_X_AXIS_ID,
 } from "../axisCalculations";
+
+describe("DEFAULT_X_AXIS_ID", () => {
+	it("should have value 'axis-1'", () => {
+		expect(DEFAULT_X_AXIS_ID).toBe("axis-1");
+	});
+});
 
 describe("calcNumericStep", () => {
 	it("rounds to nice steps", () => {


### PR DESCRIPTION
🎯 **What:** Added a missing test for the constant `DEFAULT_X_AXIS_ID` in `axisCalculations.ts`.
📊 **Coverage:** The test ensures that `DEFAULT_X_AXIS_ID` is equal to `"axis-1"`.
✨ **Result:** Improved test coverage by explicitly verifying this constant.

---
*PR created automatically by Jules for task [14574943836506584164](https://jules.google.com/task/14574943836506584164) started by @michaelkrisper*