### PR TITLE
🧹 Refactor magic numbers into named constants in detectors.ts

### DIFF
--- a/src/components/Layout/ImportSettings/utils/detectors.ts
+++ b/src/components/Layout/ImportSettings/utils/detectors.ts
@@ -1,5 +1,8 @@
 import type { ColumnType } from "../../../../types/import";
 
+const CONSISTENCY_WEIGHT = 1000;
+const MAX_LINES_TO_SAMPLE = 100;
+
 export function calculateDelimiterScore(lines: string[], delimiter: string): number {
 	let totalCount = 0;
 	const counts = new Map<number, number>();
@@ -17,7 +20,7 @@ export function calculateDelimiterScore(lines: string[], delimiter: string): num
 
 	// Score: number of lines with the most consistent non-zero count,
 	// plus a small bonus for total count to break ties.
-	return maxConsistency * 1000 + totalCount;
+	return maxConsistency * CONSISTENCY_WEIGHT + totalCount;
 }
 
 export function detectDelimiter(
@@ -29,7 +32,7 @@ export function detectDelimiter(
 
 	const lines = fileContent
 		.split(/\r?\n/)
-		.slice(0, 100)
+		.slice(0, MAX_LINES_TO_SAMPLE)
 		.filter((l) => l.trim());
 	if (lines.length === 0) return ",";
 
@@ -51,7 +54,7 @@ export function detectDecimalPoint(fileContent: string, delimiter: string): stri
 	if (!fileContent) return ".";
 	const lines = fileContent
 		.split(/\r?\n/)
-		.slice(0, 100)
+		.slice(0, MAX_LINES_TO_SAMPLE)
 		.filter((l) => l.trim());
 	let dotCount = 0;
 	let commaCount = 0;


### PR DESCRIPTION
🎯 **What:** Extracted magic numbers `1000` and `100` into `CONSISTENCY_WEIGHT` and `MAX_LINES_TO_SAMPLE` named constants in `src/components/Layout/ImportSettings/utils/detectors.ts`.
💡 **Why:** This improves the maintainability and readability of the codebase by giving meaningful names to numerical values used in the logic.
✅ **Verification:** Verified the code changes using `git diff`. Ran the project test suite using `pnpm run test`, which successfully executed all tests to ensure the logic remained correct.
✨ **Result:** A more readable and maintainable codebase without magic numbers in the detectors utility.

---
*PR created automatically by Jules for task [10346702364699158197](https://jules.google.com/task/10346702364699158197) started by @michaelkrisper*