### PR TITLE
🧹 [code health improvement] Extract magic number into constant in PopupPicker.test.tsx

### DIFF
--- a/src/components/Sidebar/__tests__/PopupPicker.test.tsx
+++ b/src/components/Sidebar/__tests__/PopupPicker.test.tsx
@@ -205,8 +205,10 @@ describe("PopupPicker", () => {
 	});
 
 	it("calculates coordinates based on window size and trigger position", () => {
+		const WINDOW_WIDTH = 1000;
+
 		// Mock innerWidth
-		vi.stubGlobal("innerWidth", 1000);
+		vi.stubGlobal("innerWidth", WINDOW_WIDTH);
 		vi.stubGlobal("scrollX", 0);
 		vi.stubGlobal("scrollY", 0);
 
@@ -232,7 +234,7 @@ describe("PopupPicker", () => {
 			top: 100,
 			left: 900,
 			bottom: 140,
-			right: 1000,
+			right: WINDOW_WIDTH,
 			x: 900,
 			y: 100,
 			toJSON: () => {}


### PR DESCRIPTION
🎯 **What:** Extracted the magic number `1000` into a `WINDOW_WIDTH` constant in `src/components/Sidebar/__tests__/PopupPicker.test.tsx`.
💡 **Why:** Hardcoded numbers in tests are hard to trace and update. By extracting this specific boundary value into a named constant (`WINDOW_WIDTH`), the relationship between the mocked global window width (`innerWidth`) and the right boundary coordinate in the test layout mock (`getBoundingClientRect().right`) is made explicitly clear. This improves readability and maintainability.
✅ **Verification:** Verified by using `git diff` to visually inspect the applied patch, executing `pnpm run test src/components/Sidebar/__tests__/PopupPicker.test.tsx` to ensure the targeted test still passes, and executing `pnpm run test` to verify the entire test suite remains unaffected.
✨ **Result:** The code is cleaner, explicitly links related setup values, and avoids repeating raw magic numbers.

---
*PR created automatically by Jules for task [17684241814292105774](https://jules.google.com/task/17684241814292105774) started by @michaelkrisper*