### PR TITLE
🧹 Extract Worker Client boilerplate to shared utility

### DIFF
--- a/src/workers/WorkerClient.ts
+++ b/src/workers/WorkerClient.ts
@@ -1,0 +1,53 @@
+export class WorkerClient<Req, Res extends { id?: number }, ParsedRes> {
+    private worker: Worker | null = null;
+    private nextId = 1;
+    private pending = new Map<
+        number,
+        { resolve: (value: ParsedRes) => void; reject: (reason: unknown) => void }
+    >();
+
+    constructor(
+        private workerFactory: () => Worker,
+        private onMessage: (
+            data: Res,
+            resolve: (value: ParsedRes) => void,
+            reject: (reason: unknown) => void,
+        ) => void,
+    ) {}
+
+    private ensureWorker(): Worker {
+        if (this.worker) return this.worker;
+        this.worker = this.workerFactory();
+        this.worker.onmessage = (ev: MessageEvent<Res>) => {
+            const data = ev.data;
+            if (data.id === undefined) return;
+            const entry = this.pending.get(data.id);
+            if (!entry) return;
+            this.pending.delete(data.id);
+            this.onMessage(data, entry.resolve, entry.reject);
+        };
+        this.worker.onerror = (ev) => {
+            const err =
+                ev instanceof Error ? ev : new Error(ev.message ?? "Worker error");
+            for (const entry of this.pending.values()) entry.reject(err);
+            this.pending.clear();
+            this.worker?.terminate();
+            this.worker = null;
+        };
+        return this.worker;
+    }
+
+    public request(createPayload: (id: number) => Req, transfer?: Transferable[]): Promise<ParsedRes> {
+        const id = this.nextId++;
+        const w = this.ensureWorker();
+        return new Promise<ParsedRes>((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            const req = createPayload(id);
+            if (transfer) {
+                w.postMessage(req, transfer);
+            } else {
+                w.postMessage(req);
+            }
+        });
+    }
+}

--- a/src/workers/WorkerClient.ts
+++ b/src/workers/WorkerClient.ts
@@ -6,14 +6,24 @@ export class WorkerClient<Req, Res extends { id?: number }, ParsedRes> {
         { resolve: (value: ParsedRes) => void; reject: (reason: unknown) => void }
     >();
 
+    private workerFactory: () => Worker;
+    private onMessage: (
+        data: Res,
+        resolve: (value: ParsedRes) => void,
+        reject: (reason: unknown) => void,
+    ) => void;
+
     constructor(
-        private workerFactory: () => Worker,
-        private onMessage: (
+        workerFactory: () => Worker,
+        onMessage: (
             data: Res,
             resolve: (value: ParsedRes) => void,
             reject: (reason: unknown) => void,
         ) => void,
-    ) {}
+    ) {
+        this.workerFactory = workerFactory;
+        this.onMessage = onMessage;
+    }
 
     private ensureWorker(): Worker {
         if (this.worker) return this.worker;

--- a/src/workers/excelClient.ts
+++ b/src/workers/excelClient.ts
@@ -1,57 +1,32 @@
 import type { ExcelWorkerRequest, ExcelWorkerResponse } from "./excel.worker";
+import { WorkerClient } from "./WorkerClient";
 
-let worker: Worker | null = null;
-let nextId = 1;
-const pending = new Map<
-    number,
-    {
-        resolve: (value: Omit<ExcelWorkerResponse, "id" | "type">) => void;
-        reject: (reason: unknown) => void;
+const client = new WorkerClient<
+    ExcelWorkerRequest,
+    ExcelWorkerResponse,
+    Omit<ExcelWorkerResponse, "id" | "type">
+>(
+    () => new Worker(new URL("./excel.worker.ts", import.meta.url), { type: "module" }),
+    (data, resolve, reject) => {
+        const { id, type, error, ...rest } = data;
+        void id;
+        if (type === "success") resolve(rest);
+        else reject(new Error(error ?? "Excel worker error"));
     }
->();
+);
 
-function ensureWorker(): Worker {
-    if (worker) return worker;
-    worker = new Worker(new URL("./excel.worker.ts", import.meta.url), {
-        type: "module",
-    });
-    worker.onmessage = (ev: MessageEvent<ExcelWorkerResponse>) => {
-        const { id, type, error, ...data } = ev.data;
-        const entry = pending.get(id);
-        if (!entry) return;
-        pending.delete(id);
-        if (type === "success") entry.resolve(data);
-        else entry.reject(new Error(error ?? "Excel worker error"));
-    };
-    worker.onerror = (ev) => {
-        const err = ev instanceof Error ? ev : new Error(ev.message ?? "Worker error");
-        for (const entry of pending.values()) entry.reject(err);
-        pending.clear();
-        worker?.terminate();
-        worker = null;
-    };
-    return worker;
-}
-
-export function readExcelFileInWorker(file: File): Promise<Omit<ExcelWorkerResponse, "id" | "type">> {
-    const id = nextId++;
-    const w = ensureWorker();
-    return new Promise((resolve, reject) => {
-        pending.set(id, { resolve, reject });
-        const req: ExcelWorkerRequest = { id, action: "read", file };
-        w.postMessage(req);
-    });
+export function readExcelFileInWorker(
+    file: File
+): Promise<Omit<ExcelWorkerResponse, "id" | "type">> {
+    return client.request((id) => ({ id, action: "read", file }));
 }
 
 export function changeSheetInWorker(
     workbookData: ArrayBuffer,
     sheetName: string
 ): Promise<Omit<ExcelWorkerResponse, "id" | "type">> {
-    const id = nextId++;
-    const w = ensureWorker();
-    return new Promise((resolve, reject) => {
-        pending.set(id, { resolve, reject });
-        const req: ExcelWorkerRequest = { id, action: "changeSheet", workbookData, sheetName };
-        w.postMessage(req, [workbookData]);
-    });
+    return client.request(
+        (id) => ({ id, action: "changeSheet", workbookData, sheetName }),
+        [workbookData]
+    );
 }

--- a/src/workers/formulaClient.ts
+++ b/src/workers/formulaClient.ts
@@ -1,49 +1,22 @@
 import type {
-	FormulaEvaluationResult,
-	FormulaWorkerParams,
+    FormulaEvaluationResult,
+    FormulaWorkerParams,
 } from "../utils/formula";
+import { WorkerClient } from "./WorkerClient";
 
-let worker: Worker | null = null;
-let nextId = 1;
-const pending = new Map<
-	number,
-	{
-		resolve: (value: FormulaEvaluationResult) => void;
-		reject: (reason: unknown) => void;
-	}
->();
-
-function ensureWorker(): Worker {
-	if (worker) return worker;
-	worker = new Worker(new URL("./formula.worker.ts", import.meta.url), {
-		type: "module",
-	});
-	worker.onmessage = (ev: MessageEvent<FormulaEvaluationResult>) => {
-		const { id } = ev.data;
-		if (id === undefined) return;
-		const entry = pending.get(id);
-		if (!entry) return;
-		pending.delete(id);
-		entry.resolve(ev.data);
-	};
-	worker.onerror = (ev) => {
-		const err =
-			ev instanceof Error ? ev : new Error(ev.message ?? "Worker error");
-		for (const entry of pending.values()) entry.reject(err);
-		pending.clear();
-		worker?.terminate();
-		worker = null;
-	};
-	return worker;
-}
+const client = new WorkerClient<
+    FormulaWorkerParams & { id: number },
+    FormulaEvaluationResult,
+    FormulaEvaluationResult
+>(
+    () => new Worker(new URL("./formula.worker.ts", import.meta.url), { type: "module" }),
+    (data, resolve) => {
+        resolve(data);
+    }
+);
 
 export function evaluateFormulaInWorker(
-	params: FormulaWorkerParams,
+    params: FormulaWorkerParams,
 ): Promise<FormulaEvaluationResult> {
-	const id = nextId++;
-	const w = ensureWorker();
-	return new Promise<FormulaEvaluationResult>((resolve, reject) => {
-		pending.set(id, { resolve, reject });
-		w.postMessage({ ...params, id });
-	});
+    return client.request((id) => ({ ...params, id }));
 }

--- a/src/workers/parserClient.ts
+++ b/src/workers/parserClient.ts
@@ -1,51 +1,21 @@
 import type { ParsedDataset } from "../services/persistence";
 import type { ParseSettings } from "../utils/data-parser";
 import type { ParserRequest, ParserResponse } from "./parser.worker";
+import { WorkerClient } from "./WorkerClient";
 
-let worker: Worker | null = null;
-let nextId = 1;
-const pending = new Map<
-	number,
-	{
-		resolve: (value: ParsedDataset[]) => void;
-		reject: (reason: unknown) => void;
-	}
->();
-
-function ensureWorker(): Worker {
-	if (worker) return worker;
-	worker = new Worker(new URL("./parser.worker.ts", import.meta.url), {
-		type: "module",
-	});
-	worker.onmessage = (ev: MessageEvent<ParserResponse>) => {
-		const { id, type, datasets, error } = ev.data;
-		const entry = pending.get(id);
-		if (!entry) return;
-		pending.delete(id);
-		if (type === "success" && datasets) entry.resolve(datasets);
-		else entry.reject(new Error(error ?? "Parser worker error"));
-	};
-	worker.onerror = (ev) => {
-		const err =
-			ev instanceof Error ? ev : new Error(ev.message ?? "Worker error");
-		for (const entry of pending.values()) entry.reject(err);
-		pending.clear();
-		worker?.terminate();
-		worker = null;
-	};
-	return worker;
-}
+const client = new WorkerClient<ParserRequest, ParserResponse, ParsedDataset[]>(
+    () => new Worker(new URL("./parser.worker.ts", import.meta.url), { type: "module" }),
+    (data, resolve, reject) => {
+        const { type, datasets, error } = data;
+        if (type === "success" && datasets) resolve(datasets);
+        else reject(new Error(error ?? "Parser worker error"));
+    }
+);
 
 export function parseDataInWorker(
-	file: File,
-	type: string,
-	settings?: ParseSettings,
+    file: File,
+    type: string,
+    settings?: ParseSettings,
 ): Promise<ParsedDataset[]> {
-	const id = nextId++;
-	const w = ensureWorker();
-	return new Promise<ParsedDataset[]>((resolve, reject) => {
-		pending.set(id, { resolve, reject });
-		const req: ParserRequest = { id, file, type, settings };
-		w.postMessage(req);
-	});
+    return client.request((id) => ({ id, file, type, settings }));
 }


### PR DESCRIPTION
🎯 **What:** Extracted boilerplate logic for creating and interacting with Web Workers into a shared generic utility class `WorkerClient`.
💡 **Why:** `parserClient`, `excelClient`, and `formulaClient` each duplicated the boilerplate logic of worker instantiation, `nextId` incrementing, request/response tracking with a `Map`, and error handling/cleanup. Moving this logic to a reusable class significantly reduces code duplication, improving maintainability and readability while preventing future drift across implementations.
✅ **Verification:** Verified by checking out the changes, linting (`pnpm run lint`), and ensuring the full test suite (`pnpm run test` with 1051 tests) passed without regressions. Verified via automated Code Review to be correct, and removed any extra workspace files left over from exploration.
✨ **Result:** A more robust and much cleaner worker client infrastructure with all boilerplate isolated in a single, well-typed file.

---
*PR created automatically by Jules for task [14122304464078153221](https://jules.google.com/task/14122304464078153221) started by @michaelkrisper*