### PR TITLE
🧪 Add unit tests for logger utility

### DIFF
--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from '../logger';
+
+describe('logger', () => {
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleErrorSpy.mockRestore();
+		consoleWarnSpy.mockRestore();
+	});
+
+	describe('error', () => {
+		it('calls console.error with the provided message', () => {
+			logger.error('An error occurred');
+			expect(consoleErrorSpy).toHaveBeenCalledWith('An error occurred');
+		});
+
+		it('calls console.error with the provided message and details', () => {
+			const errorObj = new Error('Test error');
+			logger.error('An error occurred', { detail: 'something' }, errorObj);
+			expect(consoleErrorSpy).toHaveBeenCalledWith('An error occurred', { detail: 'something' }, errorObj);
+		});
+	});
+
+	describe('warn', () => {
+		it('calls console.warn with the provided message', () => {
+			logger.warn('A warning occurred');
+			expect(consoleWarnSpy).toHaveBeenCalledWith('A warning occurred');
+		});
+
+		it('calls console.warn with the provided message and details', () => {
+			logger.warn('A warning occurred', { detail: 'something' }, 42);
+			expect(consoleWarnSpy).toHaveBeenCalledWith('A warning occurred', { detail: 'something' }, 42);
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The utility module `src/utils/logger.ts` was completely untested, despite being a core central logging shim.

📊 **Coverage:** What scenarios are now tested
Tests were added in `src/utils/__tests__/logger.test.ts` to cover:
- `logger.error` correctly delegating to `console.error` with standard and rest arguments.
- `logger.warn` correctly delegating to `console.warn` with standard and rest arguments.
- Spies are properly cleared and restored using `beforeEach` and `afterEach` hooks to prevent side effects in other tests.

✨ **Result:** The improvement in test coverage
The `logger.ts` file is now fully covered by unit tests, ensuring that any future refactoring of this choke point won't silently drop telemetry or logging outputs.

---
*PR created automatically by Jules for task [7212215677478554720](https://jules.google.com/task/7212215677478554720) started by @michaelkrisper*