### PR TITLE
🧪 Add test for COLOR_PALETTE in themes

### DIFF
--- a/src/themes.test.ts
+++ b/src/themes.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { THEME_CYCLE, THEMES, type ThemeName } from "./themes";
+import { COLOR_PALETTE, THEME_CYCLE, THEMES, type ThemeName } from "./themes";
+
+describe("COLOR_PALETTE configuration", () => {
+	it("should have expected length", () => {
+		expect(COLOR_PALETTE).toHaveLength(6);
+	});
+
+	it("should contain valid hex color strings", () => {
+		for (const color of COLOR_PALETTE) {
+			expect(typeof color).toBe("string");
+			expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+		}
+	});
+});
 
 describe("THEMES configuration", () => {
 	it("should have all themes from THEMES included in THEME_CYCLE", () => {


### PR DESCRIPTION
🎯 **What:** Added tests for the previously untested `COLOR_PALETTE` constant in `src/themes.ts`.
📊 **Coverage:** Covered the length of the array and verified that all elements are valid 6-character hex colors.
✨ **Result:** Improved test coverage and ensuring `COLOR_PALETTE` maintains its expected structure.

---
*PR created automatically by Jules for task [17692168368733523903](https://jules.google.com/task/17692168368733523903) started by @michaelkrisper*