### PR TITLE
🔒 Fix XSS vulnerability in SVG path data

### DIFF
--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -278,7 +278,7 @@ export const exportToSVG = (
 				let dashArray = "";
 				if (s.lineStyle === "dashed") dashArray = 'stroke-dasharray="8,6"';
 				else if (s.lineStyle === "dotted") dashArray = 'stroke-dasharray="2,4"';
-				svg += `<path d="${pathData.trim()}" fill="none" stroke="${escapeHTML(s.lineColor)}" stroke-width="1" ${dashArray} />`;
+				svg += `<path d="${escapeHTML(pathData.trim())}" fill="none" stroke="${escapeHTML(s.lineColor)}" stroke-width="1" ${dashArray} />`;
 			}
 		}
 		if (s.pointStyle !== "none") {


### PR DESCRIPTION
🎯 **What:** Escaped the `pathData` string when generating SVG paths to prevent Cross-Site Scripting (XSS).
⚠️ **Risk:** Unescaped path data could allow an attacker to inject malicious scripts into the generated SVG output, potentially leading to XSS when the SVG is rendered or downloaded by a user.
🛡️ **Solution:** Passed `pathData.trim()` through the existing `escapeHTML` utility before concatenating it into the SVG string, ensuring any malicious payload is properly neutralized.

---
*PR created automatically by Jules for task [845042335961219308](https://jules.google.com/task/845042335961219308) started by @michaelkrisper*