### PR TITLE
🧹 Refactor: Extract magic numbers in `seriesPrep.test.ts`

### DIFF
--- a/src/components/Plot/__tests__/seriesPrep.test.ts
+++ b/src/components/Plot/__tests__/seriesPrep.test.ts
@@ -116,11 +116,13 @@ describe("computeDataSlice", () => {
 		// stored values are deltas; absolute = stored + ref
 		const xData = new Float32Array([0, 1, 2, 3]);
 		const ref = 1000;
+		const windowStart = ref + 1;
+		const windowEnd = ref + 2;
 		// window in absolute coords
-		const r = computeDataSlice(xData, 1001, 1002, ref, true);
+		const r = computeDataSlice(xData, windowStart, windowEnd, ref, true);
 		// absolute values are [1000, 1001, 1002, 1003]
-		// findLastLE(1001) -> idx 1, -1 padding -> 0
-		// findFirstGE(1002) -> idx 2, +1 padding -> 3
+		// findLastLE(windowStart) -> idx 1, -1 padding -> 0
+		// findFirstGE(windowEnd) -> idx 2, +1 padding -> 3
 		expect(r).toEqual({ sliceStart: 0, sliceEnd: 3 });
 	});
 });


### PR DESCRIPTION
🎯 **What:** Extracted the magic numbers `1001` and `1002` into named variables `windowStart` and `windowEnd` in `src/components/Plot/__tests__/seriesPrep.test.ts`. Defined them relative to the existing `ref` variable (e.g. `ref + 1`). Also updated the corresponding comments to reflect the new variable names.
💡 **Why:** This improves the readability and maintainability of the code by replacing raw literals with descriptive, context-aware constants, clarifying the relationship between the `ref` offset and the window bounds.
✅ **Verification:** Visually verified changes with `git diff`. Ran the test suite with `pnpm run test` which executed successfully without introducing any regressions or modifying existing behavior. Ensured no extraneous files (like `pnpm-lock.yaml`) were staged.
✨ **Result:** Clean, understandable test setup without ambiguous raw numbers.

---
*PR created automatically by Jules for task [5775221835195574300](https://jules.google.com/task/5775221835195574300) started by @michaelkrisper*