### PR TITLE
🧹 [Code Health] Replace magic numbers with named constants in export tests

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -697,24 +697,24 @@ describe("formatDate", () => {
 		const date = new Date(2023, 0, 15, 12, 0, 0);
 		const val = Math.floor(date.getTime() / 1000);
 		expect(formatDate(val, UNIT_SECONDS.day)).toBe("15.1.");
-		expect(formatDate(val, 90000)).toBe("15.1.");
+		expect(formatDate(val, 25 * UNIT_SECONDS.hour)).toBe("15.1.");
 	});
 
 	it("formats correctly for hourly steps (>= 3600 but < 86400)", () => {
 		const date = new Date(2023, 0, 15, 9, 30, 0);
 		const val = Math.floor(date.getTime() / 1000);
 		expect(formatDate(val, UNIT_SECONDS.hour)).toBe("9:00");
-		expect(formatDate(val, 7200)).toBe("9:00");
+		expect(formatDate(val, 2 * UNIT_SECONDS.hour)).toBe("9:00");
 	});
 
 	it("formats correctly for minute steps (< 3600)", () => {
 		const date1 = new Date(2023, 0, 15, 9, 5, 0);
 		const val1 = Math.floor(date1.getTime() / 1000);
-		expect(formatDate(val1, 60)).toBe("09:05");
+		expect(formatDate(val1, UNIT_SECONDS.minute)).toBe("09:05");
 
 		const date2 = new Date(2023, 0, 15, 14, 30, 0);
 		const val2 = Math.floor(date2.getTime() / 1000);
-		expect(formatDate(val2, 1)).toBe("14:30");
+		expect(formatDate(val2, UNIT_SECONDS.second)).toBe("14:30");
 	});
 });
 


### PR DESCRIPTION
🎯 **What:** Replaced hardcoded "magic numbers" (`90000`, `7200`, `60`, `1`) in `src/services/__tests__/export.test.ts` with named constants derived from `UNIT_SECONDS`.
💡 **Why:** Using named constants clarifies the intent of the time values being tested (e.g., `25 * UNIT_SECONDS.hour` instead of `90000`), making the test suite significantly easier to read and maintain.
✅ **Verification:**
- Visually verified changes with `git diff`.
- Successfully ran `pnpm run test src/services/__tests__/export.test.ts` to ensure no functionality in the modified tests was broken.
- Successfully ran the entire test suite (`pnpm run test`) which passed all 1012 tests.
- Successfully ran the project linter (`pnpm run lint`).
- Removed the unintentionally generated `pnpm-lock.yaml` file to prevent PR bloat.
✨ **Result:** Improved code health and readability in the export test suite without any functional regressions.

---
*PR created automatically by Jules for task [15162103476773786530](https://jules.google.com/task/15162103476773786530) started by @michaelkrisper*