### PR TITLE
🧹 Fix Magic Number Extraction in Export Service

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { THEMES } from "../../themes";
 import { downloadFile, exportToPNG, exportToSVG, formatDate } from "../export";
+import { UNIT_SECONDS } from "../../utils/time";
 import type {
 	Dataset,
 	SeriesConfig,
@@ -662,14 +663,14 @@ describe("formatDate", () => {
 	it("formats correctly for daily steps (>= 86400)", () => {
 		const date = new Date(2023, 0, 15, 12, 0, 0);
 		const val = Math.floor(date.getTime() / 1000);
-		expect(formatDate(val, 86400)).toBe("15.1.");
+		expect(formatDate(val, UNIT_SECONDS.day)).toBe("15.1.");
 		expect(formatDate(val, 90000)).toBe("15.1.");
 	});
 
 	it("formats correctly for hourly steps (>= 3600 but < 86400)", () => {
 		const date = new Date(2023, 0, 15, 9, 30, 0);
 		const val = Math.floor(date.getTime() / 1000);
-		expect(formatDate(val, 3600)).toBe("9:00");
+		expect(formatDate(val, UNIT_SECONDS.hour)).toBe("9:00");
 		expect(formatDate(val, 7200)).toBe("9:00");
 	});
 

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -4,6 +4,7 @@ import { getColumnIndex } from "../utils/columns";
 import { worldToScreen } from "../utils/coords";
 import { m4Float32 } from "../utils/decimation";
 import { escapeHTML } from "../utils/dom";
+import { UNIT_SECONDS } from "../utils/time";
 import type {
 	Dataset,
 	SeriesConfig,
@@ -434,8 +435,8 @@ export const exportToSVG = (
  */
 export const formatDate = (val: number, step: number) => {
 	const d = new Date(val * 1000);
-	if (step >= 86400) return `${d.getDate()}.${d.getMonth() + 1}.`;
-	if (step >= 3600) return `${d.getHours()}:00`;
+	if (step >= UNIT_SECONDS.day) return `${d.getDate()}.${d.getMonth() + 1}.`;
+	if (step >= UNIT_SECONDS.hour) return `${d.getHours()}:00`;
 	return (
 		String(d.getHours()).padStart(2, "0") +
 		":" +

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -21,7 +21,7 @@ export interface TimeTick {
 const MAX_TIME_TICKS = 500;
 const MAX_SECONDARY_LABELS = 100;
 
-const UNIT_SECONDS = {
+export const UNIT_SECONDS = {
 	second: 1,
 	minute: 60,
 	hour: 3600,


### PR DESCRIPTION
* 🎯 **What:** Replaced the magic numbers `86400` and `3600` in `formatDate` from `src/services/export.ts` with the exported constant `UNIT_SECONDS.day` and `UNIT_SECONDS.hour` from `src/utils/time.ts`.
* 💡 **Why:** This improves the maintainability and readability of the codebase by replacing opaque literals with self-explanatory constants, ensuring consistency across modules.
* ✅ **Verification:** Visually verified the changes with `git diff` and ran the test suite using `pnpm run test` to ensure functionality is preserved.
* ✨ **Result:** The code is now more readable and less prone to future magic number-related errors.

---
*PR created automatically by Jules for task [13548415428640644324](https://jules.google.com/task/13548415428640644324) started by @michaelkrisper*