### PR TITLE
🧪 Add missing error path tests for loadAppState

### DIFF
--- a/src/services/__tests__/persistence.test.ts
+++ b/src/services/__tests__/persistence.test.ts
@@ -488,5 +488,51 @@ describe("persistence", () => {
 			);
 			consoleSpy.mockRestore();
 		});
+
+		it("should catch error when loadAppState fails entirely", async () => {
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			const error = new Error("Load failed");
+			const mockDb = {
+				get: vi.fn().mockRejectedValue(error),
+			};
+			openDBMock.mockResolvedValueOnce(mockDb);
+
+			const result = await persistence.loadAppState();
+
+			expect(result).toBeNull();
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Failed to load state:",
+				expect.any(Error),
+			);
+			consoleSpy.mockRestore();
+		});
+
+		it("should log error on invalid legacy state", async () => {
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+
+			const invalidLegacy = { xAxes: "invalid" };
+
+			const mockDb = {
+				get: vi
+					.fn()
+					.mockResolvedValueOnce(undefined)
+					.mockResolvedValueOnce(undefined)
+					.mockResolvedValueOnce(invalidLegacy),
+			};
+			openDBMock.mockResolvedValueOnce(mockDb);
+
+			const result = await persistence.loadAppState();
+
+			expect(result).toBeNull();
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Invalid legacy state:",
+				expect.any(Object),
+			);
+			consoleSpy.mockRestore();
+		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: The `loadAppState` function in `src/services/persistence.ts` had missing test coverage for its outer error handling (`Failed to load state:`) and when migrating an invalid legacy state.
📊 **Coverage:** Added two new test cases in `src/services/__tests__/persistence.test.ts` to mock and trigger these specific failure conditions.
✨ **Result:** Increased branch and statement test coverage for `persistence.ts`, ensuring robust error handling and fallback behavior when application state loading fails.

---
*PR created automatically by Jules for task [5891561395271834743](https://jules.google.com/task/5891561395271834743) started by @michaelkrisper*