### PR TITLE
🧪 Add error path testing for renderBackend

### DIFF
--- a/fix-ts.patch
+++ b/fix-ts.patch
@@ -1,0 +1,17 @@
+<<<<<<< SEARCH
+		// Simulate worker error with a message
+		worker.onerror({ message: "Worker thread crashed" } as ErrorEvent);
+		expect(errorSpy).toHaveBeenCalledWith("Render worker error:", "Worker thread crashed");
+
+		// Simulate worker error without a message
+		worker.onerror({ type: "error" } as any);
+		expect(errorSpy).toHaveBeenCalledWith("Render worker error:", { type: "error" });
+=======
+		// Simulate worker error with a message
+		(worker.onerror as (ev: unknown) => void)({ message: "Worker thread crashed" } as ErrorEvent);
+		expect(errorSpy).toHaveBeenCalledWith("Render worker error:", "Worker thread crashed");
+
+		// Simulate worker error without a message
+		(worker.onerror as (ev: unknown) => void)({ type: "error" } as any);
+		expect(errorSpy).toHaveBeenCalledWith("Render worker error:", { type: "error" });
+>>>>>>> REPLACE

--- a/fix.patch
+++ b/fix.patch
@@ -1,0 +1,29 @@
+--- src/components/Plot/__tests__/renderBackend.test.ts
++++ src/components/Plot/__tests__/renderBackend.test.ts
+@@ -221,7 +221,7 @@
+		const gl = makeGl2Mock();
+		const canvas = withOffscreen(makeCanvasMock(gl));
+
+-		const backend = acquireRenderBackend(canvas, viewport, [0, 0, 0]);
++		acquireRenderBackend(canvas, viewport, [0, 0, 0]);
+		expect(errorSpy).toHaveBeenCalledWith(
+			"OffscreenCanvas render worker unavailable, falling back to main-thread rendering:",
+			expect.any(Error)
+@@ -236,7 +236,7 @@
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.stubGlobal("Worker", FakeWorker);
+		const canvas = withOffscreen(makeCanvasMock(null));
+-		const backend = acquireRenderBackend(canvas, viewport, [0, 0, 0]);
++		acquireRenderBackend(canvas, viewport, [0, 0, 0]);
+
+		const worker = FakeWorker.instances[FakeWorker.instances.length - 1];
+
+@@ -248,7 +248,7 @@
+
+		// Simulate worker error without a message
+		if (typeof worker.onerror === "function") {
+-			worker.onerror({ type: "error" } as any);
++			worker.onerror({ type: "error" } as unknown as ErrorEvent);
+		}
+		expect(errorSpy).toHaveBeenCalledWith("Render worker error:", { type: "error" });
+	});

--- a/src/components/Plot/__tests__/renderBackend.test.ts
+++ b/src/components/Plot/__tests__/renderBackend.test.ts
@@ -209,3 +209,48 @@ describe("acquire/release lifecycle (StrictMode safety)", () => {
 		expect(FakeWorker.instances[0].terminate).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe("Worker initialization failure", () => {
+	it("falls back to DirectBackend if Worker creation throws", () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		class ThrowingWorker {
+			constructor() {
+				throw new Error("Worker blocked by CSP");
+			}
+		}
+		vi.stubGlobal("Worker", ThrowingWorker);
+		const gl = makeGl2Mock();
+		const canvas = withOffscreen(makeCanvasMock(gl));
+
+		const backend = acquireRenderBackend(canvas, viewport, [0, 0, 0]);
+		expect(errorSpy).toHaveBeenCalledWith(
+			"OffscreenCanvas render worker unavailable, falling back to main-thread rendering:",
+			expect.any(Error)
+		);
+		expect(canvas.getContext).toHaveBeenCalled();
+		releaseRenderBackend(canvas);
+	});
+});
+
+describe("Worker runtime errors", () => {
+	it("logs worker runtime errors to console.error", () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.stubGlobal("Worker", FakeWorker);
+		const canvas = withOffscreen(makeCanvasMock(null));
+		const backend = acquireRenderBackend(canvas, viewport, [0, 0, 0]);
+
+		const worker = FakeWorker.instances[FakeWorker.instances.length - 1];
+
+		// Simulate worker error with a message
+		if (typeof worker.onerror === "function") {
+			worker.onerror({ message: "Worker thread crashed" } as ErrorEvent);
+		}
+		expect(errorSpy).toHaveBeenCalledWith("Render worker error:", "Worker thread crashed");
+
+		// Simulate worker error without a message
+		if (typeof worker.onerror === "function") {
+			worker.onerror({ type: "error" } as any);
+		}
+		expect(errorSpy).toHaveBeenCalledWith("Render worker error:", { type: "error" });
+	});
+});

--- a/src/components/Plot/__tests__/renderBackend.test.ts.orig
+++ b/src/components/Plot/__tests__/renderBackend.test.ts.orig
@@ -222,7 +222,7 @@ describe("Worker initialization failure", () => {
 		const gl = makeGl2Mock();
 		const canvas = withOffscreen(makeCanvasMock(gl));
 
-		acquireRenderBackend(canvas, viewport, [0, 0, 0]);
+		const backend = acquireRenderBackend(canvas, viewport, [0, 0, 0]);
 		expect(errorSpy).toHaveBeenCalledWith(
 			"OffscreenCanvas render worker unavailable, falling back to main-thread rendering:",
 			expect.any(Error)
@@ -237,7 +237,7 @@ describe("Worker runtime errors", () => {
 		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		vi.stubGlobal("Worker", FakeWorker);
 		const canvas = withOffscreen(makeCanvasMock(null));
-		acquireRenderBackend(canvas, viewport, [0, 0, 0]);
+		const backend = acquireRenderBackend(canvas, viewport, [0, 0, 0]);
 
 		const worker = FakeWorker.instances[FakeWorker.instances.length - 1];
 
@@ -249,7 +249,7 @@ describe("Worker runtime errors", () => {
 
 		// Simulate worker error without a message
 		if (typeof worker.onerror === "function") {
-			worker.onerror({ type: "error" } as unknown as ErrorEvent);
+			worker.onerror({ type: "error" } as any);
 		}
 		expect(errorSpy).toHaveBeenCalledWith("Render worker error:", { type: "error" });
 	});


### PR DESCRIPTION
- 🎯 **What:** Added tests to cover the Worker creation failure and runtime error paths in `renderBackend.ts`.
- 📊 **Coverage:** Covered Worker constructor exception handling (falling back to main-thread DirectBackend) and worker runtime errors via `onerror` testing.
- ✨ **Result:** Improved robustness by explicitly validating how we recover from and log worker-related errors, preventing silent failures.

---
*PR created automatically by Jules for task [15873772622082472108](https://jules.google.com/task/15873772622082472108) started by @michaelkrisper*