### PR TITLE
🧪 Add missing error handling test for persistence loadState

### DIFF
--- a/src/services/__tests__/persistence.test.ts
+++ b/src/services/__tests__/persistence.test.ts
@@ -489,5 +489,25 @@ describe("persistence", () => {
 			);
 			consoleSpy.mockRestore();
 		});
+
+		it("should catch error when loadAppState fails", async () => {
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			const error = new Error("Load failed");
+			const mockDb = {
+				get: vi.fn().mockRejectedValue(error),
+			};
+			openDBMock.mockResolvedValueOnce(mockDb);
+
+			const result = await persistence.loadAppState();
+
+			expect(result).toBeNull();
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Failed to load state",
+				{ error: expect.any(Error) },
+			);
+			consoleSpy.mockRestore();
+		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** The missing test coverage for the error handling branch in `persistence.ts`'s state loading logic.
📊 **Coverage:** The scenario where IndexedDB fails to read the application state (`db.get` throws) is now tested.
✨ **Result:** Test coverage for `src/services/persistence.ts` is now improved and handles the required edge cases.

---
*PR created automatically by Jules for task [1116822102071121024](https://jules.google.com/task/1116822102071121024) started by @michaelkrisper*