### PR TITLE
🧪 Add missing error path test in export.ts

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -631,6 +631,26 @@ describe("downloadFile", () => {
 		).toThrow("Unsafe data URL scheme detected");
 	});
 
+	it("should throw an error and preserve cause if URL.createObjectURL fails", () => {
+		const mockError = new Error("Mock creation error");
+		vi.spyOn(URL, "createObjectURL").mockImplementationOnce(() => {
+			throw mockError;
+		});
+
+		expect.hasAssertions();
+		try {
+			downloadFile(
+				"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+				"test.png",
+				"image/png",
+			);
+		} catch (error) {
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toBe("Unsafe data URL scheme detected");
+			expect((error as Error).cause).toBe(mockError);
+		}
+	});
+
 	it("should handle normal strings using Blob correctly", () => {
 		const cleanup = downloadFile("Hello, world!", "test.txt", "text/plain");
 


### PR DESCRIPTION
🎯 **What:** Addressed a testing gap in `export.ts` where the `catch` block handling errors during `URL.createObjectURL` execution for data URLs lacked test coverage.
📊 **Coverage:** Added a test scenario in `export.test.ts` that mocks `URL.createObjectURL` to throw an error, verifying that `downloadFile` correctly catches the error, throws an "Unsafe data URL scheme detected" error, and preserves the original error in the `cause` property.
✨ **Result:** Achieved higher test coverage for `export.ts` and ensured that error reporting correctly wraps the underlying problem with the expected structure.

---
*PR created automatically by Jules for task [17180273154372900522](https://jules.google.com/task/17180273154372900522) started by @michaelkrisper*