### PR TITLE
🧹 Replace magic number 720 with 12 * 60 in demoData tests

### DIFF
--- a/src/services/__tests__/demoData.test.ts
+++ b/src/services/__tests__/demoData.test.ts
@@ -190,8 +190,8 @@ describe("demoData", () => {
 
 		// Verify solar irradiance reduction due to clouds (hour 12 is daytime)
 		// rowCount = 1000 -> 1000 minutes = 16.6 hours. Hour of day starts at 0.
-		// Let's check row index 720 (12 hours * 60 mins). This is definitely daytime.
-		const daytimeIdx = 720;
+		// Let's check row index corresponding to 12 hours * 60 mins. This is definitely daytime.
+		const daytimeIdx = 12 * 60;
 
 		const baseSolarCol = baseDataset.data[3];
 		const edgeSolarCol = edgeDataset.data[3];


### PR DESCRIPTION
🎯 **What:** The magic number `720` in `src/services/__tests__/demoData.test.ts` was replaced with the explicit calculation `12 * 60`. 
💡 **Why:** This improves readability and maintainability by making it clear that the index represents 12 hours converted into minutes, as explained in the adjacent comment.
✅ **Verification:** Verified the fix visually via `git diff`. Ran the project's linter and full test suite via `pnpm run lint` and `pnpm run test`, both of which passed completely. Ensured no unintended lockfiles were committed.
✨ **Result:** The test file is now cleaner and its logic is more immediately understandable to other developers without relying solely on comments.

---
*PR created automatically by Jules for task [9878965074439884742](https://jules.google.com/task/9878965074439884742) started by @michaelkrisper*