### PR TITLE
🧹 [code health improvement] Use useLayoutEffect to safely update syncViewportRef

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "webgraphy",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "webgraphy",
-			"version": "1.1.1",
+			"version": "1.2.0",
 			"dependencies": {
 				"idb": "^8.0.3",
 				"lucide-react": "^1.14.0",

--- a/src/components/Plot/ChartContainer.tsx
+++ b/src/components/Plot/ChartContainer.tsx
@@ -1,6 +1,6 @@
 // src/components/Plot/ChartContainer.tsx
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useAutoScale } from "../../hooks/useAutoScale";
 import { useContainerSize } from "../../hooks/useContainerSize";
 import { useDataImport } from "../../hooks/useDataImport";
@@ -565,9 +565,10 @@ export default function ChartContainer() {
 
 	// Latest-callback ref: keep syncViewportRef pointing at the current
 	// syncViewport so the stable imperative handle and RAF closures call the
-	// up-to-date version. The write is intentional during render.
-	// eslint-disable-next-line react-hooks/refs
-	syncViewportRef.current = syncViewport;
+	// up-to-date version. We use useLayoutEffect to safely update the ref.
+	useLayoutEffect(() => {
+		syncViewportRef.current = syncViewport;
+	}, [syncViewport]);
 
 	// 6. Effects
 	// Keep the render worker's scene context current (shared-viewport mode


### PR DESCRIPTION
🎯 **What:** Modified `ChartContainer.tsx` to safely update `syncViewportRef.current` inside a `useLayoutEffect` hook instead of updating it directly during the render phase, which suppresses the ESLint `react-hooks/refs` warning without using an inline disable directive.
💡 **Why:** React refs are not meant to be modified during the render phase. Mutating refs during render can cause concurrent rendering issues. Wrapping it in `useLayoutEffect` ensures that the ref updates synchronously after DOM mutations but outside of the render cycle, preserving the "latest-state" pattern correctly while respecting React rules.
✅ **Verification:** Verified changes visually with `git diff`. Ran `npm run lint`, `npm run build`, and `npm run test` which all passed, confirming that the ESLint error is resolved and functionality remains intact.
✨ **Result:** Cleaned up code health by addressing a linter warning appropriately and making the codebase strictly adhere to React rules of hooks.

---
*PR created automatically by Jules for task [3600558730121028055](https://jules.google.com/task/3600558730121028055) started by @michaelkrisper*