### PR TITLE
🧹 [Code Health] Replace magic numbers with named constants in export.test.ts

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -710,11 +710,11 @@ describe("formatDate", () => {
 	it("formats correctly for minute steps (< 3600)", () => {
 		const date1 = new Date(2023, 0, 15, 9, 5, 0);
 		const val1 = Math.floor(date1.getTime() / 1000);
-		expect(formatDate(val1, 60)).toBe("09:05");
+		expect(formatDate(val1, UNIT_SECONDS.minute)).toBe("09:05");
 
 		const date2 = new Date(2023, 0, 15, 14, 30, 0);
 		const val2 = Math.floor(date2.getTime() / 1000);
-		expect(formatDate(val2, 1)).toBe("14:30");
+		expect(formatDate(val2, UNIT_SECONDS.second)).toBe("14:30");
 	});
 });
 


### PR DESCRIPTION
🎯 **What:** Replaced the magic numbers `60` and `1` with their respective named constants `UNIT_SECONDS.minute` and `UNIT_SECONDS.second` in `src/services/__tests__/export.test.ts`.

💡 **Why:** Using named constants instead of raw literal numbers improves code readability and maintainability. This aligns with existing patterns in the test file where `UNIT_SECONDS.day` and `UNIT_SECONDS.hour` are already used.

✅ **Verification:** Verified the exact property names in `src/utils/time.ts`, inspected the replacement using `git diff`, and ensured all tests passed successfully using `pnpm run test` and `pnpm run lint`.

✨ **Result:** Enhanced the clarity of test assertions by standardizing how time values are formatted, without altering existing functionality.

---
*PR created automatically by Jules for task [12334867114924167405](https://jules.google.com/task/12334867114924167405) started by @michaelkrisper*