### PR TITLE
🧹 [Code Health] Replace magic numbers with time constants in formatDate

### DIFF
--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -4,6 +4,7 @@ import { getColumnIndex } from "../utils/columns";
 import { worldToScreen } from "../utils/coords";
 import { m4Float32 } from "../utils/decimation";
 import { escapeHTML } from "../utils/dom";
+import { UNIT_SECONDS } from "../utils/time";
 import type {
 	Dataset,
 	SeriesConfig,
@@ -434,8 +435,8 @@ export const exportToSVG = (
  */
 export const formatDate = (val: number, step: number) => {
 	const d = new Date(val * 1000);
-	if (step >= 86400) return `${d.getDate()}.${d.getMonth() + 1}.`;
-	if (step >= 3600) return `${d.getHours()}:00`;
+	if (step >= UNIT_SECONDS.day) return `${d.getDate()}.${d.getMonth() + 1}.`;
+	if (step >= UNIT_SECONDS.hour) return `${d.getHours()}:00`;
 	return (
 		String(d.getHours()).padStart(2, "0") +
 		":" +

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -21,7 +21,7 @@ export interface TimeTick {
 const MAX_TIME_TICKS = 500;
 const MAX_SECONDARY_LABELS = 100;
 
-const UNIT_SECONDS = {
+export const UNIT_SECONDS = {
 	second: 1,
 	minute: 60,
 	hour: 3600,


### PR DESCRIPTION
- 🎯 **What:** Replaced magic numbers (`86400` and `3600`) with `UNIT_SECONDS.day` and `UNIT_SECONDS.hour` in `src/services/export.ts` and exported `UNIT_SECONDS` from `src/utils/time.ts`.
- 💡 **Why:** By extracting these magic numbers and using existing time unit constants, readability is improved and the values are self-documenting, making it clear they represent the number of seconds in a day and an hour. This adheres to DRY principles.
- ✅ **Verification:** Verified via `git diff` and full test suite execution (`pnpm run test`) to ensure the formatting logic remained functionally identical and no regressions were introduced.
- ✨ **Result:** Improved code health and maintainability without altering existing functionality.

---
*PR created automatically by Jules for task [3691670876815544982](https://jules.google.com/task/3691670876815544982) started by @michaelkrisper*