### PR TITLE
🧪 [testing improvement] processRawColumn boundary cases and type strictness

### DIFF
--- a/src/utils/__tests__/data-processing.test.ts
+++ b/src/utils/__tests__/data-processing.test.ts
@@ -70,4 +70,37 @@ describe("processRawColumn", () => {
 		expect(Number.isNaN(result.data[1])).toBe(true);
 		expect(Number.isNaN(result.data[2])).toBe(true);
 	});
+
+	it("should handle an empty array", () => {
+		const data: number[] = [];
+		const result = processRawColumn(data);
+
+		expect(result.refPoint).toBe(0);
+		expect(result.bounds).toEqual({ min: Infinity, max: -Infinity });
+		expect(result.data.length).toBe(0);
+	});
+
+	it("should handle arrays with strings that cannot be parsed as numbers", () => {
+		// @ts-expect-error - Expected to test bad data resilience
+		const data: number[] = [10, "foo", 20];
+		const result = processRawColumn(data);
+
+		expect(result.refPoint).toBe(10);
+		expect(result.bounds).toEqual({ min: 10, max: 20 });
+
+		expect(result.data[0]).toBe(0);
+		expect(Number.isNaN(result.data[1])).toBe(true);
+		expect(result.data[2]).toBe(10);
+	});
+
+	it("should handle arrays with strings at the beginning", () => {
+		// @ts-expect-error - Expected to test bad data resilience
+		const data: number[] = ["foo", 20];
+		const result = processRawColumn(data);
+
+		expect(result.refPoint).toBe(20);
+		expect(result.bounds).toEqual({ min: 20, max: 20 });
+		expect(Number.isNaN(result.data[0])).toBe(true);
+		expect(result.data[1]).toBe(0);
+	});
 });

--- a/src/utils/data-processing.ts
+++ b/src/utils/data-processing.ts
@@ -24,7 +24,7 @@ export function processRawColumn(
 	// Any NaNs before the reference point are copied as NaN
 	for (; startIdx < rowCount; startIdx++) {
 		const val = sourceData[startIdx];
-		if (val !== null && !Number.isNaN(val)) {
+		if (val !== null && typeof val === "number" && !Number.isNaN(val)) {
 			refPoint = val;
 			break;
 		}
@@ -34,7 +34,7 @@ export function processRawColumn(
 	// Single pass for the rest of the data: calculate bounds and relative data
 	for (let i = startIdx; i < rowCount; i++) {
 		const val = sourceData[i];
-		if (val !== null && !Number.isNaN(val)) {
+		if (val !== null && typeof val === "number" && !Number.isNaN(val)) {
 			if (val < min) min = val;
 			if (val > max) max = val;
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `processRawColumn` function lacked boundary tests for empty arrays and mixed types (like strings). During investigation, it was discovered that `processRawColumn` would improperly accept strings (like `"foo"`) as the `refPoint` because `Number.isNaN("foo")` evaluates to `false` since it doesn't coerce strings.

📊 **Coverage:** What scenarios are now tested
- Empty arrays: Returns default values `min: Infinity, max: -Infinity`, and empty data array.
- Invalid strings: Handles strings that cannot be parsed as numbers, falling back to valid numbers.
- Strings at start: Correctly skips over non-numeric string values instead of setting them as the reference point.

✨ **Result:** The improvement in test coverage
Test coverage is improved with reliable edge cases verified. Furthermore, the `processRawColumn` source logic has been fortified with a `typeof val === "number"` check to reject strings and strictly accept parsed numeric floats during processing, preventing downstream calculation NaNs when dealing with corrupted data.

---
*PR created automatically by Jules for task [16121071406497387390](https://jules.google.com/task/16121071406497387390) started by @michaelkrisper*