### PR TITLE
🧹 [Code Health] Replace magic number with IDLE_WAKE_THRESHOLD_MS in renderBackend.ts

### DIFF
--- a/src/components/Plot/renderBackend.ts
+++ b/src/components/Plot/renderBackend.ts
@@ -34,6 +34,8 @@ import {
 } from "./rendererCore";
 import { VIEWPORT_SAB_BYTES, ViewportWriter } from "./viewportChannel";
 
+const IDLE_WAKE_THRESHOLD_MS = 1000;
+
 export interface RenderBackend {
 	setViewport(viewport: RendererViewport): void;
 	setPlotBg(rgb: number[]): void;
@@ -309,7 +311,7 @@ class WorkerBackend implements RenderBackend {
 			// The worker's render loop parks itself when idle; nudge it back to
 			// life when writes resume after a pause.
 			const now = Date.now();
-			if (now - this.lastWriteAt > 1000) this.post({ t: "wake" });
+			if (now - this.lastWriteAt > IDLE_WAKE_THRESHOLD_MS) this.post({ t: "wake" });
 			this.lastWriteAt = now;
 			return;
 		}


### PR DESCRIPTION
🎯 **What:** Replaced the hardcoded `1000` magic number in `src/components/Plot/renderBackend.ts` with a clearly named constant `IDLE_WAKE_THRESHOLD_MS`.

💡 **Why:** This improves maintainability and readability by explicitly stating the intent of the number (which represents the 1-second timeout before the worker's render loop is prodded back to life after being idle).

✅ **Verification:** 
- Visual inspection via `git diff`.
- Code passed the linter without errors (`pnpm run lint`).
- The entire test suite (`pnpm run test`) and specific file tests ran and all passed.

✨ **Result:** The code is cleaner, more readable, and explicitly declares the intent behind the threshold logic.

---
*PR created automatically by Jules for task [4329398740616996151](https://jules.google.com/task/4329398740616996151) started by @michaelkrisper*