### PR TITLE
🧹 Replace console.error with thrown errors in WebGLRenderer

### DIFF
--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -512,8 +512,7 @@ export const WebGLRenderer = React.memo(
 			gl.shaderSource(vs, VERTEX_SHADER_SOURCE);
 			gl.compileShader(vs);
 			if (!gl.getShaderParameter(vs, gl.COMPILE_STATUS)) {
-				console.error("VS Error:", gl.getShaderInfoLog(vs));
-				return;
+				throw new Error(`VS Error: ${gl.getShaderInfoLog(vs)}`);
 			}
 
 			const fs = gl.createShader(gl.FRAGMENT_SHADER);
@@ -521,8 +520,7 @@ export const WebGLRenderer = React.memo(
 			gl.shaderSource(fs, FRAGMENT_SHADER_SOURCE);
 			gl.compileShader(fs);
 			if (!gl.getShaderParameter(fs, gl.COMPILE_STATUS)) {
-				console.error("FS Error:", gl.getShaderInfoLog(fs));
-				return;
+				throw new Error(`FS Error: ${gl.getShaderInfoLog(fs)}`);
 			}
 
 			const program = gl.createProgram();
@@ -531,8 +529,7 @@ export const WebGLRenderer = React.memo(
 			gl.attachShader(program, fs);
 			gl.linkProgram(program);
 			if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-				console.error("Link Error:", gl.getProgramInfoLog(program));
-				return;
+				throw new Error(`Link Error: ${gl.getProgramInfoLog(program)}`);
 			}
 			programRef.current = program;
 			const locs: WebGLLocations = {


### PR DESCRIPTION
🎯 **What:** Replaced direct `console.error` logging with thrown errors (`throw new Error(...)`) in `src/components/Plot/WebGLRenderer.tsx` for WebGL shader and program compilation failures.
💡 **Why:** This improves maintainability and avoids "log and swallow" anti-patterns. By throwing an error, we allow the application's top-level `ErrorBoundary` to properly catch and handle WebGL initialization failures instead of silently failing and leaving the canvas in an invalid state while spamming the console.
✅ **Verification:** Replaced the console errors with `throw new Error(...)`, ran `git diff` to verify the code changes, and executed the full test suite (`pnpm test`) to ensure no functionality is broken.
✨ **Result:** The codebase is cleaner and handles WebGL initialization errors more gracefully by allowing them to bubble up to error boundaries rather than just logging to the console.

---
*PR created automatically by Jules for task [6184752615937005224](https://jules.google.com/task/6184752615937005224) started by @michaelkrisper*