### PR TITLE
🧹 refactor: fix react-hooks/refs lint error in ColorPicker

### DIFF
--- a/src/components/Sidebar/ColorPicker.tsx
+++ b/src/components/Sidebar/ColorPicker.tsx
@@ -166,8 +166,10 @@ function ColorPickerInputs({
 	};
 
 	const rgbRef = useRef({ r, g, b });
-	// eslint-disable-next-line react-hooks/refs
-	rgbRef.current = { r, g, b };
+
+	useEffect(() => {
+		rgbRef.current = { r, g, b };
+	}, [r, g, b]);
 
 	useEffect(() => {
 		const el = rgbInputsRef.current;


### PR DESCRIPTION
🎯 **What:** Fixed an ESLint issue (`react-hooks/refs`) caused by mutating `rgbRef.current` directly during the render phase in `ColorPicker.tsx`. Removed the `eslint-disable` comment and wrapped the mutation in a `useEffect`.

💡 **Why:** Mutating refs during rendering breaks React's concurrent rendering guarantees (renders should be pure). By moving this side effect into a `useEffect`, we make the component safer and more predictable while appeasing the linter without needing a disable comment.

✅ **Verification:** 
- Visual inspection via `git diff`.
- Verified the ESLint error is resolved by running `pnpm run lint`.
- Validated all tests pass with `pnpm run test`, including the specific `ColorPicker.test.tsx` test suite.

✨ **Result:** Clean, compliant React code with no `eslint-disable` workarounds, ensuring pure render phases.

---
*PR created automatically by Jules for task [5888522078684502790](https://jules.google.com/task/5888522078684502790) started by @michaelkrisper*