### PR TITLE
🧹 [Refactor] Convert file-level description to JSDoc for syncStoreUpdates

### DIFF
--- a/src/components/Plot/syncStoreUpdates.ts
+++ b/src/components/Plot/syncStoreUpdates.ts
@@ -1,9 +1,3 @@
-// Reconcile axis-range updates produced during interactive panning/zooming
-// with the persisted store state. Filters out updates that match the current
-// store values within AXIS_EPSILON and only triggers a batched commit if any
-// axis actually moved. Extracted from ChartContainer so the filtering can be
-// unit-tested without spinning up the store.
-
 import { AXIS_EPSILON } from "../../utils/axisCalculations";
 
 export type AxisRangeUpdate = Record<string, { min: number; max: number }>;
@@ -20,6 +14,13 @@ interface StoreLike {
 	batchUpdateAxes(xUpdates: AxisRangeUpdate, yUpdates: AxisRangeUpdate): void;
 }
 
+/**
+ * Reconcile axis-range updates produced during interactive panning/zooming
+ * with the persisted store state. Filters out updates that match the current
+ * store values within AXIS_EPSILON and only triggers a batched commit if any
+ * axis actually moved. Extracted from ChartContainer so the filtering can be
+ * unit-tested without spinning up the store.
+ */
 export function syncStoreUpdates(
 	state: StoreLike,
 	xUpdates: AxisRangeUpdate,


### PR DESCRIPTION
🎯 **What:** Converted a file-level block comment into a proper JSDoc comment attached directly to the `syncStoreUpdates` function.
     💡 **Why:** The file-level comment triggered a false positive in code health checks (commented-out variable declaration) and improperly documented the file instead of the specific exported function. Using JSDoc properly attributes the documentation to the function itself and avoids linter false-positives.
     ✅ **Verification:** Ran `pnpm run lint` and `pnpm run test` to verify that linting and unit tests pass successfully without any regressions.
     ✨ **Result:** Improved code health by resolving the false-positive and improved maintainability by properly documenting the function interface.

---
*PR created automatically by Jules for task [17822149360716248893](https://jules.google.com/task/17822149360716248893) started by @michaelkrisper*