### PR TITLE
🧹 Refactor magic numbers in export tests to use named constants

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -693,28 +693,28 @@ describe("downloadFile", () => {
 });
 
 describe("formatDate", () => {
-	it("formats correctly for daily steps (>= 86400)", () => {
+	it(`formats correctly for daily steps (>= ${UNIT_SECONDS.day})`, () => {
 		const date = new Date(2023, 0, 15, 12, 0, 0);
 		const val = Math.floor(date.getTime() / 1000);
 		expect(formatDate(val, UNIT_SECONDS.day)).toBe("15.1.");
-		expect(formatDate(val, 90000)).toBe("15.1.");
+		expect(formatDate(val, 25 * UNIT_SECONDS.hour)).toBe("15.1.");
 	});
 
-	it("formats correctly for hourly steps (>= 3600 but < 86400)", () => {
+	it(`formats correctly for hourly steps (>= ${UNIT_SECONDS.hour} but < ${UNIT_SECONDS.day})`, () => {
 		const date = new Date(2023, 0, 15, 9, 30, 0);
 		const val = Math.floor(date.getTime() / 1000);
 		expect(formatDate(val, UNIT_SECONDS.hour)).toBe("9:00");
-		expect(formatDate(val, 7200)).toBe("9:00");
+		expect(formatDate(val, 2 * UNIT_SECONDS.hour)).toBe("9:00");
 	});
 
-	it("formats correctly for minute steps (< 3600)", () => {
+	it(`formats correctly for minute steps (< ${UNIT_SECONDS.hour})`, () => {
 		const date1 = new Date(2023, 0, 15, 9, 5, 0);
 		const val1 = Math.floor(date1.getTime() / 1000);
-		expect(formatDate(val1, 60)).toBe("09:05");
+		expect(formatDate(val1, UNIT_SECONDS.minute)).toBe("09:05");
 
 		const date2 = new Date(2023, 0, 15, 14, 30, 0);
 		const val2 = Math.floor(date2.getTime() / 1000);
-		expect(formatDate(val2, 1)).toBe("14:30");
+		expect(formatDate(val2, UNIT_SECONDS.second)).toBe("14:30");
 	});
 });
 


### PR DESCRIPTION
🎯 **What:** Replaced raw magic numbers with calculations using `UNIT_SECONDS` constants in the `formatDate` test block within `src/services/__tests__/export.test.ts`. Also updated test descriptions to dynamically interpolate these constants.
💡 **Why:** Using named constants rather than hardcoded numeric literals (like `90000` or `7200`) explicitly clarifies the intent behind the values being tested (e.g., representing exactly one day and one hour, or exactly two hours), which improves both code readability and future maintainability.
✅ **Verification:** Verified the applied replacements with `git diff`, and ensured the refactor caused no regressions by running both the specific modified test file and the full test suite (`pnpm run test`), with all tests passing successfully.
✨ **Result:** A more readable and maintainable test suite where the semantic meaning of boundary values is explicitly self-documenting.

---
*PR created automatically by Jules for task [8819401776852912893](https://jules.google.com/task/8819401776852912893) started by @michaelkrisper*