### PR TITLE
🧹 Code Health: Extract RESOLUTION_SECONDS constant in demoData

### DIFF
--- a/src/services/__tests__/demoData.test.ts
+++ b/src/services/__tests__/demoData.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as randomUtils from "../../utils/random";
-import { generateDemoDataset, getDemoAppState } from "../demoData";
+import {
+	RESOLUTION_SECONDS,
+	generateDemoDataset,
+	getDemoAppState,
+} from "../demoData";
 import type { Dataset } from "../persistence";
 
 describe("demoData", () => {
@@ -91,7 +95,7 @@ describe("demoData", () => {
 			});
 		});
 
-		it("should generate deterministic timestamps strictly increasing by 60", () => {
+		it(`should generate deterministic timestamps strictly increasing by ${RESOLUTION_SECONDS}`, () => {
 			const dataset = generateDemoDataset(100);
 			const tsCol = dataset.data[0];
 
@@ -101,15 +105,15 @@ describe("demoData", () => {
 
 			// Timestamp bounds check
 			expect(tsCol.bounds.max - tsCol.bounds.min).toBe(
-				(dataset.rowCount - 1) * 60,
+				(dataset.rowCount - 1) * RESOLUTION_SECONDS,
 			);
 
 			// Relative data check
 			expect(tsCol.data[0]).toBe(0);
-			expect(tsCol.data[1]).toBe(60);
-			expect(tsCol.data[2]).toBe(120);
+			expect(tsCol.data[1]).toBe(RESOLUTION_SECONDS);
+			expect(tsCol.data[2]).toBe(RESOLUTION_SECONDS * 2);
 			expect(tsCol.data[dataset.rowCount - 1]).toBe(
-				(dataset.rowCount - 1) * 60,
+				(dataset.rowCount - 1) * RESOLUTION_SECONDS,
 			);
 		});
 

--- a/src/services/demoData.ts
+++ b/src/services/demoData.ts
@@ -6,6 +6,8 @@ import type {
 	YAxisConfig,
 } from "./persistence";
 
+export const RESOLUTION_SECONDS = 60;
+
 export function generateDemoDataset(rowCount = 10000): Dataset {
 	const columns = [
 		"Timestamp",
@@ -27,7 +29,7 @@ export function generateDemoDataset(rowCount = 10000): Dataset {
 	}));
 
 	for (let i = 0; i < rowCount; i++) {
-		const ts = startTime + i * 60; // 1 minute resolution
+		const ts = startTime + i * RESOLUTION_SECONDS; // 1 minute resolution
 		const minutesElapsed = i;
 		const hourOfDay = (minutesElapsed / 60) % 24;
 		const dayOfYear = (minutesElapsed / (24 * 60)) % 365;


### PR DESCRIPTION
🎯 **What:** Extracted the magic number `60` into a named constant `RESOLUTION_SECONDS` in `src/services/demoData.ts` and updated `src/services/__tests__/demoData.test.ts` to use it.
💡 **Why:** Magic numbers make code harder to read and maintain. By defining `RESOLUTION_SECONDS`, the intent of the value is clear, and any future changes to the timestamp resolution will automatically propagate to the test assertions, preventing test drift.
✅ **Verification:** Verified that linting passes (`pnpm run lint`) and all tests pass without regressions (`pnpm run test`). Ensured `git status` only contained the intended source and test file changes.
✨ **Result:** Improved maintainability and readability of the demo data generation logic and its associated tests.

---
*PR created automatically by Jules for task [2135911092598011670](https://jules.google.com/task/2135911092598011670) started by @michaelkrisper*