### PR TITLE
🧹 [Code Health] Remove unused canvas mocking in downloadFile tests

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -505,20 +505,8 @@ describe("downloadFile", () => {
 
 	beforeEach(() => {
 		const mockAnchor = { href: "", download: "", click: mockClick };
-		const mockCanvas = {
-			getContext: vi.fn(() => ({
-				scale: vi.fn(),
-				fillRect: vi.fn(),
-				drawImage: vi.fn(),
-			})),
-			toDataURL: vi.fn(() => "data:image/png;base64,mock"),
-		};
 		const documentMock = {
-			createElement: vi.fn((tag: string) => {
-				if (tag === "a") return mockAnchor;
-				if (tag === "canvas") return mockCanvas;
-				return {};
-			}),
+			createElement: vi.fn().mockReturnValue(mockAnchor),
 		};
 		vi.stubGlobal("document", documentMock);
 		// We still need the original URL class to validate the URL syntax in the new logic


### PR DESCRIPTION
- 🎯 **What:** Removed `mockCanvas` and its conditional creation from `downloadFile` test setup in `src/services/__tests__/export.test.ts`.
- 💡 **Why:** The `downloadFile` function only creates an `<a>` element. The mock canvas code was unused execution logic, removing it simplifies the test setup.
- ✅ **Verification:** Verified by running the relevant test file and the full test suite.
- ✨ **Result:** Improved test readability and setup efficiency without changing behavior.

---
*PR created automatically by Jules for task [1292486841497156520](https://jules.google.com/task/1292486841497156520) started by @michaelkrisper*