### PR TITLE
test: close coverage gaps in the numerically risky modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-WebGraphy — client-only PWA for high-performance data visualization with WebGL. React 19 + TypeScript + Vite. No backend; all data lives in the browser (IndexedDB). Deployed to GitHub Pages from `master`.
+WebGraphy — client-only PWA for high-performance data visualization with WebGL. React 19 + TypeScript + Vite. No backend; all data lives in the browser (IndexedDB). Deployed to GitHub Pages from `main`.
 
 ## Commands
 
@@ -13,6 +13,7 @@ Package manager is **npm** (ships with Node >=24). CI runs `npm ci`; locally use
 - `npm run dev` — Vite dev server.
 - `npm run build` — `tsc -b && vite build` (type-check then bundle).
 - `npm run lint` — ESLint over the repo.
+- `npm run format` / `npm run format:check` — Biome formatter (tabs, 80 cols); CI enforces `format:check`.
 - `npm test` — Vitest run (one-shot).
 - `npx vitest run --coverage` — tests with coverage thresholds enforced (what CI runs). Thresholds live in `vitest.config.ts`; the build fails if coverage drops below them. Ratchet up, never down.
 - Single test file: `npx vitest run src/utils/__tests__/formula.test.ts`
@@ -21,7 +22,7 @@ Package manager is **npm** (ships with Node >=24). CI runs `npm ci`; locally use
 
 `@` is aliased to `./src` (see `vitest.config.ts`). Tests run in jsdom; `src/__tests__/setup.ts` mocks `localStorage`.
 
-CI (`.github/workflows/ci.yml`): lint → coverage test → build, then deploy `dist` to Pages on `master`. All four gates must pass.
+CI (`.github/workflows/ci.yml`): format check → lint → coverage test → build, then deploy `dist` to Pages on `main`. All gates must pass.
 
 ## Architecture
 

--- a/src/components/Plot/crosshair/__tests__/computeSnap.test.ts
+++ b/src/components/Plot/crosshair/__tests__/computeSnap.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import type {
+	Dataset,
+	SeriesConfig,
+	XAxisConfig,
+	YAxisConfig,
+} from "../../../../services/persistence";
+import { computeSnap } from "../computeSnap";
+import type { SeriesMetadata } from "../types";
+
+/**
+ * The crosshair decides which sample the user is pointing at and what the
+ * tooltip claims that sample is. A wrong pick reads as correct data, so the
+ * snapping is checked against hand-computed expectations rather than snapshots.
+ */
+
+const PADDING = { top: 10, right: 10, bottom: 10, left: 10 };
+const WIDTH = 210;
+const HEIGHT = 110;
+
+const xAxis = (over: Partial<XAxisConfig> = {}): XAxisConfig =>
+	({
+		id: "axis-1",
+		min: 0,
+		max: 10,
+		xMode: "numeric",
+		showGrid: true,
+		name: "",
+		...over,
+	}) as XAxisConfig;
+
+const yAxis = (over: Partial<YAxisConfig> = {}): YAxisConfig =>
+	({
+		id: "axis-1",
+		min: 0,
+		max: 100,
+		showGrid: true,
+		name: "Y",
+		position: "left",
+		color: "#000",
+		...over,
+	}) as YAxisConfig;
+
+const dataset = (id: string): Dataset => ({ id }) as Dataset;
+
+const seriesConfig = (over: Partial<SeriesConfig> = {}): SeriesConfig =>
+	({
+		id: "s1",
+		name: "Temp",
+		yColumn: "t",
+		sourceId: "ds-1",
+		yAxisId: "axis-1",
+		lineColor: "#ff0000",
+		pointStyle: "circle",
+		...over,
+	}) as SeriesConfig;
+
+function meta(over: Partial<SeriesMetadata> = {}): SeriesMetadata {
+	return {
+		series: seriesConfig(),
+		ds: dataset("ds-1"),
+		axis: yAxis(),
+		xAxis: xAxis(),
+		xIdx: 0,
+		yIdx: 1,
+		xCol: { data: Float32Array.from([0, 2, 4, 6, 8, 10]), refPoint: 0 },
+		yCol: { data: Float32Array.from([0, 20, 40, 60, 80, 100]), refPoint: 0 },
+		...over,
+	};
+}
+
+/** Screen x for a world x under the fixture's axis and padding. */
+const screenX = (worldX: number) =>
+	PADDING.left +
+	((worldX - 0) / 10) * (WIDTH - PADDING.left - PADDING.right);
+
+const base = {
+	seriesMetadata: [meta()],
+	xAxisNameById: { "axis-1": "Time" },
+	width: WIDTH,
+	height: HEIGHT,
+	padding: PADDING,
+};
+
+describe("computeSnap", () => {
+	it("returns null when there is nothing to snap to", () => {
+		expect(computeSnap({ ...base, pos: { x: 50, y: 50 }, seriesMetadata: [] })).toBeNull();
+	});
+
+	it("returns null when the series has no x axis", () => {
+		const withoutAxis = meta({ xAxis: undefined as unknown as XAxisConfig });
+		expect(
+			computeSnap({
+				...base,
+				pos: { x: 50, y: 50 },
+				seriesMetadata: [withoutAxis],
+			}),
+		).toBeNull();
+	});
+
+	it("snaps to the nearest sample, not the nearest pixel", () => {
+		// Pointer sits at world x = 3.4, between samples at 2 and 4.
+		const result = computeSnap({ ...base, pos: { x: screenX(3.4), y: 50 } });
+
+		expect(result).not.toBeNull();
+		expect(result?.snapScreenX).toBeCloseTo(screenX(4), 5);
+		expect(result?.entries).toHaveLength(1);
+		expect(result?.entries[0].items[0].value).toBe(40);
+	});
+
+	it("snaps to the left sample when the pointer is just past it", () => {
+		const result = computeSnap({ ...base, pos: { x: screenX(2.4), y: 50 } });
+		expect(result?.entries[0].items[0].value).toBe(20);
+	});
+
+	it("clamps to the first and last sample outside the data range", () => {
+		const left = computeSnap({ ...base, pos: { x: screenX(-5), y: 50 } });
+		const right = computeSnap({ ...base, pos: { x: screenX(50), y: 50 } });
+
+		expect(left?.entries[0].items[0].value).toBe(0);
+		expect(right?.entries[0].items[0].value).toBe(100);
+	});
+
+	it("applies the column reference point to the reported values", () => {
+		// Timestamps are stored as small deltas plus a reference point; reading
+		// the deltas alone would report values off by the reference.
+		const shifted = meta({
+			xCol: { data: Float32Array.from([0, 2, 4]), refPoint: 1_000_000 },
+			yCol: { data: Float32Array.from([1, 2, 3]), refPoint: 500 },
+			xAxis: xAxis({ min: 1_000_000, max: 1_000_004 }),
+		});
+
+		const result = computeSnap({
+			...base,
+			seriesMetadata: [shifted],
+			pos: { x: screenX(5), y: 50 },
+		});
+
+		expect(result?.entries[0].items[0].value).toBe(502);
+		expect(result?.entries[0].xLabel).toContain("1,000,002");
+	});
+
+	it("groups series that share an x value and axis into one entry", () => {
+		const second = meta({
+			series: seriesConfig({ id: "s2", name: "Humidity", lineColor: "#00ff00" }),
+			yCol: { data: Float32Array.from([5, 15, 25, 35, 45, 55]), refPoint: 0 },
+		});
+
+		const result = computeSnap({
+			...base,
+			seriesMetadata: [meta(), second],
+			pos: { x: screenX(4), y: 50 },
+		});
+
+		expect(result?.entries).toHaveLength(1);
+		expect(result?.entries[0].items.map((i) => i.label)).toEqual([
+			"Temp",
+			"Humidity",
+		]);
+	});
+
+	it("keeps series on different x axes in separate groups", () => {
+		const other = meta({
+			series: seriesConfig({ id: "s2", name: "Other", sourceId: "ds-2" }),
+			ds: dataset("ds-2"),
+			xAxis: xAxis({ id: "axis-2" }),
+		});
+
+		const result = computeSnap({
+			...base,
+			seriesMetadata: [meta(), other],
+			xAxisNameById: { "axis-1": "Time", "axis-2": "Distance" },
+			pos: { x: screenX(4), y: 50 },
+		});
+
+		expect(result?.entries).toHaveLength(2);
+		expect(result?.entries.map((e) => e.xAxisName)).toEqual([
+			"Time",
+			"Distance",
+		]);
+	});
+
+	it("falls back to a placeholder for an axis with no registered name", () => {
+		const result = computeSnap({
+			...base,
+			xAxisNameById: {},
+			pos: { x: screenX(4), y: 50 },
+		});
+		expect(result?.entries[0].xAxisName).toBe("Unknown Axis");
+	});
+
+	it("formats a date axis as a full date rather than a number", () => {
+		const t0 = Math.floor(new Date(2026, 0, 1).getTime() / 1000);
+		const dated = meta({
+			xCol: { data: Float32Array.from([0, 3600, 7200]), refPoint: t0 },
+			xAxis: xAxis({ xMode: "date", min: t0, max: t0 + 7200 }),
+		});
+
+		const result = computeSnap({
+			...base,
+			seriesMetadata: [dated],
+			pos: { x: WIDTH / 2, y: 50 },
+		});
+
+		// Not a bare number: the date formatter produced something else.
+		expect(result?.entries[0].xLabel).not.toMatch(/^[\d,.]+$/);
+	});
+
+	it("uses category labels for both axes when present", () => {
+		const categorical = meta({
+			xCol: {
+				data: Float32Array.from([0, 1, 2]),
+				refPoint: 0,
+				categoryLabels: ["Mon", "Tue", "Wed"],
+			},
+			yCol: {
+				data: Float32Array.from([0, 1, 2]),
+				refPoint: 0,
+				categoryLabels: ["low", "mid", "high"],
+			},
+			xAxis: xAxis({ xMode: "categorical", min: 0, max: 2 }),
+		});
+
+		const result = computeSnap({
+			...base,
+			seriesMetadata: [categorical],
+			pos: { x: screenX(10), y: 50 },
+		});
+
+		expect(result?.entries[0].xLabel).toBe("Wed");
+		expect(result?.entries[0].items[0].valueLabel).toBe("high");
+	});
+
+	it("falls back to the column name when a series has no name", () => {
+		const unnamed = meta({ series: seriesConfig({ name: "", yColumn: "raw" }) });
+		const result = computeSnap({
+			...base,
+			seriesMetadata: [unnamed],
+			pos: { x: screenX(4), y: 50 },
+		});
+		expect(result?.entries[0].items[0].label).toBe("raw");
+	});
+
+	it("falls back to a default colour when the series has none", () => {
+		const colourless = meta({
+			series: seriesConfig({ lineColor: "" as unknown as string }),
+		});
+		const result = computeSnap({
+			...base,
+			seriesMetadata: [colourless],
+			pos: { x: screenX(4), y: 50 },
+		});
+		expect(result?.entries[0].items[0].color).toBe("#333");
+	});
+
+	it("places the item at the screen position of its own y axis", () => {
+		// Two series on y axes with different ranges must not land on the same
+		// pixel just because their raw values match.
+		const wideAxis = meta({
+			series: seriesConfig({ id: "s2", name: "Wide" }),
+			axis: yAxis({ id: "axis-2", min: 0, max: 1000 }),
+		});
+
+		const result = computeSnap({
+			...base,
+			seriesMetadata: [meta(), wideAxis],
+			pos: { x: screenX(4), y: 50 },
+		});
+
+		const [narrow, wide] = result!.entries[0].items;
+		expect(narrow.value).toBe(wide.value);
+		expect(narrow.yScreen).not.toBeCloseTo(wide.yScreen, 3);
+	});
+});

--- a/src/components/Plot/crosshair/__tests__/computeSnap.test.ts
+++ b/src/components/Plot/crosshair/__tests__/computeSnap.test.ts
@@ -71,8 +71,7 @@ function meta(over: Partial<SeriesMetadata> = {}): SeriesMetadata {
 
 /** Screen x for a world x under the fixture's axis and padding. */
 const screenX = (worldX: number) =>
-	PADDING.left +
-	((worldX - 0) / 10) * (WIDTH - PADDING.left - PADDING.right);
+	PADDING.left + ((worldX - 0) / 10) * (WIDTH - PADDING.left - PADDING.right);
 
 const base = {
 	seriesMetadata: [meta()],
@@ -84,7 +83,9 @@ const base = {
 
 describe("computeSnap", () => {
 	it("returns null when there is nothing to snap to", () => {
-		expect(computeSnap({ ...base, pos: { x: 50, y: 50 }, seriesMetadata: [] })).toBeNull();
+		expect(
+			computeSnap({ ...base, pos: { x: 50, y: 50 }, seriesMetadata: [] }),
+		).toBeNull();
 	});
 
 	it("returns null when the series has no x axis", () => {
@@ -174,10 +175,7 @@ describe("computeSnap", () => {
 		});
 
 		expect(result?.entries).toHaveLength(2);
-		expect(result?.entries.map((e) => e.xAxisName)).toEqual([
-			"Time",
-			"Distance",
-		]);
+		expect(result?.entries.map((e) => e.xAxisName)).toEqual(["Time", "Distance"]);
 	});
 
 	it("falls back to a placeholder for an axis with no registered name", () => {

--- a/src/components/Plot/crosshair/__tests__/drawCanvas.test.ts
+++ b/src/components/Plot/crosshair/__tests__/drawCanvas.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { drawCanvas } from "../drawCanvas";
+import type { SnapGroup, SnapResult } from "../types";
+
+/**
+ * jsdom has no 2D canvas implementation, so the context is mocked and the
+ * assertions are about the sequence of drawing calls. That is enough to pin
+ * the parts that actually go wrong: markers leaking into the axis gutters,
+ * and the wrong glyph being drawn for a point style.
+ */
+
+const PADDING = { top: 10, right: 10, bottom: 10, left: 10 };
+const WIDTH = 200;
+const HEIGHT = 100;
+
+function makeCtx() {
+	return {
+		clearRect: vi.fn(),
+		save: vi.fn(),
+		restore: vi.fn(),
+		scale: vi.fn(),
+		beginPath: vi.fn(),
+		moveTo: vi.fn(),
+		lineTo: vi.fn(),
+		stroke: vi.fn(),
+		fill: vi.fn(),
+		arc: vi.fn(),
+		fillRect: vi.fn(),
+		strokeRect: vi.fn(),
+		setLineDash: vi.fn(),
+		strokeStyle: "",
+		fillStyle: "",
+		lineWidth: 0,
+	};
+}
+
+let ctx: ReturnType<typeof makeCtx>;
+let canvas: HTMLCanvasElement;
+
+const item = (over: Partial<SnapGroup["items"][number]> = {}) => ({
+	label: "Temp",
+	value: 5,
+	color: "#ff0000",
+	xScreen: 100,
+	yScreen: 50,
+	pointStyle: "circle",
+	...over,
+});
+
+const snapWith = (...items: SnapGroup["items"]): SnapResult => ({
+	snapScreenX: 100,
+	entries: [{ xLabel: "5", xAxisName: "Time", items }],
+});
+
+const draw = (over: Record<string, unknown> = {}) =>
+	drawCanvas({
+		canvas,
+		snap: snapWith(item()),
+		pos: { x: 100, y: 50 },
+		isPanning: false,
+		snapLineColor: "#999999",
+		padding: PADDING,
+		width: WIDTH,
+		height: HEIGHT,
+		plotBg: "#ffffff",
+		...over,
+	});
+
+beforeEach(() => {
+	ctx = makeCtx();
+	canvas = {
+		width: WIDTH,
+		height: HEIGHT,
+		getContext: vi.fn().mockReturnValue(ctx),
+	} as unknown as HTMLCanvasElement;
+});
+
+describe("drawCanvas", () => {
+	it("does nothing without a canvas", () => {
+		expect(() => draw({ canvas: null })).not.toThrow();
+	});
+
+	it("does nothing when the 2D context is unavailable", () => {
+		canvas = {
+			width: WIDTH,
+			height: HEIGHT,
+			getContext: vi.fn().mockReturnValue(null),
+		} as unknown as HTMLCanvasElement;
+
+		draw();
+
+		expect(ctx.clearRect).not.toHaveBeenCalled();
+	});
+
+	it("clears without drawing when there is nothing to show", () => {
+		for (const over of [
+			{ snap: null },
+			{ pos: null },
+			{ isPanning: true },
+		] as const) {
+			ctx = makeCtx();
+			canvas = {
+				width: WIDTH,
+				height: HEIGHT,
+				getContext: vi.fn().mockReturnValue(ctx),
+			} as unknown as HTMLCanvasElement;
+
+			draw(over);
+
+			// The previous frame must still be wiped, otherwise a stale
+			// crosshair stays on screen during a pan.
+			expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, WIDTH, HEIGHT);
+			expect(ctx.save).not.toHaveBeenCalled();
+		}
+	});
+
+	it("draws the dashed snap line down the plot area", () => {
+		draw();
+
+		expect(ctx.setLineDash).toHaveBeenCalledWith([3, 3]);
+		expect(ctx.moveTo).toHaveBeenCalledWith(100, PADDING.top);
+		expect(ctx.lineTo).toHaveBeenCalledWith(100, HEIGHT - PADDING.bottom);
+		// Dashing is reset before the markers so they are drawn solid.
+		expect(ctx.setLineDash).toHaveBeenLastCalledWith([]);
+		expect(ctx.restore).toHaveBeenCalled();
+	});
+
+	it("scales by the device pixel ratio", () => {
+		const original = window.devicePixelRatio;
+		Object.defineProperty(window, "devicePixelRatio", {
+			value: 2,
+			configurable: true,
+		});
+
+		draw();
+
+		expect(ctx.scale).toHaveBeenCalledWith(2, 2);
+		Object.defineProperty(window, "devicePixelRatio", {
+			value: original,
+			configurable: true,
+		});
+	});
+
+	it("draws a circle marker by default", () => {
+		draw();
+
+		expect(ctx.arc).toHaveBeenCalledTimes(2);
+		// Halo first, then the smaller coloured glyph on top.
+		expect(ctx.arc.mock.calls[0][2]).toBeGreaterThan(ctx.arc.mock.calls[1][2]);
+		expect(ctx.fillRect).not.toHaveBeenCalled();
+	});
+
+	it("draws a square marker for the square point style", () => {
+		draw({ snap: snapWith(item({ pointStyle: "square" })) });
+
+		expect(ctx.fillRect).toHaveBeenCalledTimes(2);
+		expect(ctx.strokeRect).toHaveBeenCalledTimes(1);
+		expect(ctx.arc).not.toHaveBeenCalled();
+	});
+
+	it("draws two strokes for the cross point style", () => {
+		draw({ snap: snapWith(item({ pointStyle: "cross" })) });
+
+		expect(ctx.arc).not.toHaveBeenCalled();
+		expect(ctx.fillRect).not.toHaveBeenCalled();
+		// Halo pass plus coloured pass, four line segments in total.
+		expect(ctx.moveTo.mock.calls.length).toBeGreaterThanOrEqual(5);
+	});
+
+	it("skips markers that fall outside the plot area", () => {
+		// One marker per gutter — all four must be dropped so they cannot draw
+		// over the axis labels.
+		const outside = snapWith(
+			item({ yScreen: PADDING.top - 1 }),
+			item({ yScreen: HEIGHT - PADDING.bottom + 1 }),
+			item({ xScreen: PADDING.left - 1 }),
+			item({ xScreen: WIDTH - PADDING.right + 1 }),
+		);
+
+		draw({ snap: outside });
+
+		expect(ctx.arc).not.toHaveBeenCalled();
+	});
+
+	it("still draws markers exactly on the plot boundary", () => {
+		draw({ snap: snapWith(item({ yScreen: PADDING.top })) });
+		expect(ctx.arc).toHaveBeenCalled();
+	});
+
+	it("draws every item of every group", () => {
+		const twoGroups: SnapResult = {
+			snapScreenX: 100,
+			entries: [
+				{ xLabel: "5", xAxisName: "Time", items: [item(), item()] },
+				{ xLabel: "7", xAxisName: "Distance", items: [item()] },
+			],
+		};
+
+		draw({ snap: twoGroups });
+
+		// Three circle markers, two arcs each.
+		expect(ctx.arc).toHaveBeenCalledTimes(6);
+	});
+});

--- a/src/components/Plot/crosshair/__tests__/renderTooltipHTML.test.ts
+++ b/src/components/Plot/crosshair/__tests__/renderTooltipHTML.test.ts
@@ -15,7 +15,11 @@ const COLORS = {
 	tooltipColor: "#111111",
 };
 
-const item = (label: string, value: number, over: Record<string, unknown> = {}) => ({
+const item = (
+	label: string,
+	value: number,
+	over: Record<string, unknown> = {},
+) => ({
 	label,
 	value,
 	color: "#ff0000",
@@ -25,7 +29,11 @@ const item = (label: string, value: number, over: Record<string, unknown> = {}) 
 	...over,
 });
 
-const group = (xLabel: string, xAxisName: string, items: SnapGroup["items"]) => ({
+const group = (
+	xLabel: string,
+	xAxisName: string,
+	items: SnapGroup["items"],
+) => ({
 	xLabel,
 	xAxisName,
 	items,
@@ -104,9 +112,7 @@ describe("renderTooltipHTML", () => {
 
 	it("renders one labelled row per item", () => {
 		render(
-			snapWith(
-				group("4", "Time", [item("Temp", 40), item("Humidity", 55)]),
-			),
+			snapWith(group("4", "Time", [item("Temp", 40), item("Humidity", 55)])),
 		);
 
 		const [first, second] = visibleRows();
@@ -137,9 +143,9 @@ describe("renderTooltipHTML", () => {
 		// is still correct — only the styling boundary is off.
 		expect(row.children[1].textContent).toBe("1");
 		expect(row.children[2].textContent).toBe(",234.5");
-		expect(
-			`${row.children[1].textContent}${row.children[2].textContent}`,
-		).toBe("1,234.5");
+		expect(`${row.children[1].textContent}${row.children[2].textContent}`).toBe(
+			"1,234.5",
+		);
 	});
 
 	it("leaves the decimal span empty for a whole number", () => {
@@ -162,9 +168,9 @@ describe("renderTooltipHTML", () => {
 
 	it("prefixes the axis name only when several axes are shown", () => {
 		render(snapWith(group("4", "Time", [item("Temp", 40)])));
-		expect(
-			tooltip.querySelector(".chart-tooltip-x-label")?.textContent,
-		).toBe("4");
+		expect(tooltip.querySelector(".chart-tooltip-x-label")?.textContent).toBe(
+			"4",
+		);
 
 		tooltip = document.createElement("div");
 		render(

--- a/src/components/Plot/crosshair/__tests__/renderTooltipHTML.test.ts
+++ b/src/components/Plot/crosshair/__tests__/renderTooltipHTML.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderTooltipHTML } from "../renderTooltipHTML";
+import type { SnapGroup, SnapResult } from "../types";
+
+/**
+ * The tooltip recycles its DOM nodes instead of rebuilding them, because it is
+ * rewritten on every mouse move. Recycling bugs do not throw — they leave a
+ * stale row visible or drop a series — so the tests below check the resulting
+ * DOM after successive renders, not just after the first one.
+ */
+
+const COLORS = {
+	tooltipSubColor: "#888888",
+	tooltipDividerColor: "#cccccc",
+	tooltipColor: "#111111",
+};
+
+const item = (label: string, value: number, over: Record<string, unknown> = {}) => ({
+	label,
+	value,
+	color: "#ff0000",
+	yScreen: 10,
+	xScreen: 20,
+	pointStyle: "circle",
+	...over,
+});
+
+const group = (xLabel: string, xAxisName: string, items: SnapGroup["items"]) => ({
+	xLabel,
+	xAxisName,
+	items,
+});
+
+const snapWith = (...groups: SnapGroup[]): SnapResult => ({
+	snapScreenX: 42,
+	entries: groups,
+});
+
+let tooltip: HTMLDivElement;
+
+const render = (snap: SnapResult | null, over: Record<string, unknown> = {}) =>
+	renderTooltipHTML({
+		tooltip,
+		snap,
+		pos: { x: 100, y: 200 },
+		isPanning: false,
+		...COLORS,
+		...over,
+	});
+
+const rows = () =>
+	Array.from(tooltip.querySelectorAll<HTMLElement>(".chart-tooltip-item-row"));
+
+const visibleRows = () => rows().filter((r) => !r.hidden);
+
+const visibleGroups = () =>
+	Array.from(tooltip.children).filter(
+		(g) => (g as HTMLElement).style.display !== "none",
+	) as HTMLElement[];
+
+beforeEach(() => {
+	tooltip = document.createElement("div");
+});
+
+describe("renderTooltipHTML", () => {
+	it("does nothing without a tooltip element", () => {
+		expect(() =>
+			renderTooltipHTML({
+				tooltip: null,
+				snap: snapWith(group("1", "Time", [item("Temp", 5)])),
+				pos: { x: 0, y: 0 },
+				isPanning: false,
+				...COLORS,
+			}),
+		).not.toThrow();
+	});
+
+	it("hides itself when there is no snap, no position, or a pan is running", () => {
+		for (const over of [
+			{ snap: null },
+			{ pos: null },
+			{ isPanning: true },
+		] as const) {
+			tooltip = document.createElement("div");
+			renderTooltipHTML({
+				tooltip,
+				snap: snapWith(group("1", "Time", [item("Temp", 5)])),
+				pos: { x: 1, y: 2 },
+				isPanning: false,
+				...COLORS,
+				...over,
+			});
+			expect(tooltip.style.display).toBe("none");
+		}
+	});
+
+	it("positions itself below and right of the pointer", () => {
+		render(snapWith(group("1", "Time", [item("Temp", 5)])));
+
+		expect(tooltip.style.display).toBe("");
+		expect(tooltip.style.left).toBe("112px");
+		expect(tooltip.style.top).toBe("215px");
+	});
+
+	it("renders one labelled row per item", () => {
+		render(
+			snapWith(
+				group("4", "Time", [item("Temp", 40), item("Humidity", 55)]),
+			),
+		);
+
+		const [first, second] = visibleRows();
+		expect(first.children[0].textContent).toBe("Temp:");
+		expect(second.children[0].textContent).toBe("Humidity:");
+		expect(tooltip.querySelector(".chart-tooltip-x-label")?.textContent).toBe(
+			"4",
+		);
+	});
+
+	it("splits the value at the decimal separator", () => {
+		render(snapWith(group("1", "Time", [item("Temp", 12.5)])));
+
+		const row = visibleRows()[0];
+		// Integer and fractional parts live in separate spans so the decimals
+		// can be dimmed without reformatting the number.
+		expect(row.children[1].textContent).toBe("12");
+		expect(row.children[2].textContent).toBe(".5");
+	});
+
+	it("splits at the thousands separator for large values", () => {
+		render(snapWith(group("1", "Time", [item("Temp", 1234.5)])));
+
+		const row = visibleRows()[0];
+		// Documents current behaviour: the split searches for the first "." or
+		// "," and a grouped number hits the thousands separator first, so the
+		// grouping digits end up in the dimmed decimal span. The rendered text
+		// is still correct — only the styling boundary is off.
+		expect(row.children[1].textContent).toBe("1");
+		expect(row.children[2].textContent).toBe(",234.5");
+		expect(
+			`${row.children[1].textContent}${row.children[2].textContent}`,
+		).toBe("1,234.5");
+	});
+
+	it("leaves the decimal span empty for a whole number", () => {
+		render(snapWith(group("1", "Time", [item("Temp", 42)])));
+
+		const row = visibleRows()[0];
+		expect(row.children[1].textContent).toBe("42");
+		expect(row.children[2].textContent).toBe("");
+	});
+
+	it("prefers a category label over the numeric value", () => {
+		render(
+			snapWith(group("1", "Time", [item("State", 2, { valueLabel: "high" })])),
+		);
+
+		const row = visibleRows()[0];
+		expect(row.children[1].textContent).toBe("high");
+		expect(row.children[2].textContent).toBe("");
+	});
+
+	it("prefixes the axis name only when several axes are shown", () => {
+		render(snapWith(group("4", "Time", [item("Temp", 40)])));
+		expect(
+			tooltip.querySelector(".chart-tooltip-x-label")?.textContent,
+		).toBe("4");
+
+		tooltip = document.createElement("div");
+		render(
+			snapWith(
+				group("4", "Time", [item("Temp", 40)]),
+				group("7", "Distance", [item("Speed", 12)]),
+			),
+		);
+		const labels = Array.from(
+			tooltip.querySelectorAll(".chart-tooltip-x-label"),
+		).map((n) => n.textContent);
+		expect(labels).toEqual(["Time: 4", "Distance: 7"]);
+	});
+
+	it("separates the second and later groups with a divider", () => {
+		render(
+			snapWith(
+				group("4", "Time", [item("Temp", 40)]),
+				group("7", "Distance", [item("Speed", 12)]),
+			),
+		);
+
+		const [first, second] = visibleGroups();
+		expect(first.style.borderTop).toBe("");
+		// jsdom normalises the hex colour to rgb() when reading the style back.
+		expect(second.style.borderTop).toBe("1px solid rgb(204, 204, 204)");
+		expect(second.style.paddingTop).toBe("4px");
+	});
+
+	it("hides leftover rows when a later render has fewer items", () => {
+		render(
+			snapWith(
+				group("4", "Time", [
+					item("Temp", 40),
+					item("Humidity", 55),
+					item("Pressure", 1013),
+				]),
+			),
+		);
+		expect(visibleRows()).toHaveLength(3);
+
+		// Same tooltip element, fewer series — the third row must not linger.
+		render(snapWith(group("4", "Time", [item("Temp", 41)])));
+
+		expect(visibleRows()).toHaveLength(1);
+		expect(rows()).toHaveLength(3);
+		expect(visibleRows()[0].children[1].textContent).toBe("41");
+	});
+
+	it("hides leftover groups when a later render has fewer of them", () => {
+		render(
+			snapWith(
+				group("4", "Time", [item("Temp", 40)]),
+				group("7", "Distance", [item("Speed", 12)]),
+			),
+		);
+		expect(visibleGroups()).toHaveLength(2);
+
+		render(snapWith(group("4", "Time", [item("Temp", 40)])));
+
+		expect(visibleGroups()).toHaveLength(1);
+		expect(tooltip.children).toHaveLength(2);
+	});
+
+	it("reuses existing nodes instead of recreating them", () => {
+		render(snapWith(group("4", "Time", [item("Temp", 40)])));
+		const firstRow = rows()[0];
+		const firstGroup = tooltip.firstElementChild;
+
+		render(snapWith(group("5", "Time", [item("Temp", 50)])));
+
+		expect(rows()[0]).toBe(firstRow);
+		expect(tooltip.firstElementChild).toBe(firstGroup);
+		expect(rows()[0].children[1].textContent).toBe("50");
+	});
+
+	it("restores a previously hidden row when the series comes back", () => {
+		render(
+			snapWith(group("4", "Time", [item("Temp", 40), item("Humidity", 55)])),
+		);
+		render(snapWith(group("4", "Time", [item("Temp", 40)])));
+		expect(visibleRows()).toHaveLength(1);
+
+		render(
+			snapWith(group("4", "Time", [item("Temp", 40), item("Humidity", 60)])),
+		);
+
+		expect(visibleRows()).toHaveLength(2);
+		expect(visibleRows()[1].children[1].textContent).toBe("60");
+	});
+
+	it("grows the DOM when a later render adds groups", () => {
+		render(snapWith(group("4", "Time", [item("Temp", 40)])));
+
+		render(
+			snapWith(
+				group("4", "Time", [item("Temp", 40)]),
+				group("7", "Distance", [item("Speed", 12)]),
+				group("9", "Depth", [item("Pressure", 3)]),
+			),
+		);
+
+		expect(visibleGroups()).toHaveLength(3);
+	});
+});

--- a/src/utils/__tests__/decimation.test.ts
+++ b/src/utils/__tests__/decimation.test.ts
@@ -240,6 +240,100 @@ describe("m4Float32", () => {
 		expect(result.x.length).toBeGreaterThan(0);
 		expect(Array.from(result.x)).toEqual([0, 1, 2, 4]);
 	});
+
+	// Same ordering invariant as the x-anchored variant: samples are gathered
+	// as (first, min, max, nan, last) and sorted back into index order.
+	it("emits indices in ascending order for every extremum arrangement", () => {
+		for (let minPos = 1; minPos < 5; minPos++) {
+			for (let maxPos = 1; maxPos < 5; maxPos++) {
+				if (minPos === maxPos) continue;
+				const x = new Float32Array([0, 1, 2, 3, 4, 5]);
+				const y = new Float32Array([0, 0, 0, 0, 0, 0]);
+				y[minPos] = -100;
+				y[maxPos] = 100;
+
+				// threshold 4 -> a single bucket over all six points.
+				const r = m4Float32(x, y, 4);
+
+				for (let i = 1; i < r.x.length; i++) {
+					expect(r.x[i]).toBeGreaterThanOrEqual(r.x[i - 1]);
+				}
+				expect(Array.from(r.y)).toContain(-100);
+				expect(Array.from(r.y)).toContain(100);
+			}
+		}
+	});
+
+	it("keeps order when a bucket carries first, min, max, NaN and last", () => {
+		// The five-entry case: every slot distinct, which is the only path
+		// through the three-comparison insertion sort.
+		const x = new Float32Array([0, 1, 2, 3, 4, 5, 6]);
+		const y = new Float32Array([1, -50, 2, NaN, 80, 3, 4]);
+
+		const r = m4Float32(x, y, 4);
+
+		for (let i = 1; i < r.x.length; i++) {
+			expect(r.x[i]).toBeGreaterThanOrEqual(r.x[i - 1]);
+		}
+		const ys = Array.from(r.y);
+		expect(ys).toContain(-50);
+		expect(ys).toContain(80);
+		// The NaN is deliberately kept so the renderer breaks the line there.
+		expect(ys.some((v) => Number.isNaN(v))).toBe(true);
+	});
+
+	it("writes a grown buffer back through out when downsampling", () => {
+		const n = 500;
+		const x = new Float32Array(n);
+		const y = new Float32Array(n);
+		for (let i = 0; i < n; i++) {
+			x[i] = i;
+			y[i] = Math.cos(i * 0.2) * 50;
+		}
+		const out = { x: new Float32Array(4), y: new Float32Array(4) };
+
+		const r = m4Float32(x, y, 128, out);
+
+		// Too small for 128/4 buckets, so a fresh buffer is allocated — and the
+		// caller must receive it, otherwise the next frame reallocates again.
+		expect(out.x.length).toBeGreaterThan(4);
+		expect(out.y.length).toBe(out.x.length);
+		expect(r.x.buffer).toBe(out.x.buffer);
+		expect(r.x.length).toBeGreaterThan(4);
+	});
+
+	it("preserves every bucket's extrema against a full-resolution scan", () => {
+		// The defining property of M4: whatever the decimation does, the visible
+		// silhouette must not change, so each bucket's true min and max have to
+		// appear in the output.
+		const n = 2048;
+		const threshold = 256;
+		const x = new Float32Array(n);
+		const y = new Float32Array(n);
+		for (let i = 0; i < n; i++) {
+			x[i] = i;
+			// Deterministic, spiky, and not aligned to the bucket grid.
+			y[i] = Math.sin(i * 0.37) * 100 + ((i * 17) % 23);
+		}
+
+		const r = m4Float32(x, y, threshold, undefined);
+		const emitted = new Set(Array.from(r.y));
+
+		const numBuckets = Math.floor(threshold / 4);
+		const bucketSize = n / numBuckets;
+		for (let b = 0; b < numBuckets; b++) {
+			const start = Math.floor(b * bucketSize);
+			const end = Math.min(n - 1, Math.floor((b + 1) * bucketSize) - 1);
+			let lo = Infinity;
+			let hi = -Infinity;
+			for (let i = start; i <= end; i++) {
+				if (y[i] < lo) lo = y[i];
+				if (y[i] > hi) hi = y[i];
+			}
+			expect(emitted.has(lo)).toBe(true);
+			expect(emitted.has(hi)).toBe(true);
+		}
+	});
 });
 
 describe("m4ByXFloat32", () => {
@@ -348,6 +442,104 @@ describe("m4ByXFloat32", () => {
 		expect(ys).not.toContain(NaN);
 		expect(ys).toContain(1);
 		expect(ys).toContain(3);
+	});
+
+	// The per-bucket samples are collected as (first, min, max, last) in
+	// discovery order and then insertion-sorted back into index order. If that
+	// sort is wrong the renderer draws segments that jump backwards in x —
+	// visible as a scribble, not as a crash. These cover all three sort arities.
+	it("emits x in non-decreasing order for every extremum arrangement", () => {
+		// Within one bucket of five points, walk every position the min and max
+		// can occupy relative to first/last. Each arrangement exercises a
+		// different bucket length (3, 4 or 5 entries) and sort path.
+		for (let minPos = 0; minPos < 5; minPos++) {
+			for (let maxPos = 0; maxPos < 5; maxPos++) {
+				if (minPos === maxPos) continue;
+				const x = new Float32Array([0, 1, 2, 3, 4]);
+				const y = new Float32Array([0, 0, 0, 0, 0]);
+				y[minPos] = -100;
+				y[maxPos] = 100;
+
+				const r = m4ByXFloat32(x, y, 0, 0, 5, 5);
+
+				for (let i = 1; i < r.x.length; i++) {
+					expect(r.x[i]).toBeGreaterThanOrEqual(r.x[i - 1]);
+				}
+				// Whatever the ordering, both extrema must survive.
+				expect(Array.from(r.y)).toContain(-100);
+				expect(Array.from(r.y)).toContain(100);
+			}
+		}
+	});
+
+	it("skips NaN when picking the leading and trailing continuity anchors", () => {
+		// Anchors let the line enter and leave the viewport instead of starting
+		// inside it. A NaN anchor would draw a gap at the edge, so the search
+		// walks outwards past NaNs.
+		const x = new Float32Array([0, 1, 2, 3, 4, 5, 6, 7]);
+		const y = new Float32Array([5, NaN, NaN, 10, 20, NaN, NaN, 9]);
+
+		// Viewport covers only x in [3, 5); indices 1-2 and 5-6 are the NaN runs
+		// immediately outside it.
+		const r = m4ByXFloat32(x, y, 0, 3, 5, 2);
+
+		const ys = Array.from(r.y);
+		expect(ys).not.toContain(NaN);
+		// Leading anchor skipped back over the NaNs to index 0...
+		expect(ys[0]).toBe(5);
+		// ...and the trailing one forward over the NaNs to index 7.
+		expect(ys[ys.length - 1]).toBe(9);
+	});
+
+	it("reuses a large enough out buffer instead of allocating", () => {
+		const x = new Float32Array([0, 1, 2, 3]);
+		const y = new Float32Array([1, 2, 3, 4]);
+		const out = { x: new Float32Array(64), y: new Float32Array(64) };
+		const originalX = out.x;
+		const originalY = out.y;
+
+		const r = m4ByXFloat32(x, y, 0, 0, 4, 4, out);
+
+		expect(out.x).toBe(originalX);
+		expect(out.y).toBe(originalY);
+		expect(r.x.buffer).toBe(originalX.buffer);
+		expect(Array.from(r.y)).toContain(1);
+	});
+
+	it("grows an undersized out buffer and still returns every sample", () => {
+		const n = 400;
+		const x = new Float32Array(n);
+		const y = new Float32Array(n);
+		for (let i = 0; i < n; i++) {
+			x[i] = i;
+			y[i] = Math.sin(i * 0.3) * 100;
+		}
+		// Deliberately far too small: the buffer has to be replaced, and the
+		// replacement has to be handed back through `out` for the next frame.
+		const out = { x: new Float32Array(2), y: new Float32Array(2) };
+
+		const r = m4ByXFloat32(x, y, 0, 0, n, 4, out);
+
+		expect(out.x.length).toBeGreaterThan(2);
+		expect(r.x.length).toBeGreaterThan(2);
+		expect(r.x.length).toBe(r.y.length);
+		for (let i = 0; i < r.y.length; i++) {
+			expect(Number.isNaN(r.y[i])).toBe(false);
+		}
+	});
+
+	it("hands the out buffer back even when the input is degenerate", () => {
+		const x = new Float32Array([1, 2, 3]);
+		const y = new Float32Array([1, 2, 3]);
+		const out = { x: new Float32Array(0), y: new Float32Array(0) };
+
+		// xMax <= xMin: nothing to draw, but the caller still reuses `out`
+		// next frame, so it must come back as a usable buffer.
+		const r = m4ByXFloat32(x, y, 0, 10, 10, 1, out);
+
+		expect(r.x.length).toBe(0);
+		expect(out.x.length).toBeGreaterThan(0);
+		expect(out.y.length).toBe(out.x.length);
 	});
 });
 

--- a/src/utils/__tests__/regression.test.ts
+++ b/src/utils/__tests__/regression.test.ts
@@ -191,4 +191,155 @@ describe("Regression Utilities", () => {
 			expect(result[0]).toBe(1);
 		});
 	});
+
+	// Above 256 points kdeSmoothing switches from the exact O(N^2) evaluation
+	// to an O(N) grid-binning approximation. That second path produces the
+	// numbers users actually see (real datasets are far larger than 256), so
+	// it is checked here against the exact definition rather than against
+	// itself.
+	describe("kdeSmoothing — grid path (N > 256)", () => {
+		const GRID_PATH_THRESHOLD = 256;
+
+		/** Textbook Gaussian kernel smoother, used as the reference. */
+		const exactKde = (
+			x: Float64Array,
+			y: Float64Array,
+			h: number,
+		): Float64Array => {
+			const out = new Float64Array(x.length);
+			for (let i = 0; i < x.length; i++) {
+				let num = 0;
+				let den = 0;
+				for (let j = 0; j < x.length; j++) {
+					const dx = x[i] - x[j];
+					const w = Math.exp(-(dx * dx) / (2 * h * h));
+					num += w * y[j];
+					den += w;
+				}
+				out[i] = den > 0 ? num / den : y[i];
+			}
+			return out;
+		};
+
+		const evenlySpaced = (n: number, step = 1) =>
+			Float64Array.from({ length: n }, (_, i) => i * step);
+
+		it("takes the grid path above the threshold and stays close to the exact result", () => {
+			const n = GRID_PATH_THRESHOLD * 2;
+			const x = evenlySpaced(n);
+			// Deterministic pseudo-noise on top of a smooth signal.
+			const y = Float64Array.from({ length: n }, (_, i) => {
+				const signal = Math.sin(i / 20) * 10;
+				const noise = ((i * 37) % 11) - 5;
+				return signal + noise;
+			});
+			const h = 5;
+
+			const actual = kdeSmoothing(x, y, h);
+			const reference = exactKde(x, y, h);
+
+			expect(actual.length).toBe(n);
+			// The grid path bins and convolves rather than evaluating every
+			// pair, so it is an approximation — but a close one.
+			for (let i = 0; i < n; i++) {
+				expect(actual[i]).toBeCloseTo(reference[i], 1);
+			}
+		});
+
+		it("reproduces a constant signal exactly", () => {
+			const n = GRID_PATH_THRESHOLD + 100;
+			const x = evenlySpaced(n);
+			const y = new Float64Array(n).fill(7);
+
+			const result = kdeSmoothing(x, y, 3);
+
+			// A weighted average of identical values must be that value; any
+			// normalisation bug in the binning shows up here immediately.
+			for (let i = 0; i < n; i++) {
+				expect(result[i]).toBeCloseTo(7, 9);
+			}
+		});
+
+		it("reduces the spread of noise around a flat signal", () => {
+			const n = GRID_PATH_THRESHOLD * 4;
+			const x = evenlySpaced(n);
+			const y = Float64Array.from({ length: n }, (_, i) =>
+				i % 2 === 0 ? 10 : -10,
+			);
+
+			const result = kdeSmoothing(x, y, 4);
+
+			const spread = (arr: ArrayLike<number>) => {
+				let min = Infinity;
+				let max = -Infinity;
+				for (let i = 0; i < arr.length; i++) {
+					if (arr[i] < min) min = arr[i];
+					if (arr[i] > max) max = arr[i];
+				}
+				return max - min;
+			};
+
+			expect(spread(result)).toBeLessThan(spread(y));
+			// The alternating signal averages to zero away from the edges;
+			// binning leaves a residual on the order of 1e-5.
+			expect(result[Math.floor(n / 2)]).toBeCloseTo(0, 4);
+		});
+
+		it("returns the mean when all x collapse to one point", () => {
+			const n = GRID_PATH_THRESHOLD + 1;
+			const x = new Float64Array(n).fill(42);
+			const y = Float64Array.from({ length: n }, (_, i) => i);
+
+			// range < 1e-12, so there is no grid to bin onto and the whole
+			// column degenerates to its average.
+			const result = kdeSmoothing(x, y, 1);
+
+			const mean = (n - 1) / 2;
+			for (let i = 0; i < n; i++) {
+				expect(result[i]).toBeCloseTo(mean, 9);
+			}
+		});
+
+		it("keeps out-of-range points finite when x is not sorted ascending", () => {
+			// Bin indices are derived from x[0] and x[n-1]; unsorted input can
+			// therefore land below bin 0 or above the last bin. Those points
+			// must be clamped, not produce NaN or read out of bounds.
+			const n = GRID_PATH_THRESHOLD + 50;
+			const x = evenlySpaced(n);
+			x[10] = -500;
+			x[20] = 5000;
+			const y = Float64Array.from({ length: n }, (_, i) => i % 5);
+
+			const result = kdeSmoothing(x, y, 3);
+
+			expect(result.length).toBe(n);
+			for (let i = 0; i < n; i++) {
+				expect(Number.isFinite(result[i])).toBe(true);
+			}
+		});
+
+		it("derives a bandwidth automatically on the grid path", () => {
+			const n = GRID_PATH_THRESHOLD * 2;
+			const x = evenlySpaced(n, 0.5);
+			const y = Float64Array.from({ length: n }, (_, i) =>
+				Math.cos(i / 15) * 4,
+			);
+
+			const auto = kdeSmoothing(x, y);
+			const narrow = kdeSmoothing(x, y, 0.5);
+
+			expect(auto.length).toBe(n);
+			for (let i = 0; i < n; i++) {
+				expect(Number.isFinite(auto[i])).toBe(true);
+			}
+
+			const spread = (arr: Float64Array) =>
+				Math.max(...arr) - Math.min(...arr);
+			// Silverman's rule lands around h ~ 22 for this spacing, i.e. about
+			// half the cosine period, so the automatic bandwidth flattens the
+			// curve far more than a deliberately narrow one.
+			expect(spread(auto)).toBeLessThan(spread(narrow));
+			expect(spread(narrow)).toBeGreaterThan(4);
+		});
+	});
 });

--- a/src/utils/__tests__/regression.test.ts
+++ b/src/utils/__tests__/regression.test.ts
@@ -321,9 +321,7 @@ describe("Regression Utilities", () => {
 		it("derives a bandwidth automatically on the grid path", () => {
 			const n = GRID_PATH_THRESHOLD * 2;
 			const x = evenlySpaced(n, 0.5);
-			const y = Float64Array.from({ length: n }, (_, i) =>
-				Math.cos(i / 15) * 4,
-			);
+			const y = Float64Array.from({ length: n }, (_, i) => Math.cos(i / 15) * 4);
 
 			const auto = kdeSmoothing(x, y);
 			const narrow = kdeSmoothing(x, y, 0.5);
@@ -333,8 +331,7 @@ describe("Regression Utilities", () => {
 				expect(Number.isFinite(auto[i])).toBe(true);
 			}
 
-			const spread = (arr: Float64Array) =>
-				Math.max(...arr) - Math.min(...arr);
+			const spread = (arr: Float64Array) => Math.max(...arr) - Math.min(...arr);
 			// Silverman's rule lands around h ~ 22 for this spacing, i.e. about
 			// half the cosine period, so the automatic bandwidth flattens the
 			// curve far more than a deliberately narrow one.

--- a/src/utils/formula/__tests__/wholeColumn.test.ts
+++ b/src/utils/formula/__tests__/wholeColumn.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "vitest";
+import {
+	evaluateGroupAverage,
+	tryRegressionFormula,
+} from "../wholeColumn";
+
+/**
+ * `tryRegressionFormula` and `evaluateGroupAverage` produce columns the user
+ * reads as analysis rather than as raw data, so a wrong dispatch or a silently
+ * dropped column is invisible in the chart. They are driven directly here
+ * instead of through the store.
+ */
+
+/** Columns arrive pre-split as Float32 deltas plus a reference point. */
+const asColumn = (values: number[]) => ({
+	data: Float32Array.from(values),
+	refPoint: 0,
+});
+
+describe("tryRegressionFormula", () => {
+	const columns = ["Time", "Value"];
+	// y = 2x + 1 exactly, so every fit has an unambiguous answer.
+	const x = [0, 1, 2, 3, 4, 5];
+	const y = x.map((v) => 2 * v + 1);
+	const columnData = [asColumn(x), asColumn(y)];
+
+	it("returns null for a formula that is not a regression", () => {
+		expect(
+			tryRegressionFormula("[Value] * 2", columns, x.length, columnData),
+		).toBeNull();
+	});
+
+	it("returns null when the referenced column is unknown", () => {
+		expect(
+			tryRegressionFormula("linreg([Missing])", columns, x.length, columnData),
+		).toBeNull();
+	});
+
+	it("resolves a column given by its bare name after a dataset prefix", () => {
+		// Columns are stored as "Dataset: Column"; formulas reference the tail.
+		const prefixed = ["Time", "Demo: Value"];
+		const result = tryRegressionFormula(
+			"linreg([Value])",
+			prefixed,
+			x.length,
+			columnData,
+		);
+		expect(result).not.toBeNull();
+		expect(result?.length).toBe(x.length);
+	});
+
+	it("returns null when the positional column data is missing", () => {
+		// The caller passes [x, y] positionally; a single column means the
+		// regression has nothing to fit against.
+		expect(
+			tryRegressionFormula("linreg([Value])", columns, x.length, [
+				asColumn(x),
+			]),
+		).toBeNull();
+	});
+
+	it("fits a linear regression", () => {
+		const result = tryRegressionFormula(
+			"linreg([Value])",
+			columns,
+			x.length,
+			columnData,
+		);
+		expect(result).not.toBeNull();
+		for (let i = 0; i < x.length; i++) {
+			expect(result?.[i]).toBeCloseTo(y[i], 4);
+		}
+	});
+
+	it("dispatches every regression pattern to a finite result", () => {
+		// One case per entry in REGRESSION_PATTERNS: a typo in a pattern or a
+		// missing switch arm shows up as a null here.
+		const formulas = [
+			"linreg([Value])",
+			"polyreg([Value], 2)",
+			"polyreg([Value])",
+			"expreg([Value])",
+			"logreg([Value])",
+			"kde([Value])",
+			"kde([Value], 1.5)",
+		];
+		for (const formula of formulas) {
+			const result = tryRegressionFormula(
+				formula,
+				columns,
+				x.length,
+				columnData,
+			);
+			expect(result, formula).not.toBeNull();
+			expect(result?.length, formula).toBe(x.length);
+			for (let i = 0; i < x.length; i++) {
+				expect(Number.isFinite(result?.[i]), `${formula} @${i}`).toBe(true);
+			}
+		}
+	});
+
+	it("is case-insensitive and tolerates surrounding whitespace", () => {
+		const result = tryRegressionFormula(
+			"  LINREG([Value])  ",
+			columns,
+			x.length,
+			columnData,
+		);
+		expect(result).not.toBeNull();
+	});
+
+	it("applies the reference point offset before fitting", () => {
+		// Large timestamps are stored as small Float32 deltas plus a refPoint;
+		// fitting the deltas alone would silently shift the result.
+		const offsetData = [
+			{ data: Float32Array.from(x), refPoint: 1_000_000 },
+			asColumn(y),
+		];
+		const result = tryRegressionFormula(
+			"linreg([Value])",
+			columns,
+			x.length,
+			offsetData,
+		);
+		expect(result).not.toBeNull();
+		for (let i = 0; i < x.length; i++) {
+			expect(result?.[i]).toBeCloseTo(y[i], 3);
+		}
+	});
+});
+
+describe("evaluateGroupAverage", () => {
+	const columns = ["Time", "Value"];
+	const HOUR_SECONDS = 3600;
+	// Four samples spread over two whole hours, two per hour.
+	const times = [0, 60, HOUR_SECONDS, HOUR_SECONDS + 60];
+	const values = [10, 20, 100, 200];
+	// columnData is indexed by compileFormula's usedColumnIndices, i.e. in the
+	// order the formula references columns — the referenced value column first,
+	// then the time column appended by ensureTimeColumn. Not the global order.
+	const columnData = [asColumn(values), asColumn(times)];
+
+	// Same pattern evaluateFormulaSync uses to route into the group pass.
+	const matchFor = (formula: string) => {
+		const m = formula
+			.trim()
+			.match(/^avg(day|hour|minute|second)([lcr])?\(\[(.+)\]\)$/i);
+		expect(m, `pattern did not match ${formula}`).not.toBeNull();
+		return m as RegExpMatchArray;
+	};
+
+	it("averages values within each time bucket", () => {
+		const formula = "avghour([Value])";
+		const result = evaluateGroupAverage(
+			matchFor(formula),
+			formula,
+			columns,
+			times.length,
+			columnData,
+		);
+
+		expect(result.type).toBe("success");
+		if (result.type !== "success") return;
+		// Two hourly buckets -> a compact two-row sub-dataset.
+		expect(result.newColumn?.data.length).toBe(2);
+		expect(result.sparseXColumn?.data.length).toBe(2);
+
+		const ys = Array.from(result.newColumn!.data).map(
+			(v) => v + result.newColumn!.refPoint,
+		);
+		expect(ys[0]).toBeCloseTo(15, 4);
+		expect(ys[1]).toBeCloseTo(150, 4);
+	});
+
+	it("reports an unknown value column instead of producing a column", () => {
+		const formula = "avghour([Nope])";
+		const result = evaluateGroupAverage(
+			matchFor(formula),
+			formula,
+			columns,
+			times.length,
+			columnData,
+		);
+
+		expect(result.type).toBe("error");
+		if (result.type !== "error") return;
+		expect(result.error).toContain("Nope");
+	});
+
+	it("surfaces a compile error from the underlying formula", () => {
+		const formula = "avghour([Value])";
+		const result = evaluateGroupAverage(
+			matchFor(formula),
+			// A formula the compiler rejects; the group pass must not swallow it.
+			"[Value] +",
+			columns,
+			times.length,
+			columnData,
+		);
+
+		expect(result.type).toBe("error");
+	});
+
+	it("places the representative point according to the alignment flag", () => {
+		const read = (formula: string) => {
+			const result = evaluateGroupAverage(
+				matchFor(formula),
+				formula,
+				columns,
+				times.length,
+				columnData,
+			);
+			expect(result.type).toBe("success");
+			if (result.type !== "success") return [];
+			return Array.from(result.sparseXColumn!.data).map(
+				(v) => v + result.sparseXColumn!.refPoint,
+			);
+		};
+
+		const left = read("avghourl([Value])");
+		const right = read("avghourr([Value])");
+		const centre = read("avghour([Value])");
+
+		// Left anchors on the first sample of the bucket, right on the last,
+		// and the default sits between them.
+		expect(left[0]).toBe(times[0]);
+		expect(right[0]).toBe(times[1]);
+		expect(centre[0]).toBeGreaterThanOrEqual(left[0]);
+		expect(centre[0]).toBeLessThanOrEqual(right[0]);
+	});
+
+	it("buckets by the requested granularity", () => {
+		const formula = "avgminute([Value])";
+		const result = evaluateGroupAverage(
+			matchFor(formula),
+			formula,
+			columns,
+			times.length,
+			columnData,
+		);
+
+		expect(result.type).toBe("success");
+		if (result.type !== "success") return;
+		// Minute buckets keep all four samples apart, unlike the hourly case.
+		expect(result.newColumn?.data.length).toBe(4);
+	});
+
+	it("passes the dataset id and name through to the result", () => {
+		const formula = "avghour([Value])";
+		const result = evaluateGroupAverage(
+			matchFor(formula),
+			formula,
+			columns,
+			times.length,
+			columnData,
+			"ds-1",
+			"Hourly",
+		);
+
+		expect(result.type).toBe("success");
+		if (result.type !== "success") return;
+		expect(result.datasetId).toBe("ds-1");
+		expect(result.name).toBe("Hourly");
+	});
+
+	it("emits rows in ascending x even when the input is unordered", () => {
+		const unorderedTimes = [HOUR_SECONDS, 0, HOUR_SECONDS + 60, 60];
+		const unorderedValues = [100, 10, 200, 20];
+		const formula = "avghour([Value])";
+
+		const result = evaluateGroupAverage(
+			matchFor(formula),
+			formula,
+			columns,
+			unorderedTimes.length,
+			[asColumn(unorderedValues), asColumn(unorderedTimes)],
+		);
+
+		expect(result.type).toBe("success");
+		if (result.type !== "success") return;
+		const xs = Array.from(result.sparseXColumn!.data).map(
+			(v) => v + result.sparseXColumn!.refPoint,
+		);
+		for (let i = 1; i < xs.length; i++) {
+			expect(xs[i]).toBeGreaterThanOrEqual(xs[i - 1]);
+		}
+	});
+});

--- a/src/utils/formula/__tests__/wholeColumn.test.ts
+++ b/src/utils/formula/__tests__/wholeColumn.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	evaluateGroupAverage,
-	tryRegressionFormula,
-} from "../wholeColumn";
+import { evaluateGroupAverage, tryRegressionFormula } from "../wholeColumn";
 
 /**
  * `tryRegressionFormula` and `evaluateGroupAverage` produce columns the user
@@ -53,9 +50,7 @@ describe("tryRegressionFormula", () => {
 		// The caller passes [x, y] positionally; a single column means the
 		// regression has nothing to fit against.
 		expect(
-			tryRegressionFormula("linreg([Value])", columns, x.length, [
-				asColumn(x),
-			]),
+			tryRegressionFormula("linreg([Value])", columns, x.length, [asColumn(x)]),
 		).toBeNull();
 	});
 
@@ -85,12 +80,7 @@ describe("tryRegressionFormula", () => {
 			"kde([Value], 1.5)",
 		];
 		for (const formula of formulas) {
-			const result = tryRegressionFormula(
-				formula,
-				columns,
-				x.length,
-				columnData,
-			);
+			const result = tryRegressionFormula(formula, columns, x.length, columnData);
 			expect(result, formula).not.toBeNull();
 			expect(result?.length, formula).toBe(x.length);
 			for (let i = 0; i < x.length; i++) {

--- a/src/workers/__tests__/render.worker.test.ts
+++ b/src/workers/__tests__/render.worker.test.ts
@@ -375,12 +375,7 @@ describe("render.worker — SharedArrayBuffer viewport path", () => {
 		// path, where the host writes once per frame and sends nothing else.
 		for (let i = 0; i < 3; i++) {
 			gl.clear.mockClear();
-			writer.write(
-				11,
-				true,
-				[{ min: i, max: 10 + i }],
-				[{ min: 0, max: 50 }],
-			);
+			writer.write(11, true, [{ min: i, max: 10 + i }], [{ min: 0, max: 50 }]);
 			await nextFrame();
 			await nextFrame();
 			expect(gl.clear).toHaveBeenCalled();

--- a/src/workers/__tests__/render.worker.test.ts
+++ b/src/workers/__tests__/render.worker.test.ts
@@ -9,6 +9,11 @@ import {
 	makeCanvasMock,
 	makeGl2Mock,
 } from "../../components/Plot/__tests__/glMock";
+import type { SceneContext } from "../../components/Plot/frameScene";
+import {
+	VIEWPORT_SAB_BYTES,
+	ViewportWriter,
+} from "../../components/Plot/viewportChannel";
 import type { RenderWorkerRequest } from "../render.worker";
 import "../render.worker";
 
@@ -208,5 +213,183 @@ describe("render.worker", () => {
 		send({ t: "dispose" });
 		expect(gl.deleteProgram).toHaveBeenCalledTimes(3);
 		expect(closeSpy).toHaveBeenCalled();
+	});
+
+	it("redraws on plotBg and highlight messages", async () => {
+		const { gl } = initWorker();
+		send({
+			t: "frame",
+			xAxes: axes,
+			yAxes: axes,
+			interacting: false,
+			highlight: null,
+		});
+		await nextFrame();
+
+		gl.clear.mockClear();
+		send({ t: "plotBg", rgb: [0, 0, 0] });
+		await nextFrame();
+		expect(gl.clear).toHaveBeenCalledTimes(1);
+
+		gl.clear.mockClear();
+		send({ t: "highlight", id: "s1" });
+		await nextFrame();
+		// highlight alone does not queue a frame draw; it only marks the shared
+		// scene dirty for the SAB loop.
+		expect(gl.clear).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * When the page is crossOriginIsolated the host hands the worker a
+ * SharedArrayBuffer and stops sending per-frame messages entirely: the worker
+ * polls the viewport itself and derives the whole scene. That path never runs
+ * in the message-driven tests above, so it is driven explicitly here.
+ */
+describe("render.worker — SharedArrayBuffer viewport path", () => {
+	const sceneCtx: SceneContext = {
+		width: 200,
+		height: 100,
+		padding: { top: 10, right: 10, bottom: 10, left: 10 },
+		axisLayout: { "axis-1": { total: 40, label: 30 } },
+		xAxesMetrics: [
+			{
+				id: "axis-1",
+				height: 50,
+				labelBottom: 10,
+				secLabelBottom: 25,
+				titleBottom: 40,
+				cumulativeOffset: 0,
+			},
+		],
+		leftOffsets: {},
+		rightOffsets: {},
+		axisColor: "#3a3a35",
+		zeroLineColor: "#a09c93",
+		gridColor: "#ececea",
+		plotBg: "#ffffff",
+		labelColor: "#6b6760",
+		secLabelBg: "rgba(255,255,255,0.93)",
+		fontFamily: "sans-serif",
+		seriesByXAxisId: {},
+		seriesByYAxisId: {
+			"axis-1": [{ name: "Temp", yColumn: "t", lineColor: "#4589ff" }],
+		},
+		xAxesMeta: [
+			{
+				id: "axis-1",
+				name: "",
+				showGrid: true,
+				xMode: "numeric",
+				columnNames: ["Time"],
+			},
+		],
+		yAxesMeta: [
+			{
+				id: "axis-1",
+				name: "Axis 1",
+				color: "#475569",
+				position: "left",
+				showGrid: true,
+			},
+		],
+	};
+
+	function initShared() {
+		const gl = makeGl2Mock();
+		const canvas = makeCanvasMock(gl);
+		const sab = new ArrayBuffer(VIEWPORT_SAB_BYTES);
+		send({
+			t: "init",
+			canvas: canvas as unknown as OffscreenCanvas,
+			viewport,
+			plotBg: [1, 1, 1],
+			// ViewportReader accepts a plain ArrayBuffer, which keeps the test
+			// independent of crossOriginIsolated / COOP+COEP headers.
+			viewportSab: sab as unknown as SharedArrayBuffer,
+		});
+		send({ t: "series", list: [] });
+		return { gl, canvas, writer: new ViewportWriter(sab) };
+	}
+
+	it("draws a frame from the shared viewport once the scene version matches", async () => {
+		const { gl, writer } = initShared();
+		send({ t: "sceneCtx", ctx: sceneCtx, version: 7 });
+
+		writer.write(7, true, [{ min: 0, max: 10 }], [{ min: 0, max: 50 }]);
+		send({ t: "wake" });
+		await nextFrame();
+		await nextFrame();
+
+		expect(gl.clear).toHaveBeenCalled();
+	});
+
+	it("ignores snapshots whose version does not match the current scene", async () => {
+		const { gl, writer } = initShared();
+		send({ t: "sceneCtx", ctx: sceneCtx, version: 7 });
+		await nextFrame();
+		await nextFrame();
+		gl.clear.mockClear();
+
+		// Host published a viewport for a scene the worker has not received
+		// yet. Drawing it would mix new ranges with stale axis metadata.
+		writer.write(99, false, [{ min: 0, max: 10 }], [{ min: 0, max: 50 }]);
+		send({ t: "wake" });
+		await nextFrame();
+		await nextFrame();
+
+		expect(gl.clear).not.toHaveBeenCalled();
+	});
+
+	it("clamps the axis count to the scene metadata", async () => {
+		const { gl, writer } = initShared();
+		send({ t: "sceneCtx", ctx: sceneCtx, version: 3 });
+
+		// Four axes published, but the scene only knows about one of each. The
+		// extra slots must be dropped rather than read past the metadata array.
+		writer.write(
+			3,
+			false,
+			[
+				{ min: 0, max: 10 },
+				{ min: 10, max: 20 },
+			],
+			[
+				{ min: 0, max: 5 },
+				{ min: 5, max: 9 },
+			],
+		);
+		send({ t: "wake" });
+		await nextFrame();
+		await nextFrame();
+
+		expect(gl.clear).toHaveBeenCalled();
+	});
+
+	it("keeps redrawing as the host publishes new viewports", async () => {
+		const { gl, writer } = initShared();
+		send({ t: "sceneCtx", ctx: sceneCtx, version: 11 });
+		send({ t: "wake" });
+
+		// Each published snapshot must produce its own draw — this is the pan
+		// path, where the host writes once per frame and sends nothing else.
+		for (let i = 0; i < 3; i++) {
+			gl.clear.mockClear();
+			writer.write(
+				11,
+				true,
+				[{ min: i, max: 10 + i }],
+				[{ min: 0, max: 50 }],
+			);
+			await nextFrame();
+			await nextFrame();
+			expect(gl.clear).toHaveBeenCalled();
+		}
+
+		// A tick with no new snapshot must not redraw.
+		gl.clear.mockClear();
+		await nextFrame();
+		await nextFrame();
+		expect(gl.clear).not.toHaveBeenCalled();
 	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,11 +23,13 @@ export default defineConfig({
 			provider: "v8",
 			reporter: ["text", "json", "html"],
 			exclude: ["node_modules", "dist"],
+			// Kept just under the current actuals so coverage can only go up.
+			// Ratchet these when they rise; never lower them.
 			thresholds: {
-				statements: 85,
-				branches: 73,
-				functions: 85,
-				lines: 85,
+				statements: 91,
+				branches: 80,
+				functions: 86,
+				lines: 92,
 			},
 		},
 	},


### PR DESCRIPTION
Closes #712.

Overall: **87.2 → 91.7 %** statements, **76.8 → 80.3 %** branches, 1102 → 1177 tests.

| Module | Statements | Branches |
|---|---|---|
| `utils/regression.ts` | 73.9 → **100 %** | 59.7 → 93.5 % |
| `workers/render.worker.ts` | 62.1 → **94.5 %** | 49.3 → 82.1 % |
| `utils/decimation.ts` | 81.7 → 88.5 % | 82.1 → 89.5 % |
| `utils/formula/wholeColumn.ts` | 89.4 → 95.4 % | 69.4 → 80.2 % |
| `Plot/crosshair/*` | **0 → 99.5 %** | **0 → 97.4 %** |

### What was actually untested

- **`kdeSmoothing` above 256 points.** Below the threshold it runs an exact O(N²) evaluation; above it, an O(N) grid-binning approximation — and that second path is the one every real dataset takes. It had no coverage. It is now checked against a textbook Gaussian kernel smoother written in the test, not against itself, plus the degenerate zero-range case and unsorted input.
- **The whole SharedArrayBuffer render path.** `drawSharedFrame`/`sharedLoop`/`wakeSharedLoop` and the `sceneCtx`/`wake`/`highlight` messages never ran in tests. Driven now via `ViewportWriter` over a plain `ArrayBuffer`, so the tests do not depend on COOP/COEP headers. Includes the version-mismatch guard — publishing a viewport for a scene the worker has not received must *not* draw.
- **The entire crosshair feature.** `computeSnap`, `renderTooltipHTML` and `drawCanvas` had zero tests between them. The snapping is asserted against hand-computed positions, and the tooltip's DOM-node recycling is checked across *successive* renders — that is where it can strand a stale row.
- **M4 extrema preservation** is now a property test against a full-resolution scan, rather than a handful of fixed cases.

### One thing found, deliberately not fixed here

`renderTooltipHTML` splits a formatted value into an integer and a decimal span with `formatted.search(/[.,]/)`. For a grouped number like `1,234.5` that matches the **thousands** separator first, so the split lands as `1` + `,234.5` and the grouping digits get the dimmed decimal styling. The rendered text is still correct — it is purely cosmetic. It is documented by a test that pins current behaviour rather than silently changed inside a coverage PR; happy to fix it separately.

### Also

Thresholds raised 85/73/85/85 → **91/80/86/92**, just under the new actuals. Stale `master` references in CLAUDE.md updated to `main`, and the new format script documented.