### PR TITLE
🧹 [code health] replace direct console.error with thrown Errors in WebGL renderer

### DIFF
--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -512,8 +512,7 @@ export const WebGLRenderer = React.memo(
 			gl.shaderSource(vs, VERTEX_SHADER_SOURCE);
 			gl.compileShader(vs);
 			if (!gl.getShaderParameter(vs, gl.COMPILE_STATUS)) {
-				console.error("VS Error:", gl.getShaderInfoLog(vs));
-				return;
+				throw new Error(`VS Error: ${gl.getShaderInfoLog(vs)}`);
 			}
 
 			const fs = gl.createShader(gl.FRAGMENT_SHADER);
@@ -521,8 +520,7 @@ export const WebGLRenderer = React.memo(
 			gl.shaderSource(fs, FRAGMENT_SHADER_SOURCE);
 			gl.compileShader(fs);
 			if (!gl.getShaderParameter(fs, gl.COMPILE_STATUS)) {
-				console.error("FS Error:", gl.getShaderInfoLog(fs));
-				return;
+				throw new Error(`FS Error: ${gl.getShaderInfoLog(fs)}`);
 			}
 
 			const program = gl.createProgram();
@@ -531,8 +529,7 @@ export const WebGLRenderer = React.memo(
 			gl.attachShader(program, fs);
 			gl.linkProgram(program);
 			if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-				console.error("Link Error:", gl.getProgramInfoLog(program));
-				return;
+				throw new Error(`Link Error: ${gl.getProgramInfoLog(program)}`);
 			}
 			programRef.current = program;
 			const locs: WebGLLocations = {


### PR DESCRIPTION
🎯 **What:** Replaced direct `console.error` calls with thrown `Error` objects in `src/components/Plot/WebGLRenderer.tsx` when WebGL shaders or programs fail to compile/link.
💡 **Why:** By throwing an Error, React's ErrorBoundary can properly catch and display the rendering failure, rather than silently failing and leaving the user with a broken UI while the error is hidden in the console.
✅ **Verification:** Replaced the code, ran tests, and verified via `git diff` that no behavior outside of error handling is altered.
✨ **Result:** Improved robustness and visibility of WebGL initialization errors.

---
*PR created automatically by Jules for task [7827314796813081917](https://jules.google.com/task/7827314796813081917) started by @michaelkrisper*