### PR TITLE
🧪 Add missing error path tests in persistence.ts

### DIFF
--- a/src/services/__tests__/persistence.test.ts
+++ b/src/services/__tests__/persistence.test.ts
@@ -488,5 +488,46 @@ describe("persistence", () => {
 			);
 			consoleSpy.mockRestore();
 		});
+
+		it("should catch error when loadAppState fails", async () => {
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			const error = new Error("Load failed");
+			const mockDb = {
+				get: vi.fn().mockRejectedValue(error),
+			};
+			openDBMock.mockResolvedValueOnce(mockDb);
+
+			const result = await persistence.loadAppState();
+
+			expect(result).toBeNull();
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Failed to load state:",
+				expect.any(Error),
+			);
+			consoleSpy.mockRestore();
+		});
+
+		it("should catch error when clearAppState fails due to getDB error", async () => {
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			vi.resetModules();
+			const idbMock = await import("idb");
+			const openDBMockInner = vi.mocked(idbMock.openDB);
+			openDBMockInner.mockRejectedValue(new Error("Failed to open IndexedDB"));
+
+			const persistenceModule = await import("../persistence");
+			const localPersistence = persistenceModule.persistence;
+
+			await localPersistence.clearAppState();
+
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Failed to clear state:",
+				expect.any(Error),
+			);
+			consoleSpy.mockRestore();
+		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** Added missing error path tests for `loadAppState` and `clearAppState` to verify proper error catching.
📊 **Coverage:** Covered the `catch` blocks in `loadAppState` for DB read errors and in `clearAppState` for DB initialization errors.
✨ **Result:** Increased test coverage and ensured robust error handling in the persistence service.

---
*PR created automatically by Jules for task [17269965726965309674](https://jules.google.com/task/17269965726965309674) started by @michaelkrisper*