### PR TITLE
🧪 [testing improvement] Parameterize error handling tests for initiateImport

### DIFF
--- a/src/hooks/__tests__/useDataImport.test.tsx
+++ b/src/hooks/__tests__/useDataImport.test.tsx
@@ -792,7 +792,10 @@ describe("useDataImport hook", () => {
     global.FileReader = originalFileReader;
   });
 
-  it("should handle file reading errors in initiateImport with a string error", async () => {
+  it.each([
+    { label: "an Error", thrown: new Error("File read failed"), expected: "File read failed" },
+    { label: "a string", thrown: "String error", expected: "String error" },
+  ])("surfaces $label thrown synchronously during initiateImport", async ({ thrown, expected }) => {
     const { result } = renderHook(() => useDataImport());
 
     const file = new File([""], "test.csv", { type: "text/csv" });
@@ -800,7 +803,7 @@ describe("useDataImport hook", () => {
     const originalFileReader = global.FileReader;
     class MockFileReader {
       readAsText() {
-        throw "String error";
+        throw thrown;
       }
     }
     global.FileReader = MockFileReader as unknown as typeof FileReader;
@@ -809,7 +812,7 @@ describe("useDataImport hook", () => {
       await result.current.importFile(file);
     });
 
-    expect(result.current.error).toBe("String error");
+    expect(result.current.error).toBe(expected);
 
     global.FileReader = originalFileReader;
   });


### PR DESCRIPTION
🎯 **What:** Replaced the disconnected primitive string throw test for `initiateImport` with a clean `it.each` block that tests throwing both a standard `Error` and a `string`.
📊 **Coverage:** Specifically targets the `catch (err: unknown)` block in `initiateImport`, validating the `err instanceof Error ? err.message : String(err)` fallback.
✨ **Result:** A cohesive, parameterized test that guarantees both error shapes surface correctly in the hook's `error` state.

---
*PR created automatically by Jules for task [14798883768628325514](https://jules.google.com/task/14798883768628325514) started by @michaelkrisper*