### PR TITLE
🧹 [Code Health] Remove redundant console.error from ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -31,7 +31,6 @@ export default class ErrorBoundary extends React.Component<Props, State> {
 			error,
 			errorInfo,
 		});
-		console.error("[ErrorBoundary]", error, errorInfo.componentStack);
 	}
 
 	handleReset = () => {


### PR DESCRIPTION
🎯 **What:** Removed explicit `console.error` logging from `ErrorBoundary`'s `componentDidCatch` method.
💡 **Why:** React automatically logs errors caught by Error Boundaries in development mode, so this explicit logging is redundant and can cause duplicate noise. It's better to let React or external logging services handle this properly.
✅ **Verification:** Visually verified the code removal using `git diff`, ran the local test `pnpm run test src/components/__tests__/ErrorBoundary.test.tsx`, and passed the complete test suite.
✨ **Result:** Improved codebase maintainability by reducing redundant, manually managed logging logic without altering functional component behavior.

---
*PR created automatically by Jules for task [10260062016749054919](https://jules.google.com/task/10260062016749054919) started by @michaelkrisper*