### PR TITLE
🧹 refactor(tests): replace magic numbers with UNIT_SECONDS constants in export tests

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -693,28 +693,30 @@ describe("downloadFile", () => {
 });
 
 describe("formatDate", () => {
-	it("formats correctly for daily steps (>= 86400)", () => {
+	it(`formats correctly for daily steps (>= ${UNIT_SECONDS.day})`, () => {
 		const date = new Date(2023, 0, 15, 12, 0, 0);
 		const val = Math.floor(date.getTime() / 1000);
 		expect(formatDate(val, UNIT_SECONDS.day)).toBe("15.1.");
-		expect(formatDate(val, 90000)).toBe("15.1.");
+		expect(formatDate(val, UNIT_SECONDS.day + 1 * UNIT_SECONDS.hour)).toBe(
+			"15.1.",
+		);
 	});
 
-	it("formats correctly for hourly steps (>= 3600 but < 86400)", () => {
+	it(`formats correctly for hourly steps (>= ${UNIT_SECONDS.hour} but < ${UNIT_SECONDS.day})`, () => {
 		const date = new Date(2023, 0, 15, 9, 30, 0);
 		const val = Math.floor(date.getTime() / 1000);
 		expect(formatDate(val, UNIT_SECONDS.hour)).toBe("9:00");
-		expect(formatDate(val, 7200)).toBe("9:00");
+		expect(formatDate(val, 2 * UNIT_SECONDS.hour)).toBe("9:00");
 	});
 
-	it("formats correctly for minute steps (< 3600)", () => {
+	it(`formats correctly for minute steps (< ${UNIT_SECONDS.hour})`, () => {
 		const date1 = new Date(2023, 0, 15, 9, 5, 0);
 		const val1 = Math.floor(date1.getTime() / 1000);
-		expect(formatDate(val1, 60)).toBe("09:05");
+		expect(formatDate(val1, UNIT_SECONDS.minute)).toBe("09:05");
 
 		const date2 = new Date(2023, 0, 15, 14, 30, 0);
 		const val2 = Math.floor(date2.getTime() / 1000);
-		expect(formatDate(val2, 1)).toBe("14:30");
+		expect(formatDate(val2, UNIT_SECONDS.second)).toBe("14:30");
 	});
 });
 


### PR DESCRIPTION
🎯 **What:** Replaced hardcoded magic numbers representing time values in `src/services/__tests__/export.test.ts` with named constants from `src/utils/time.ts` (`UNIT_SECONDS`). Also updated the test descriptions to use template literals to dynamically reflect these constants.
💡 **Why:** Hardcoded magic numbers (e.g., `86400`, `3600`) make time calculations harder to read and maintain. Using named constants clearly communicates the intent and ensures consistency across the codebase.
✅ **Verification:** Verified the fix by successfully running the full test suite (`pnpm run test`) and confirming no regressions were introduced. Also ensured lint checks passed (`pnpm run lint`).
✨ **Result:** Improved maintainability and clarity within the test suite, allowing the values and their descriptions to stay cleanly in sync with the source constants.

---
*PR created automatically by Jules for task [7266920195571784899](https://jules.google.com/task/7266920195571784899) started by @michaelkrisper*