### PR TITLE
🧪 Add unit tests for exportToPNG error handling

### DIFF
--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -520,6 +520,28 @@ describe("exportToPNG", () => {
 		expect(mockCtx.drawImage).toHaveBeenCalled();
 		expect(URL.revokeObjectURL).toHaveBeenCalled();
 	});
+
+	it("should reject if getContext returns null", async () => {
+		mockCanvas.getContext = vi.fn(() => null);
+		await expect(
+			exportToPNG([], [], [], [], 800, 600, THEMES.light)
+		).rejects.toThrow("Could not get 2D context");
+	});
+
+	it("should reject if image fails to load", async () => {
+		class MockImageError {
+			onerror: (() => void) | null = null;
+			set src(_val: string) {
+				if (this.onerror) setTimeout(this.onerror, 0);
+			}
+		}
+		vi.stubGlobal("Image", MockImageError);
+
+		await expect(
+			exportToPNG([], [], [], [], 800, 600, THEMES.light)
+		).rejects.toThrow("Failed to load SVG into image for PNG export");
+		expect(URL.revokeObjectURL).toHaveBeenCalled();
+	});
 });
 
 describe("downloadFile", () => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `exportToPNG` function in `src/services/export.ts` had untested error handling paths, specifically when the 2D canvas context cannot be retrieved and when the SVG image fails to load into the canvas. 

📊 **Coverage:** What scenarios are now tested
Added two new test cases to `src/services/__tests__/export.test.ts`:
- A test that mocks `mockCanvas.getContext` to return `null`, verifying that the function rejects with "Could not get 2D context".
- A test that stubs `global.Image` to simulate an `onerror` event, verifying that the function rejects with "Failed to load SVG into image for PNG export" and properly revokes the Object URL.

✨ **Result:** The improvement in test coverage
Test coverage for the error handling branches in `exportToPNG` is now fully complete, ensuring reliable behavior when underlying DOM APIs fail.

---
*PR created automatically by Jules for task [8281944491968236730](https://jules.google.com/task/8281944491968236730) started by @michaelkrisper*