### PR TITLE
🧹 refactor: replace magic number 1000 with named constant

### DIFF
--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -4,7 +4,7 @@ import { getColumnIndex } from "../utils/columns";
 import { worldToScreen } from "../utils/coords";
 import { m4Float32 } from "../utils/decimation";
 import { escapeHTML } from "../utils/dom";
-import { UNIT_SECONDS } from "../utils/time";
+import { MS_PER_SECOND, UNIT_SECONDS } from "../utils/time";
 import type {
 	Dataset,
 	SeriesConfig,
@@ -432,7 +432,7 @@ export const exportToSVG = (
  * @returns {string} Formatted date/time label (e.g., "14.3." or "15:30")
  */
 export const formatDate = (val: number, step: number) => {
-	const d = new Date(val * 1000);
+	const d = new Date(val * MS_PER_SECOND);
 	if (step >= UNIT_SECONDS.day) return `${d.getDate()}.${d.getMonth() + 1}.`;
 	if (step >= UNIT_SECONDS.hour) return `${d.getHours()}:00`;
 	return (

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -48,6 +48,8 @@ const formatFullDateTime = lazyFmt({
 	fractionalSecondDigits: 3,
 });
 
+export const MS_PER_SECOND = 1000;
+
 export const UNIT_SECONDS = {
 	second: 1,
 	minute: 60,


### PR DESCRIPTION
🎯 **What:** Replaced the magic number `1000` used for date conversion in `src/services/export.ts` with a newly defined named constant `MS_PER_SECOND` from `src/utils/time.ts`.
💡 **Why:** Using named constants instead of raw literals drastically improves code readability, clarifying the developer's intent and making the codebase easier to maintain.
✅ **Verification:** Verified by running `pnpm run lint` and the complete test suite (`pnpm run test`), both of which passed successfully, ensuring no regressions.
✨ **Result:** Improved maintainability and self-documenting code without altering any existing runtime behavior.

---
*PR created automatically by Jules for task [11360175032445746997](https://jules.google.com/task/11360175032445746997) started by @michaelkrisper*