### PR TITLE
test: add test coverage for generateSecondaryLabels max limit

### DIFF
--- a/src/utils/__tests__/time.test.ts
+++ b/src/utils/__tests__/time.test.ts
@@ -478,4 +478,21 @@ describe("generateSecondaryLabels", () => {
 
 		expect(labels.length).toBe(101);
 	});
+
+	it("caps the number of labels to prevent infinite loops (day unit with fitsMonths)", () => {
+		const min = 1673784000; // 2023-01-15
+		const max = 1673784000 + 200 * 2592000; // +200 months
+
+		const labels = generateSecondaryLabels(
+			min,
+			max,
+			{
+				unit: "day",
+				value: 1,
+			},
+			100000
+		);
+
+		expect(labels.length).toBe(101);
+	});
 });


### PR DESCRIPTION
Added a missing test case in `src/utils/__tests__/time.test.ts` to verify the upper limit (`MAX_SECONDARY_LABELS`) works correctly for day/week units when generating secondary labels. Fixes an uncovered branch in `generateSecondaryLabels` making the coverage for time.ts 100%.

---
*PR created automatically by Jules for task [8453184664510130892](https://jules.google.com/task/8453184664510130892) started by @michaelkrisper*