### PR TITLE
🧪 Add non-Error throwing tests for postMessage failures in parser worker

### DIFF
--- a/src/workers/__tests__/parser.worker.test.ts
+++ b/src/workers/__tests__/parser.worker.test.ts
@@ -80,7 +80,10 @@ describe("parser.worker", () => {
     expect(postMessageMock).toHaveBeenCalledWith({ id: 2, type: "error", error });
   });
 
-  it("should handle error thrown when postMessage fails (e.g., DataCloneError)", async () => {
+  it.each([
+    { label: "Error object", thrown: new Error("DataCloneError"), error: "DataCloneError" },
+    { label: "string", thrown: "String error", error: "String error" },
+  ])("should handle $label thrown when postMessage fails", async ({ thrown, error }) => {
     const mockFile = new File(["dummy"], "test.csv", { type: "text/csv" });
     const mockDataset: Dataset[] = [];
 
@@ -88,7 +91,7 @@ describe("parser.worker", () => {
 
     // Force the first postMessage to fail
     postMessageMock.mockImplementationOnce(() => {
-      throw new Error("DataCloneError");
+      throw thrown;
     });
 
     const event = new MessageEvent("message", {
@@ -106,7 +109,7 @@ describe("parser.worker", () => {
     expect(postMessageMock).toHaveBeenLastCalledWith({
       id: 4,
       type: "error",
-      error: "DataCloneError",
+      error,
     });
   });
 });


### PR DESCRIPTION
🎯 **What:** The gap in testing where `postMessage` throwing a non-Error primitive was not explicitly covered in the catch block normalization.
📊 **Coverage:** The test suite now explicitly covers `postMessage` throwing both `Error` objects and `string` primitives in `parser.worker.test.ts`.
✨ **Result:** Improved test comprehensiveness and robust error handling verification.

---
*PR created automatically by Jules for task [11206461226067766944](https://jules.google.com/task/11206461226067766944) started by @michaelkrisper*