### PR TITLE
🧹 Code Health: Improve readability of MAX_DERIVED_CATEGORY_LABELS

### DIFF
--- a/src/components/Plot/categoryLabels.ts
+++ b/src/components/Plot/categoryLabels.ts
@@ -14,7 +14,7 @@ import {
 import { getColumnIndex } from "../../utils/columns";
 
 /** Cap on x-values sampled when deriving categorical labels for a forced axis. */
-export const MAX_DERIVED_CATEGORY_LABELS = 1000;
+export const MAX_DERIVED_CATEGORY_LABELS = 1_000;
 
 export interface XAxisCategoryInfo {
 	labels: string[];


### PR DESCRIPTION
🎯 **What:** Improved the readability of the `MAX_DERIVED_CATEGORY_LABELS` constant by utilizing a numeric separator (`1_000` instead of `1000`).
💡 **Why:** This makes the numeric literal more readable and explicitly addresses the code health issue regarding raw magic number usage on line 17 of `src/components/Plot/categoryLabels.ts`. Note that the value was already bound to a well-named constant, making this a stylistic enhancement.
✅ **Verification:** Verified the code changes using `git diff` and ran the full project test suite (`pnpm run test`) to ensure no functionality was broken.
✨ **Result:** Enhanced code maintainability and readability without altering runtime behavior.

---
*PR created automatically by Jules for task [15470747001127934199](https://jules.google.com/task/15470747001127934199) started by @michaelkrisper*