### PR TITLE
🧪 Add test for error path in flushAll of persistence.ts

### DIFF
--- a/src/services/__tests__/persistence.test.ts
+++ b/src/services/__tests__/persistence.test.ts
@@ -365,6 +365,40 @@ describe("persistence", () => {
 	});
 
 	describe("error handling", () => {
+		it("should catch error when flushAll fails", async () => {
+			vi.resetModules();
+			const idbMock = await import("idb");
+			const openDBMockInner = vi.mocked(idbMock.openDB);
+			openDBMockInner.mockRejectedValue(new Error("Failed to open IndexedDB"));
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			try {
+				const persistenceModule = await import("../persistence");
+				const localPersistence = persistenceModule.persistence;
+
+				const dataset: Dataset = {
+					id: "2",
+					name: "test-flush-all",
+					columns: [],
+					data: [],
+					rowCount: 0,
+					xAxisColumn: "X",
+					xAxisId: "axis-1",
+				};
+
+				await localPersistence.saveDataset(dataset);
+				await localPersistence.flushAll();
+
+				expect(consoleSpy).toHaveBeenCalledWith(
+					"flushAll failed:",
+					expect.any(Error),
+				);
+			} finally {
+				consoleSpy.mockRestore();
+			}
+		});
+
 		it("should propagate error when openDB fails (flushed)", async () => {
 			vi.resetModules();
 			const idbMock = await import("idb");


### PR DESCRIPTION
🎯 **What:** Added a missing test for the error branch inside the `flushAll` function in `src/services/persistence.ts`.
📊 **Coverage:** The scenario where IndexedDB fails when writing all queued datasets to disk is now covered.
✨ **Result:** Improved test reliability and ensured that silent failure in `flushAll` gets correctly logged, maximizing error-handling coverage.

---
*PR created automatically by Jules for task [1837749175101840287](https://jules.google.com/task/1837749175101840287) started by @michaelkrisper*