### PR TITLE
🧹 [Code Health] Replace magic number with constant in demoData test

### DIFF
--- a/src/services/__tests__/demoData.test.ts
+++ b/src/services/__tests__/demoData.test.ts
@@ -228,10 +228,12 @@ describe("demoData", () => {
 				randomUUID: () => mockUUID,
 			});
 
+			const MOCK_ROW_COUNT = 10;
+
 			const mockDataset = {
 				id: "mock-dataset-id",
 				name: "Mock Dataset",
-				rowCount: 10,
+				rowCount: MOCK_ROW_COUNT,
 				xAxisColumn: "A: Timestamp",
 				xAxisId: "axis-1",
 				columns: [
@@ -246,31 +248,31 @@ describe("demoData", () => {
 						isFloat64: true,
 						refPoint: 0,
 						bounds: { min: 1000000, max: 2000000 },
-						data: new Float64Array(10),
+						data: new Float64Array(MOCK_ROW_COUNT),
 					},
 					{
 						isFloat64: false,
 						refPoint: 0,
 						bounds: { min: 0, max: 10 },
-						data: new Float32Array(10),
+						data: new Float32Array(MOCK_ROW_COUNT),
 					},
 					{
 						isFloat64: false,
 						refPoint: 0,
 						bounds: { min: 0, max: 100 },
-						data: new Float32Array(10),
+						data: new Float32Array(MOCK_ROW_COUNT),
 					},
 					{
 						isFloat64: false,
 						refPoint: 0,
 						bounds: { min: 0, max: 1000 },
-						data: new Float32Array(10),
+						data: new Float32Array(MOCK_ROW_COUNT),
 					},
 					{
 						isFloat64: false,
 						refPoint: 0,
 						bounds: { min: 0, max: 20 },
-						data: new Float32Array(10),
+						data: new Float32Array(MOCK_ROW_COUNT),
 					},
 				],
 			} as unknown as Dataset;


### PR DESCRIPTION
🎯 **What:** Replaced the repeated magic number `10` with a named constant `MOCK_ROW_COUNT` in `src/services/__tests__/demoData.test.ts`.

💡 **Why:** Using a named constant instead of a raw literal improves code readability and maintainability by making the relationship between the dataset's `rowCount` and the data array lengths explicit.

✅ **Verification:** Verified that the changes do not break any tests by running `pnpm run test src/services/__tests__/demoData.test.ts` and confirming all tests pass. Also ensured no new linting errors with `pnpm run lint`.

✨ **Result:** Improved codebase maintainability without altering functionality.

---
*PR created automatically by Jules for task [18392051310912335358](https://jules.google.com/task/18392051310912335358) started by @michaelkrisper*