### PR TITLE
🧪 Add tests for confirmImport catch block in useDataImport

### DIFF
--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -813,4 +813,43 @@ describe("useDataImport hook", () => {
 
     global.FileReader = originalFileReader;
   });
+
+  it.each([
+    { label: "an Error", thrown: new Error("parseDataInWorker failed"), expected: "parseDataInWorker failed" },
+    { label: "a string", thrown: "String error in parseDataInWorker", expected: "String error in parseDataInWorker" },
+  ])("surfaces $label thrown by parseDataInWorker during confirmImport", async ({ thrown, expected }) => {
+    const { result } = renderHook(() => useDataImport());
+    const file = new File(["dummy"], "test.csv", { type: "text/csv" });
+
+    const originalFileReader = global.FileReader;
+    class MockFileReader {
+      onload: ((event: { target: { result: string } }) => void) | null = null;
+      readAsText() {
+        this.onload?.({ target: { result: "data" } });
+      }
+    }
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
+
+    await act(async () => {
+      await result.current.importFile(file);
+    });
+
+    const settings: ImportSettings = {
+      delimiter: ",",
+      decimalPoint: ".",
+      startRow: 1,
+      columnConfigs: [],
+    };
+
+    vi.mocked(parseDataInWorker).mockRejectedValueOnce(thrown);
+
+    await act(async () => {
+      await result.current.confirmImport(settings);
+    });
+
+    expect(result.current.error).toBe(expected);
+    expect(result.current.isImporting).toBe(false);
+
+    global.FileReader = originalFileReader;
+  });
 });


### PR DESCRIPTION
* 🎯 **What:** The testing gap for the error path inside the `confirmImport` function block of `useDataImport.ts`.
* 📊 **Coverage:** The error path handling inside `confirmImport` is now fully tested, covering both the `Error` instance path and the non-Error primitive (string) type-checking fallback paths.
* ✨ **Result:** Branch test coverage is complete and improved for the hook error handling mechanisms.

---
*PR created automatically by Jules for task [17030799490001039329](https://jules.google.com/task/17030799490001039329) started by @michaelkrisper*