### PR TITLE
🧹 [Code Health] Replace console.error with Error throw for fragment shader in WebGLRenderer

### DIFF
--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -521,8 +521,7 @@ export const WebGLRenderer = React.memo(
 			gl.shaderSource(fs, FRAGMENT_SHADER_SOURCE);
 			gl.compileShader(fs);
 			if (!gl.getShaderParameter(fs, gl.COMPILE_STATUS)) {
-				console.error("FS Error:", gl.getShaderInfoLog(fs));
-				return;
+				throw new Error(`FS Error: ${gl.getShaderInfoLog(fs)}`);
 			}
 
 			const program = gl.createProgram();


### PR DESCRIPTION
🎯 **What:** Replaced direct `console.error` with `throw new Error` in the fragment shader compilation check.
💡 **Why:** Improves code health and maintainability by failing fast instead of silently returning on WebGL errors.
✅ **Verification:** Verified that tests pass and the logic handles compilation failure properly.
✨ **Result:** Better error observability and consistency for shader compilation.

---
*PR created automatically by Jules for task [5046318482150013814](https://jules.google.com/task/5046318482150013814) started by @michaelkrisper*