### PR TITLE
Integrate batch 2 (#597–#618): tests, perf, XSS, code-health

### DIFF
--- a/src/__tests__/mock-pwa-register.ts
+++ b/src/__tests__/mock-pwa-register.ts
@@ -1,0 +1,2 @@
+import { vi } from 'vitest';
+export const registerSW = vi.fn();

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -31,7 +31,6 @@ export default class ErrorBoundary extends React.Component<Props, State> {
 			error,
 			errorInfo,
 		});
-		console.error("[ErrorBoundary]", error, errorInfo.componentStack);
 	}
 
 	handleReset = () => {

--- a/src/components/Plot/computeAxesLayout.ts
+++ b/src/components/Plot/computeAxesLayout.ts
@@ -119,8 +119,10 @@ export function computeXAxesLayoutCached({
 		cache.depsKey = depsKey;
 	}
 
+	const activeXAxisIds = new Set(activeXAxesUsed.map((ax) => ax.id));
+
 	return liveXAxes
-		.filter((axis) => activeXAxesUsed.some((ax) => ax.id === axis.id))
+		.filter((axis) => activeXAxisIds.has(axis.id))
 		.map((axis) => {
 			const cacheKey = `${axis.min}|${axis.max}|${axis.showGrid}|${axis.xMode}|${axis.name ?? ""}`;
 			const cached = cache.entries.get(axis.id);

--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -813,4 +813,84 @@ describe("useDataImport hook", () => {
 
     global.FileReader = originalFileReader;
   });
+
+  it("should handle missing fullCsv and undefined worker datasets during confirmImport", async () => {
+    const { result } = renderHook(() => useDataImport());
+    const file = new File(["dummy"], "test.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
+
+    const originalFileReader = global.FileReader;
+    class MockFileReader {
+      onload: ((event: { target: { result: ArrayBuffer } }) => void) | null =
+        null;
+      readAsArrayBuffer() {
+        setTimeout(() => {
+          this.onload?.({ target: { result: new ArrayBuffer(8) } });
+        }, 10);
+      }
+    }
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
+
+    const xlsx = await import("xlsx");
+    const mockWorkbook = {
+      SheetNames: ["Sheet1"],
+      Sheets: { Sheet1: {} },
+    };
+    vi.mocked(xlsx.read).mockReturnValue(
+      mockWorkbook as unknown as ReturnType<typeof xlsx.read>,
+    );
+    vi.mocked(xlsx.utils.sheet_to_csv).mockReturnValue("A,B\n1,2");
+
+    await act(async () => {
+      await result.current.importFile(file);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    act(() => {
+      if (result.current.pendingFile) {
+        result.current.pendingFile.fullCsv = undefined;
+      }
+    });
+
+    vi.mocked(parseDataInWorker).mockResolvedValueOnce(
+      undefined as unknown as ReturnType<typeof parseDataInWorker>,
+    );
+
+    const settings: ImportSettings = {
+      delimiter: ",",
+      decimalPoint: ".",
+      startRow: 1,
+      commentChar: "#",
+      columnConfigs: [],
+    };
+
+    await act(async () => {
+      await result.current.confirmImport(settings);
+    });
+
+    expect(result.current.isImporting).toBe(false);
+
+    global.FileReader = originalFileReader;
+  });
+
+  it("should handle unexpected errors in initiateImport (e.g. primitive throw)", async () => {
+    const { result } = renderHook(() => useDataImport());
+
+    // Force a primitive throw by passing an object that throws when 'name' is accessed
+    const maliciousFile = {
+      get name(): string {
+        throw "Primitive error in initiateImport";
+      }
+    } as unknown as File;
+
+    await act(async () => {
+      await result.current.importFile(maliciousFile);
+    });
+
+    expect(result.current.error).toBe("Primitive error in initiateImport");
+  });
 });

--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -813,4 +813,43 @@ describe("useDataImport hook", () => {
 
     global.FileReader = originalFileReader;
   });
+
+  it.each([
+    { label: "an Error", thrown: new Error("parseDataInWorker failed"), expected: "parseDataInWorker failed" },
+    { label: "a string", thrown: "String error in parseDataInWorker", expected: "String error in parseDataInWorker" },
+  ])("surfaces $label thrown by parseDataInWorker during confirmImport", async ({ thrown, expected }) => {
+    const { result } = renderHook(() => useDataImport());
+    const file = new File(["dummy"], "test.csv", { type: "text/csv" });
+
+    const originalFileReader = global.FileReader;
+    class MockFileReader {
+      onload: ((event: { target: { result: string } }) => void) | null = null;
+      readAsText() {
+        this.onload?.({ target: { result: "data" } });
+      }
+    }
+    global.FileReader = MockFileReader as unknown as typeof FileReader;
+
+    await act(async () => {
+      await result.current.importFile(file);
+    });
+
+    const settings: ImportSettings = {
+      delimiter: ",",
+      decimalPoint: ".",
+      startRow: 1,
+      columnConfigs: [],
+    };
+
+    vi.mocked(parseDataInWorker).mockRejectedValueOnce(thrown);
+
+    await act(async () => {
+      await result.current.confirmImport(settings);
+    });
+
+    expect(result.current.error).toBe(expected);
+    expect(result.current.isImporting).toBe(false);
+
+    global.FileReader = originalFileReader;
+  });
 });

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRegisterSW = vi.fn();
+const mockRender = vi.fn();
+const mockCreateRoot = vi.fn(() => ({ render: mockRender }));
+
+vi.mock('virtual:pwa-register', () => ({
+  registerSW: mockRegisterSW,
+}));
+
+vi.mock('react-dom/client', () => ({
+  default: {
+    createRoot: mockCreateRoot,
+  },
+}));
+
+vi.mock('./App', () => ({
+  default: () => <div>Mock App</div>,
+}));
+
+describe('main.tsx', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    document.body.innerHTML = '';
+  });
+
+  it('renders the App when root element exists', async () => {
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+
+    await import('./main');
+
+    expect(mockRegisterSW).toHaveBeenCalledWith({ immediate: true });
+    expect(mockCreateRoot).toHaveBeenCalledWith(root);
+    expect(mockRender).toHaveBeenCalled();
+  });
+
+  it('does not call createRoot when root element is missing', async () => {
+    await import('./main');
+
+    expect(mockRegisterSW).toHaveBeenCalledWith({ immediate: true });
+    expect(mockCreateRoot).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -505,20 +505,8 @@ describe("downloadFile", () => {
 
 	beforeEach(() => {
 		const mockAnchor = { href: "", download: "", click: mockClick };
-		const mockCanvas = {
-			getContext: vi.fn(() => ({
-				scale: vi.fn(),
-				fillRect: vi.fn(),
-				drawImage: vi.fn(),
-			})),
-			toDataURL: vi.fn(() => "data:image/png;base64,mock"),
-		};
 		const documentMock = {
-			createElement: vi.fn((tag: string) => {
-				if (tag === "a") return mockAnchor;
-				if (tag === "canvas") return mockCanvas;
-				return {};
-			}),
+			createElement: vi.fn().mockReturnValue(mockAnchor),
 		};
 		vi.stubGlobal("document", documentMock);
 		// We still need the original URL class to validate the URL syntax in the new logic

--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { THEMES } from "../../themes";
 import { downloadFile, exportToPNG, exportToSVG, formatDate } from "../export";
+import { UNIT_SECONDS } from "../../utils/time";
 import type {
 	Dataset,
 	SeriesConfig,
@@ -662,14 +663,14 @@ describe("formatDate", () => {
 	it("formats correctly for daily steps (>= 86400)", () => {
 		const date = new Date(2023, 0, 15, 12, 0, 0);
 		const val = Math.floor(date.getTime() / 1000);
-		expect(formatDate(val, 86400)).toBe("15.1.");
+		expect(formatDate(val, UNIT_SECONDS.day)).toBe("15.1.");
 		expect(formatDate(val, 90000)).toBe("15.1.");
 	});
 
 	it("formats correctly for hourly steps (>= 3600 but < 86400)", () => {
 		const date = new Date(2023, 0, 15, 9, 30, 0);
 		const val = Math.floor(date.getTime() / 1000);
-		expect(formatDate(val, 3600)).toBe("9:00");
+		expect(formatDate(val, UNIT_SECONDS.hour)).toBe("9:00");
 		expect(formatDate(val, 7200)).toBe("9:00");
 	});
 

--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -631,6 +631,26 @@ describe("downloadFile", () => {
 		).toThrow("Unsafe data URL scheme detected");
 	});
 
+	it("should throw an error and preserve cause if URL.createObjectURL fails", () => {
+		const mockError = new Error("Mock creation error");
+		vi.spyOn(URL, "createObjectURL").mockImplementationOnce(() => {
+			throw mockError;
+		});
+
+		expect.hasAssertions();
+		try {
+			downloadFile(
+				"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+				"test.png",
+				"image/png",
+			);
+		} catch (error) {
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toBe("Unsafe data URL scheme detected");
+			expect((error as Error).cause).toBe(mockError);
+		}
+	});
+
 	it("should handle normal strings using Blob correctly", () => {
 		const cleanup = downloadFile("Hello, world!", "test.txt", "text/plain");
 

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -355,10 +355,7 @@ export const exportToSVG = (
 
 		const datasetsForThisAxis = datasetsByXAxisId[axis.id] || [];
 		const title = Array.from(
-			datasetsForThisAxis.reduce(
-				(acc, d) => acc.add(d.xAxisColumn),
-				new Set<string>(),
-			),
+			new Set(datasetsForThisAxis.map((d) => d.xAxisColumn)),
 		).join(" / ");
 		svg += `<text x="${padding.left + chartWidth / 2}" y="${baseY + 48}" text-anchor="middle" font-size="14" font-weight="bold" fill="${escapeHTML(theme.labelColor)}">${escapeHTML(title)}</text>`;
 	});
@@ -539,7 +536,9 @@ export const downloadFile = (
 				!mimeType.startsWith("image/") &&
 				!mimeType.startsWith("application/")
 			) {
-				throw new Error(`Unsupported MIME type: ${mimeType}. Expected 'image/*' or 'application/*'`);
+				throw new Error(
+					`Unsupported MIME type: ${mimeType}. Expected 'image/*' or 'application/*'`,
+				);
 			}
 			const lowerMimeType = mimeType.toLowerCase();
 			if (

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -278,7 +278,7 @@ export const exportToSVG = (
 				let dashArray = "";
 				if (s.lineStyle === "dashed") dashArray = 'stroke-dasharray="8,6"';
 				else if (s.lineStyle === "dotted") dashArray = 'stroke-dasharray="2,4"';
-				svg += `<path d="${pathData.trim()}" fill="none" stroke="${escapeHTML(s.lineColor)}" stroke-width="1" ${dashArray} />`;
+				svg += `<path d="${escapeHTML(pathData.trim())}" fill="none" stroke="${escapeHTML(s.lineColor)}" stroke-width="1" ${dashArray} />`;
 			}
 		}
 		if (s.pointStyle !== "none") {

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -4,6 +4,7 @@ import { getColumnIndex } from "../utils/columns";
 import { worldToScreen } from "../utils/coords";
 import { m4Float32 } from "../utils/decimation";
 import { escapeHTML } from "../utils/dom";
+import { UNIT_SECONDS } from "../utils/time";
 import type {
 	Dataset,
 	SeriesConfig,
@@ -434,8 +435,8 @@ export const exportToSVG = (
  */
 export const formatDate = (val: number, step: number) => {
 	const d = new Date(val * 1000);
-	if (step >= 86400) return `${d.getDate()}.${d.getMonth() + 1}.`;
-	if (step >= 3600) return `${d.getHours()}:00`;
+	if (step >= UNIT_SECONDS.day) return `${d.getDate()}.${d.getMonth() + 1}.`;
+	if (step >= UNIT_SECONDS.hour) return `${d.getHours()}:00`;
 	return (
 		String(d.getHours()).padStart(2, "0") +
 		":" +

--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -786,3 +786,27 @@ describe("evaluateFormulaSync — success paths", () => {
 		}
 	});
 });
+
+describe("compileFormula generic error fallback", () => {
+	it("returns a generic error message for non-FormulaError exceptions (TypeError)", () => {
+		// Passing an invalid argument to trigger a native TypeError inside compileFormula
+		const result = compileFormula(undefined as any, ["Col1"]);
+		expect(result.error).toBeDefined();
+		expect(result.error).toContain("Cannot read properties of undefined");
+		expect(result.evaluate([])).toBeNaN();
+	});
+
+	it("returns a stringified error message for non-Error exceptions", () => {
+		// Passing an object with a getter that throws a string primitive
+		// when accessed during iteration over availableColumns.
+		const evilColumns = {
+			get length() {
+				throw "Mock string error";
+			},
+		} as unknown as string[];
+
+		const result = compileFormula("[Col1]", evilColumns);
+		expect(result.error).toBe("Mock string error");
+		expect(result.evaluate([])).toBeNaN();
+	});
+});

--- a/src/utils/__tests__/formula.test.ts
+++ b/src/utils/__tests__/formula.test.ts
@@ -790,7 +790,7 @@ describe("evaluateFormulaSync — success paths", () => {
 describe("compileFormula generic error fallback", () => {
 	it("returns a generic error message for non-FormulaError exceptions (TypeError)", () => {
 		// Passing an invalid argument to trigger a native TypeError inside compileFormula
-		const result = compileFormula(undefined as any, ["Col1"]);
+		const result = compileFormula(undefined as unknown as string, ["Col1"]);
 		expect(result.error).toBeDefined();
 		expect(result.error).toContain("Cannot read properties of undefined");
 		expect(result.evaluate([])).toBeNaN();

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -21,7 +21,7 @@ export interface TimeTick {
 const MAX_TIME_TICKS = 500;
 const MAX_SECONDARY_LABELS = 100;
 
-const UNIT_SECONDS = {
+export const UNIT_SECONDS = {
 	second: 1,
 	minute: 60,
 	hour: 3600,

--- a/src/workers/__tests__/formula.worker.test.ts
+++ b/src/workers/__tests__/formula.worker.test.ts
@@ -98,17 +98,21 @@ describe("formula.worker", () => {
 });
 
 describe("formula.worker stringification fallback", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let evaluateFormulaSyncMock: any;
 
   beforeEach(async () => {
     vi.resetModules();
-    evaluateFormulaSyncMock = (await import("../../utils/formula")).evaluateFormulaSync;
+    evaluateFormulaSyncMock = (await import("../../utils/formula"))
+      .evaluateFormulaSync;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     globalThis.self = globalThis as any;
     globalThis.postMessage = vi.fn();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (globalThis as any).onmessage;
   });
 
@@ -119,7 +123,9 @@ describe("formula.worker stringification fallback", () => {
       throw null;
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const onmessage = (globalThis as any).onmessage;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onmessage({ data: { id: 123, formulaId: "test-id" } } as any);
 
     expect(globalThis.postMessage).toHaveBeenCalledWith({

--- a/src/workers/__tests__/formula.worker.test.ts
+++ b/src/workers/__tests__/formula.worker.test.ts
@@ -96,3 +96,36 @@ describe("formula.worker", () => {
     });
   });
 });
+
+describe("formula.worker stringification fallback", () => {
+  let evaluateFormulaSyncMock: any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    evaluateFormulaSyncMock = (await import("../../utils/formula")).evaluateFormulaSync;
+    globalThis.self = globalThis as any;
+    globalThis.postMessage = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as any).onmessage;
+  });
+
+  it("handles non-Error objects in catch block", async () => {
+    await import("../formula.worker");
+
+    evaluateFormulaSyncMock.mockImplementation(() => {
+      throw null;
+    });
+
+    const onmessage = (globalThis as any).onmessage;
+    onmessage({ data: { id: 123, formulaId: "test-id" } } as any);
+
+    expect(globalThis.postMessage).toHaveBeenCalledWith({
+      id: 123,
+      type: "error",
+      error: "null",
+    });
+  });
+});

--- a/src/workers/__tests__/parser.worker.test.ts
+++ b/src/workers/__tests__/parser.worker.test.ts
@@ -80,7 +80,10 @@ describe("parser.worker", () => {
     expect(postMessageMock).toHaveBeenCalledWith({ id: 2, type: "error", error });
   });
 
-  it("should handle error thrown when postMessage fails (e.g., DataCloneError)", async () => {
+  it.each([
+    { label: "Error object", thrown: new Error("DataCloneError"), error: "DataCloneError" },
+    { label: "string", thrown: "String error", error: "String error" },
+  ])("should handle $label thrown when postMessage fails", async ({ thrown, error }) => {
     const mockFile = new File(["dummy"], "test.csv", { type: "text/csv" });
     const mockDataset: Dataset[] = [];
 
@@ -88,7 +91,7 @@ describe("parser.worker", () => {
 
     // Force the first postMessage to fail
     postMessageMock.mockImplementationOnce(() => {
-      throw new Error("DataCloneError");
+      throw thrown;
     });
 
     const event = new MessageEvent("message", {
@@ -106,7 +109,7 @@ describe("parser.worker", () => {
     expect(postMessageMock).toHaveBeenLastCalledWith({
       id: 4,
       type: "error",
-      error: "DataCloneError",
+      error,
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,16 @@
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import { VitePWA } from "vite-plugin-pwa";
 
 export default defineConfig({
-	plugins: [react()],
+	plugins: [
+		react(),
+		VitePWA({
+			registerType: "autoUpdate",
+			injectRegister: null,
+		})
+	],
 	test: {
 		globals: true,
 		environment: "jsdom",
@@ -12,9 +19,6 @@ export default defineConfig({
 			provider: "v8",
 			reporter: ["text", "json", "html"],
 			exclude: ["node_modules", "dist"],
-			// Regression guard: thresholds sit just below the current numbers so
-			// the suite fails if coverage drops meaningfully. Ratchet them up as
-			// coverage improves.
 			thresholds: {
 				statements: 85,
 				branches: 73,
@@ -26,6 +30,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
+			"virtual:pwa-register": path.resolve(__dirname, "src/__tests__/mock-pwa-register.ts"),
 		},
 	},
 });


### PR DESCRIPTION
Second consolidation pass over #597–#618. Verified locally: lint clean, **971 tests pass**, coverage above thresholds, build green.

## Merged (13)
- **Security:** #605 (escape SVG `path` data — XSS hardening, sibling of #596)
- **Perf/cleanup:** #598 (Set for x-axis id lookup), #602 (Set-from-map for x-axis title)
- **Code health:** #599 (drop redundant ErrorBoundary console.error), #606 (extract time constants in `formatDate`, export `UNIT_SECONDS`)
- **Tests:** #600 + #617 (useDataImport error paths — conflict resolved, both kept), #601 (export createObjectURL error path), #607 (simplify downloadFile canvas mock), #608 (main.tsx tests), #611 (compileFormula fallback), #612 (formula.worker branch), #613 (parser worker postMessage)

Fixes on top: resolved #600/#617 append conflict; added the file's existing `eslint-disable` convention to #612's necessary `any`-casts.

## NOT included — recommend closing
- **#597** — subset of #606.
- **#603** — commits junk `fix-ts.patch` / `fix.patch` / `.orig` files with `<<<<<<< SEARCH` markers.
- **#609** — replaces a `Map` lookup with an O(N·M) loop; worse code for unproven gain.
- **#604 #610 #614 #618** — assert the *old* `console.error("… :", err)` format; #595 already switched persistence to structured logging `("…", { error })`, so these fail. Worth reopening once rebased onto the new format.
- **#615** — good idea (batch IndexedDB reads) but bundles a junk root `benchmark.ts`, a new `fake-indexeddb` dep, and the now-deleted `pnpm-lock.yaml`. Needs a clean re-cut.
- **#616** — broader `dateToSeconds` refactor; collides with #606 in `export.test.ts`. Review separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)