### PR TITLE
🧹 [code health improvement] Convert overlayGeometry header comment to docstring

### DIFF
--- a/src/components/Plot/overlayGeometry.ts
+++ b/src/components/Plot/overlayGeometry.ts
@@ -1,8 +1,10 @@
-// Pure vertex-buffer writers for the overlay primitives drawn by
-// WebGLRenderer.buildOverlay. Each helper appends its geometry to a packed
-// Float32Array starting at the supplied write index and returns the next
-// write index, so the caller can sum vertex counts and push draw groups
-// while the geometry itself stays testable in isolation.
+/**
+ * Pure vertex-buffer writers for the overlay primitives drawn by
+ * WebGLRenderer.buildOverlay. Each helper appends its geometry to a packed
+ * Float32Array starting at the supplied write index and returns the next
+ * write index, so the caller can sum vertex counts and push draw groups
+ * while the geometry itself stays testable in isolation.
+ */
 
 import { DEFAULT_GUTTER_TOTAL } from "./axisGutters";
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a dangling `//` comment block at the top of `src/components/Plot/overlayGeometry.ts` that described the file's purpose but wasn't formatted as a standard JSDoc block.

💡 **Why:** This improves maintainability by adopting standard JSDoc `/** ... */` syntax for the file's top-level module documentation, rather than leaving a sentence fragment hanging as a regular line comment.

✅ **Verification:**
- Ran `git diff` to verify the exact text replacement.
- Ran `pnpm run lint` and confirmed no ESLint warnings/errors were introduced.
- Ran `pnpm run test` and verified the full test suite passed correctly.

✨ **Result:** The codebase is cleaner and adheres more consistently to standard documentation formatting practices without altering any functional logic.

---
*PR created automatically by Jules for task [13581522322582893421](https://jules.google.com/task/13581522322582893421) started by @michaelkrisper*