### PR TITLE
🧪 Cover generic error paths in compileFormula fallback

### DIFF
--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -786,3 +786,27 @@ describe("evaluateFormulaSync — success paths", () => {
 		}
 	});
 });
+
+describe("compileFormula generic error fallback", () => {
+	it("returns a generic error message for non-FormulaError exceptions (TypeError)", () => {
+		// Passing an invalid argument to trigger a native TypeError inside compileFormula
+		const result = compileFormula(undefined as any, ["Col1"]);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain("Cannot read properties of undefined");
+		expect(result.evaluate([])).toBeNaN();
+	});
+
+	it("returns a stringified error message for non-Error exceptions", () => {
+		// Passing an object with a getter that throws a string primitive
+		// when accessed during iteration over availableColumns.
+		const evilColumns = {
+			get length() {
+				throw "Mock string error";
+			},
+		} as unknown as string[];
+
+		const result = compileFormula("[Col1]", evilColumns);
+		expect(result.error).toBe("Mock string error");
+		expect(result.evaluate([])).toBeNaN();
+	});
+});

--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -790,7 +790,7 @@ describe("evaluateFormulaSync — success paths", () => {
 describe("compileFormula generic error fallback", () => {
 	it("returns a generic error message for non-FormulaError exceptions (TypeError)", () => {
 		// Passing an invalid argument to trigger a native TypeError inside compileFormula
-		const result = compileFormula(undefined as any, ["Col1"]);
+		const result = compileFormula(undefined as unknown as string, ["Col1"]);
 		expect(result.error).toBeDefined();
 		expect(result.error).toContain("Cannot read properties of undefined");
 		expect(result.evaluate([])).toBeNaN();


### PR DESCRIPTION
🎯 **What:** The fallback error handling block (`err instanceof Error ? err.message : String(err)`) in `compileFormula` was lacking test coverage.
📊 **Coverage:** Added tests passing malformed inputs (undefined and objects with throwing getters) to trigger both generic `Error` instances (TypeError) and non-Error primitives (strings) to safely cover the fallback paths without mocking global JS built-ins.
✨ **Result:** Increased branch and statement coverage for the error handling block in `compileFormula`.

---
*PR created automatically by Jules for task [12517912634686227580](https://jules.google.com/task/12517912634686227580) started by @michaelkrisper*