### PR TITLE
🧪 Add error path test for initiateImport in useDataImport

### DIFF
--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -813,4 +813,84 @@ describe("useDataImport hook", () => {
 
     global.FileReader = originalFileReader;
   });
+
+  it("should handle missing fullCsv and undefined worker datasets during confirmImport", async () => {
+    const { result } = renderHook(() => useDataImport());
+    const file = new File(["dummy"], "test.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
+
+    const originalFileReader = global.FileReader;
+    class MockFileReader {
+      onload: ((event: { target: { result: ArrayBuffer } }) => void) | null =
+        null;
+      readAsArrayBuffer() {
+        setTimeout(() => {
+          this.onload?.({ target: { result: new ArrayBuffer(8) } });
+        }, 10);
+      }
+    }
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
+
+    const xlsx = await import("xlsx");
+    const mockWorkbook = {
+      SheetNames: ["Sheet1"],
+      Sheets: { Sheet1: {} },
+    };
+    vi.mocked(xlsx.read).mockReturnValue(
+      mockWorkbook as unknown as ReturnType<typeof xlsx.read>,
+    );
+    vi.mocked(xlsx.utils.sheet_to_csv).mockReturnValue("A,B\n1,2");
+
+    await act(async () => {
+      await result.current.importFile(file);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    act(() => {
+      if (result.current.pendingFile) {
+        result.current.pendingFile.fullCsv = undefined;
+      }
+    });
+
+    vi.mocked(parseDataInWorker).mockResolvedValueOnce(
+      undefined as unknown as ReturnType<typeof parseDataInWorker>,
+    );
+
+    const settings: ImportSettings = {
+      delimiter: ",",
+      decimalPoint: ".",
+      startRow: 1,
+      commentChar: "#",
+      columnConfigs: [],
+    };
+
+    await act(async () => {
+      await result.current.confirmImport(settings);
+    });
+
+    expect(result.current.isImporting).toBe(false);
+
+    global.FileReader = originalFileReader;
+  });
+
+  it("should handle unexpected errors in initiateImport (e.g. primitive throw)", async () => {
+    const { result } = renderHook(() => useDataImport());
+
+    // Force a primitive throw by passing an object that throws when 'name' is accessed
+    const maliciousFile = {
+      get name(): string {
+        throw "Primitive error in initiateImport";
+      }
+    } as unknown as File;
+
+    await act(async () => {
+      await result.current.importFile(maliciousFile);
+    });
+
+    expect(result.current.error).toBe("Primitive error in initiateImport");
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `useDataImport.test.tsx` to handle the specific error path at line 120 where `initiateImport` catches a thrown primitive error and sets it to state using the `String(err)` fallback.
📊 **Coverage:** The `catch (err: unknown)` block in `initiateImport` is now explicitly verified.
✨ **Result:** Improved test reliability by ensuring the error state handles non-standard exceptions during file import.

---
*PR created automatically by Jules for task [1448611573068947895](https://jules.google.com/task/1448611573068947895) started by @michaelkrisper*