### PR TITLE
🧹 Refactor duplicate time calculation to a shared utility function

### DIFF
--- a/src/services/__tests__/demoData.test.ts
+++ b/src/services/__tests__/demoData.test.ts
@@ -1,3 +1,4 @@
+import { dateToSeconds } from "../../utils/time";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as randomUtils from "../../utils/random";
 import { generateDemoDataset, getDemoAppState } from "../demoData";
@@ -96,7 +97,7 @@ describe("demoData", () => {
 			const tsCol = dataset.data[0];
 
 			expect(tsCol.refPoint).toBe(
-				Math.floor(new Date(2024, 0, 1).getTime() / 1000),
+				Math.floor(dateToSeconds(new Date(2024, 0, 1))),
 			);
 
 			// Timestamp bounds check

--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -1,3 +1,4 @@
+import { dateToSeconds } from "../../utils/time";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { THEMES } from "../../themes";
 import { downloadFile, exportToPNG, exportToSVG, formatDate } from "../export";
@@ -661,25 +662,25 @@ describe("downloadFile", () => {
 describe("formatDate", () => {
 	it("formats correctly for daily steps (>= 86400)", () => {
 		const date = new Date(2023, 0, 15, 12, 0, 0);
-		const val = Math.floor(date.getTime() / 1000);
+		const val = Math.floor(dateToSeconds(date));
 		expect(formatDate(val, 86400)).toBe("15.1.");
 		expect(formatDate(val, 90000)).toBe("15.1.");
 	});
 
 	it("formats correctly for hourly steps (>= 3600 but < 86400)", () => {
 		const date = new Date(2023, 0, 15, 9, 30, 0);
-		const val = Math.floor(date.getTime() / 1000);
+		const val = Math.floor(dateToSeconds(date));
 		expect(formatDate(val, 3600)).toBe("9:00");
 		expect(formatDate(val, 7200)).toBe("9:00");
 	});
 
 	it("formats correctly for minute steps (< 3600)", () => {
 		const date1 = new Date(2023, 0, 15, 9, 5, 0);
-		const val1 = Math.floor(date1.getTime() / 1000);
+		const val1 = Math.floor(dateToSeconds(date1));
 		expect(formatDate(val1, 60)).toBe("09:05");
 
 		const date2 = new Date(2023, 0, 15, 14, 30, 0);
-		const val2 = Math.floor(date2.getTime() / 1000);
+		const val2 = Math.floor(dateToSeconds(date2));
 		expect(formatDate(val2, 1)).toBe("14:30");
 	});
 });

--- a/src/services/demoData.ts
+++ b/src/services/demoData.ts
@@ -1,3 +1,4 @@
+import { dateToSeconds } from "../utils/time";
 import { secureRandom } from "../utils/random";
 import type {
 	DataColumn,
@@ -17,7 +18,7 @@ export function generateDemoDataset(rowCount = 10000): Dataset {
 	const datasetId = "demo-dataset";
 
 	const currentYear = new Date().getFullYear();
-	const startTime = Math.floor(new Date(currentYear, 0, 1).getTime() / 1000);
+	const startTime = Math.floor(dateToSeconds(new Date(currentYear, 0, 1)));
 
 	const data: DataColumn[] = columns.map((colName) => ({
 		isFloat64: colName === "Timestamp",

--- a/src/utils/__tests__/data-parser.test.ts
+++ b/src/utils/__tests__/data-parser.test.ts
@@ -1,3 +1,4 @@
+import { dateToSeconds } from "../time";
 import { describe, expect, it, vi } from "vitest";
 import * as jsonUtils from "../json";
 import { parseData } from "../data-parser";
@@ -137,7 +138,7 @@ describe("data-parser", () => {
 
 			expect(datasets).toHaveLength(1);
 			expect(datasets[0].data[0].refPoint).toBe(
-				new Date(2025, 11, 24).getTime() / 1000,
+				dateToSeconds(new Date(2025, 11, 24)),
 			);
 			expect(datasets[0].data[0].isFloat64).toBe(true);
 		});
@@ -303,7 +304,7 @@ describe("data-parser", () => {
 
 			expect(datasets).toHaveLength(1);
 			expect(datasets[0].data[0].refPoint).toBe(
-				new Date(2025, 11, 24).getTime() / 1000,
+				dateToSeconds(new Date(2025, 11, 24)),
 			);
 			expect(datasets[0].data[1].categoryLabels).toEqual(["A", "B"]);
 			expect(datasets[0].data[2].refPoint).toBe(1.1);

--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -1,3 +1,4 @@
+import { dateToSeconds } from "../time";
 import { describe, expect, it, vi } from "vitest";
 import {
 	compileFormula,
@@ -93,9 +94,9 @@ describe("compileFormula", () => {
 
 		expect(usedColumnIndices).toEqual([1, 0]);
 
-		const t1 = new Date("2023-01-01T10:00:00Z").getTime() / 1000;
-		const t2 = new Date("2023-01-01T11:00:00Z").getTime() / 1000;
-		const t3 = new Date("2023-01-02T10:00:00Z").getTime() / 1000;
+		const t1 = dateToSeconds(new Date("2023-01-01T10:00:00Z"));
+		const t2 = dateToSeconds(new Date("2023-01-01T11:00:00Z"));
+		const t3 = dateToSeconds(new Date("2023-01-02T10:00:00Z"));
 
 		expect(evaluate([10, t1], ctx)).toBe(10);
 		expect(evaluate([20, t2], ctx)).toBe(15);
@@ -242,9 +243,9 @@ describe("compileFormula", () => {
 	it("should test sumday, avghour, sumhour, avgminute, avgsecond", () => {
 		const resSumDay = compileFormula("sumday([Temp])", columns);
 		const ctxSumDay = resSumDay.createContext?.();
-		const t1 = new Date("2023-01-01T10:00:00Z").getTime() / 1000;
-		const t2 = new Date("2023-01-01T11:00:00Z").getTime() / 1000;
-		const t3 = new Date("2023-01-02T10:00:00Z").getTime() / 1000;
+		const t1 = dateToSeconds(new Date("2023-01-01T10:00:00Z"));
+		const t2 = dateToSeconds(new Date("2023-01-01T11:00:00Z"));
+		const t3 = dateToSeconds(new Date("2023-01-02T10:00:00Z"));
 
 		expect(resSumDay.evaluate([10, t1], ctxSumDay)).toBe(10);
 		expect(resSumDay.evaluate([20, t2], ctxSumDay)).toBe(30);

--- a/src/utils/data-parser.ts
+++ b/src/utils/data-parser.ts
@@ -1,5 +1,6 @@
 // Data Parser (v0.5.0 - Main Thread)
 
+import { dateToSeconds } from "./time";
 import type { DataColumn, ParsedDataset } from "../services/persistence";
 import { processRawColumn } from "./data-processing";
 import { secureJSONParse } from "./json";
@@ -700,7 +701,7 @@ function getDateFormatIndices(format: string): DateFormatIndices {
 function parseDate(val: string, format?: string): number {
 	if (!format) {
 		const d = new Date(val);
-		return d.getTime() / 1000;
+		return dateToSeconds(d);
 	}
 
 	const idx = getDateFormatIndices(format);
@@ -737,11 +738,11 @@ function parseDate(val: string, format?: string): number {
 	) {
 		dateScratch.setFullYear(year, month, day);
 		dateScratch.setHours(hour, min, sec, 0);
-		return dateScratch.getTime() / 1000;
+		return dateToSeconds(dateScratch);
 	}
 
 	const d = new Date(val);
-	return d.getTime() / 1000;
+	return dateToSeconds(d);
 }
 
 const dateScratch = new Date();

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -126,7 +126,7 @@ export function generateTimeTicks(
 	else if (unit === "month") d.setMonth(d.getMonth() - value);
 	else if (unit === "year") d.setFullYear(d.getFullYear() - value);
 
-	let current = d.getTime() / 1000;
+	let current = dateToSeconds(d);
 	// Use a slightly larger max for margin (approx 1 step)
 	const marginSeconds =
 		(unit === "month"
@@ -150,7 +150,7 @@ export function generateTimeTicks(
 		else if (unit === "month") d.setMonth(d.getMonth() + value);
 		else if (unit === "year") d.setFullYear(d.getFullYear() + value);
 
-		current = d.getTime() / 1000;
+		current = dateToSeconds(d);
 		if (ticks.length > MAX_TIME_TICKS) break;
 	}
 
@@ -204,7 +204,7 @@ export function generateSecondaryLabels(
 		d.setTime(min * 1000);
 		d.setHours(0, 0, 0, 0);
 		d.setDate(d.getDate() - 1); // margin
-		let current = d.getTime() / 1000;
+		let current = dateToSeconds(d);
 		while (current <= max + 86400) {
 			labels.push({
 				timestamp: current,
@@ -215,7 +215,7 @@ export function generateSecondaryLabels(
 				}),
 			});
 			d.setDate(d.getDate() + 1);
-			current = d.getTime() / 1000;
+			current = dateToSeconds(d);
 			if (labels.length > MAX_SECONDARY_LABELS) break;
 		}
 		return labels;
@@ -231,7 +231,7 @@ export function generateSecondaryLabels(
 			d.setHours(0, 0, 0, 0);
 			d.setDate(1);
 			d.setMonth(d.getMonth() - 1); // margin
-			let current = d.getTime() / 1000;
+			let current = dateToSeconds(d);
 			while (current <= max + UNIT_SECONDS.month) {
 				labels.push({
 					timestamp: current,
@@ -241,7 +241,7 @@ export function generateSecondaryLabels(
 					}),
 				});
 				d.setMonth(d.getMonth() + 1);
-				current = d.getTime() / 1000;
+				current = dateToSeconds(d);
 				if (labels.length > MAX_SECONDARY_LABELS) break;
 			}
 			return labels;
@@ -253,18 +253,22 @@ export function generateSecondaryLabels(
 	d.setHours(0, 0, 0, 0);
 	d.setMonth(0, 1);
 	d.setFullYear(d.getFullYear() - 1); // margin
-	let current = d.getTime() / 1000;
+	let current = dateToSeconds(d);
 	while (current <= max + 31536000) {
 		labels.push({
 			timestamp: current,
 			label: String(d.getFullYear()),
 		});
 		d.setFullYear(d.getFullYear() + 1);
-		current = d.getTime() / 1000;
+		current = dateToSeconds(d);
 		if (labels.length > MAX_SECONDARY_LABELS) break;
 	}
 
 	return labels;
+}
+
+export function dateToSeconds(d: Date): number {
+	return d.getTime() / 1000;
 }
 
 export function formatFullDate(ts: number): string {


### PR DESCRIPTION
* 🎯 **What:** Extracted the duplicate time calculation `d.getTime() / 1000` to a new `dateToSeconds` utility function in `src/utils/time.ts` and replaced all occurrences across the codebase.
* 💡 **Why:** This improves maintainability and readability by centralizing the date-to-seconds conversion logic.
* ✅ **Verification:** Validated the replacements visually using `git diff`, and ran the full test suite (`pnpm test`) to confirm no functionality regressions were introduced. Also ran linting (`pnpm lint`).
* ✨ **Result:** A cleaner, more maintainable codebase with consistent date-to-seconds calculation.

---
*PR created automatically by Jules for task [15704466787664034188](https://jules.google.com/task/15704466787664034188) started by @michaelkrisper*