### PR TITLE
🧪 Add tests for getAxisById

### DIFF
--- a/src/utils/__tests__/axisCalculations.test.ts
+++ b/src/utils/__tests__/axisCalculations.test.ts
@@ -7,6 +7,7 @@ import {
 	calcNumericTicks,
 	calcYAxisTicks,
 	formatAxisLabel,
+	getAxisById,
 	syncAxesWithTargets,
 } from "../axisCalculations";
 
@@ -242,5 +243,37 @@ describe("syncAxesWithTargets", () => {
 		const updates = syncAxesWithTargets(state, targetXAxes, targetYs);
 		expect(updates.xUpdates).toEqual({ x1: { min: -10, max: 110 } });
 		expect(updates.yUpdates).toEqual({});
+	});
+});
+
+describe("getAxisById", () => {
+	it("returns axis via direct lookup for canonical IDs", () => {
+		const axes = [{ id: "axis-1" }, { id: "axis-2" }, { id: "axis-3" }];
+		expect(getAxisById(axes, "axis-2")).toBe(axes[1]);
+	});
+
+	it("falls back to .find() for out-of-order arrays", () => {
+		const axes = [{ id: "axis-3" }, { id: "axis-1" }, { id: "axis-2" }];
+		expect(getAxisById(axes, "axis-1")).toBe(axes[1]);
+	});
+
+	it("falls back to .find() for non-canonical IDs", () => {
+		const axes = [{ id: "custom-id-1" }, { id: "custom-id-2" }];
+		expect(getAxisById(axes, "custom-id-2")).toBe(axes[1]);
+	});
+
+	it("returns undefined when the ID does not exist in the array", () => {
+		const axes = [{ id: "axis-1" }, { id: "axis-2" }];
+		expect(getAxisById(axes, "axis-3")).toBeUndefined();
+		expect(getAxisById(axes, "custom-id")).toBeUndefined();
+	});
+
+	it("returns undefined when the array is empty", () => {
+		expect(getAxisById([], "axis-1")).toBeUndefined();
+	});
+
+	it("handles malformed canonical IDs by falling back to find", () => {
+		const axes = [{ id: "axis-abc" }];
+		expect(getAxisById(axes, "axis-abc")).toBe(axes[0]);
 	});
 });


### PR DESCRIPTION
🎯 **What:** Added comprehensive tests for the `getAxisById` utility function in `src/utils/axisCalculations.ts` to improve testing coverage.
📊 **Coverage:** Covered direct lookups for canonical IDs, fallbacks to `.find()` for out-of-order arrays and non-canonical IDs, undefined responses for non-existent IDs and empty arrays, and handling of malformed canonical IDs.
✨ **Result:** Increased code reliability and established a testing baseline for this pure function, ensuring safe future refactoring.

---
*PR created automatically by Jules for task [11193652807702893149](https://jules.google.com/task/11193652807702893149) started by @michaelkrisper*