### PR TITLE
🧹 refactor: replace magic numbers in export tests with named constants

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -693,28 +693,28 @@ describe("downloadFile", () => {
 });
 
 describe("formatDate", () => {
-	it("formats correctly for daily steps (>= 86400)", () => {
+	it(`formats correctly for daily steps (>= ${UNIT_SECONDS.day})`, () => {
 		const date = new Date(2023, 0, 15, 12, 0, 0);
 		const val = Math.floor(date.getTime() / 1000);
 		expect(formatDate(val, UNIT_SECONDS.day)).toBe("15.1.");
-		expect(formatDate(val, 90000)).toBe("15.1.");
+		expect(formatDate(val, UNIT_SECONDS.day + 3600)).toBe("15.1.");
 	});
 
-	it("formats correctly for hourly steps (>= 3600 but < 86400)", () => {
+	it(`formats correctly for hourly steps (>= ${UNIT_SECONDS.hour} but < ${UNIT_SECONDS.day})`, () => {
 		const date = new Date(2023, 0, 15, 9, 30, 0);
 		const val = Math.floor(date.getTime() / 1000);
 		expect(formatDate(val, UNIT_SECONDS.hour)).toBe("9:00");
-		expect(formatDate(val, 7200)).toBe("9:00");
+		expect(formatDate(val, UNIT_SECONDS.hour * 2)).toBe("9:00");
 	});
 
-	it("formats correctly for minute steps (< 3600)", () => {
+	it(`formats correctly for minute steps (< ${UNIT_SECONDS.hour})`, () => {
 		const date1 = new Date(2023, 0, 15, 9, 5, 0);
 		const val1 = Math.floor(date1.getTime() / 1000);
-		expect(formatDate(val1, 60)).toBe("09:05");
+		expect(formatDate(val1, UNIT_SECONDS.minute)).toBe("09:05");
 
 		const date2 = new Date(2023, 0, 15, 14, 30, 0);
 		const val2 = Math.floor(date2.getTime() / 1000);
-		expect(formatDate(val2, 1)).toBe("14:30");
+		expect(formatDate(val2, UNIT_SECONDS.second)).toBe("14:30");
 	});
 });
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced hardcoded magic numbers (e.g., `86400`, `3600`, `90000`, `7200`, `60`, `1`) in the `formatDate` test suite of `src/services/__tests__/export.test.ts` with named constants derived from `UNIT_SECONDS`.

💡 **Why:** How this improves maintainability
Using named constants instead of raw literals drastically improves code readability by clearly communicating the intent and unit of the values (e.g., `UNIT_SECONDS.hour * 2` vs `7200`). This ensures that developers can easily understand the test conditions at a glance without having to mentally convert seconds into meaningful durations.

✅ **Verification:** How you confirmed the change is safe
1. Replaced the literals accurately via Git merge diff based on direct inspection of the file lines.
2. Manually verified the changes with `git diff`.
3. Ran `pnpm run test src/services/__tests__/export.test.ts` successfully to ensure no functionality or assertions were broken.
4. Ran `pnpm run lint` and the linting suite passed successfully.

✨ **Result:** The improvement achieved
A more readable and maintainable test suite where the expected unit durations are self-documenting.

---
*PR created automatically by Jules for task [6248052015801169563](https://jules.google.com/task/6248052015801169563) started by @michaelkrisper*