### PR TITLE
perf: add hot-path benchmarks with a CI regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,22 @@ jobs:
         with:
           path: dist
 
+  # Separate job so a noisy benchmark never blocks the deploy pipeline, and so
+  # it runs concurrently with the quality gates rather than lengthening them.
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Benchmark hot path against the baseline
+        # Results are normalised against a control workload measured in the
+        # same run, so they survive the spread between runner classes.
+        run: npm run bench:check
+
   deploy:
     # Only deploy a green build of main; reuses the artifact from quality.
     needs: quality

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ graphify-out/
 .gemini/
 .remember/
 .ruff_cache/
+
+# Benchmark run output; the committed baseline is bench-baseline.json.
+bench-result.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Package manager is **npm** (ships with Node >=24). CI runs `npm ci`; locally use
 - `npm run lint` — ESLint over the repo.
 - `npm run format` / `npm run format:check` — Biome formatter (tabs, 80 cols); CI enforces `format:check`.
 - `npm test` — Vitest run (one-shot).
+- `npm run bench:check` — hot-path benchmarks vs. the committed baseline (what CI runs). Results are normalised against a control workload measured in the same run, so they survive runner noise. Refresh with `npm run bench:update` after a deliberate perf change; benchmarks live in `src/__bench__/`.
 - `npx vitest run --coverage` — tests with coverage thresholds enforced (what CI runs). Thresholds live in `vitest.config.ts`; the build fails if coverage drops below them. Ratchet up, never down.
 - Single test file: `npx vitest run src/utils/__tests__/formula.test.ts`
 - Single test by name: `npx vitest run -t "name substring"`

--- a/bench-baseline.json
+++ b/bench-baseline.json
@@ -1,0 +1,22 @@
+{
+	"note": "Costs are normalised against the control workload in the same run, so they are comparable across machines. Regenerate with `npm run bench:update`.",
+	"costs": {
+		"m4Float32 10k -> 512": 0.127683,
+		"m4Float32 1M -> 2048": 9.92473,
+		"m4ByXFloat32 1M full span": 7.80781,
+		"m4ByXFloat32 1M zoomed to 1%": 0.174149,
+		"m4MergeOctave": 0.647336,
+		"compile a mixed expression": 0.0103744,
+		"simple expression x100000 rows": 6.38555,
+		"mixed expression x100000 rows": 81.1737,
+		"findFirstGE x1000": 0.0742334,
+		"findLastLE x1000": 0.0783504,
+		"findClosest x1000": 0.0684147,
+		"monotonicity scan 1M (cold)": 7.91139,
+		"monotonicity lookup (warm)": 0.000127196,
+		"segment split 1M with NaN runs (cold)": 5.28282,
+		"computeDataSlice 1M monotonic": 0.000289642,
+		"computeDataSlice 1M non-monotonic": 0.00013282,
+		"computeDrawRanges over gappy slice": 0.000457883
+	}
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
 		"format:check": "biome format .",
 		"lint": "eslint .",
 		"preview": "vite preview",
-		"test": "vitest run"
+		"test": "vitest run",
+		"bench": "vitest bench --run --outputJson=bench-result.json",
+		"bench:check": "npm run bench && node scripts/bench-check.mjs",
+		"bench:update": "npm run bench && node scripts/bench-check.mjs --update"
 	},
 	"dependencies": {
 		"@fontsource/comic-neue": "^5.3.0",

--- a/scripts/bench-check.mjs
+++ b/scripts/bench-check.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Compares a benchmark run against the committed baseline.
+ *
+ * CI runners are noisy enough that absolute wall-clock numbers cannot gate a
+ * pull request — the same code can differ by 2x between two runs on the same
+ * runner class. Every benchmark is therefore normalised against the control
+ * workload from the *same run*: we compare `control_hz / bench_hz`, a unitless
+ * cost, rather than the raw hz. A slow runner slows the control by the same
+ * factor and the ratio is unchanged; a genuine regression still moves it.
+ *
+ *   node scripts/bench-check.mjs --update   rewrite the baseline
+ *   node scripts/bench-check.mjs            compare, exit 1 on a regression
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+
+const RESULT_FILE = "bench-result.json";
+const BASELINE_FILE = "bench-baseline.json";
+const CONTROL_NAME = "reference workload";
+
+/**
+ * Tolerance for a single benchmark before it counts as a regression.
+ * Deliberately loose to start with: a gate that cries wolf gets disabled.
+ * Tighten it once a few weeks of CI runs show the real spread.
+ */
+const TOLERANCE = 0.25;
+
+/** Benchmarks noisier than this are reported but never fail the build. */
+const MAX_TRUSTED_RME = 8;
+
+const update = process.argv.includes("--update");
+
+function loadRun(path) {
+	if (!existsSync(path)) {
+		console.error(`Missing ${path} — run \`npm run bench\` first.`);
+		process.exit(1);
+	}
+	const raw = JSON.parse(readFileSync(path, "utf8"));
+	const out = {};
+	let control = null;
+	for (const file of raw.files ?? []) {
+		for (const group of file.groups ?? []) {
+			for (const b of group.benchmarks ?? []) {
+				if (b.name === CONTROL_NAME) {
+					control = b.hz;
+					continue;
+				}
+				// Group names carry the file path; the bench name alone is the
+				// stable identity across runs.
+				out[b.name] = { hz: b.hz, rme: b.rme };
+			}
+		}
+	}
+	if (control === null) {
+		console.error(
+			`No control benchmark named "${CONTROL_NAME}" in the run. It must be` +
+				" present so results can be normalised.",
+		);
+		process.exit(1);
+	}
+	const costs = {};
+	for (const [name, { hz, rme }] of Object.entries(out)) {
+		// Cost relative to the control: higher means slower.
+		costs[name] = { cost: control / hz, rme };
+	}
+	return { costs, controlHz: control };
+}
+
+const run = loadRun(RESULT_FILE);
+
+if (update) {
+	const baseline = {
+		note:
+			"Costs are normalised against the control workload in the same run," +
+			" so they are comparable across machines. Regenerate with" +
+			" `npm run bench:update`.",
+		costs: Object.fromEntries(
+			Object.entries(run.costs).map(([k, v]) => [
+				k,
+				Number(v.cost.toPrecision(6)),
+			]),
+		),
+	};
+	writeFileSync(BASELINE_FILE, `${JSON.stringify(baseline, null, "\t")}\n`);
+	console.log(
+		`Baseline written with ${Object.keys(baseline.costs).length} benchmarks.`,
+	);
+	process.exit(0);
+}
+
+if (!existsSync(BASELINE_FILE)) {
+	console.error(
+		`Missing ${BASELINE_FILE} — create it with \`npm run bench:update\`.`,
+	);
+	process.exit(1);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_FILE, "utf8")).costs;
+
+const regressions = [];
+const improvements = [];
+const missing = [];
+const added = [];
+
+for (const name of Object.keys(baseline)) {
+	if (!(name in run.costs)) missing.push(name);
+}
+
+const rows = [];
+for (const [name, { cost, rme }] of Object.entries(run.costs)) {
+	const base = baseline[name];
+	if (base === undefined) {
+		added.push(name);
+		rows.push([name, "—", cost.toPrecision(4), "new"]);
+		continue;
+	}
+	const delta = (cost - base) / base;
+	const noisy = rme > MAX_TRUSTED_RME;
+	let verdict = "ok";
+	if (delta > TOLERANCE) {
+		if (noisy) {
+			verdict = `slower but noisy (rme ${rme.toFixed(1)}%)`;
+		} else {
+			verdict = "REGRESSION";
+			regressions.push({ name, base, cost, delta });
+		}
+	} else if (delta < -TOLERANCE) {
+		verdict = "faster";
+		improvements.push({ name, delta });
+	}
+	rows.push([
+		name,
+		base.toPrecision(4),
+		cost.toPrecision(4),
+		`${delta >= 0 ? "+" : ""}${(delta * 100).toFixed(1)}%  ${verdict}`,
+	]);
+}
+
+const width = Math.max(...rows.map((r) => r[0].length), 4);
+console.log(
+	`${"name".padEnd(width)}  ${"base".padStart(9)}  ${"now".padStart(9)}  delta`,
+);
+for (const [name, base, now, verdict] of rows) {
+	console.log(
+		`${name.padEnd(width)}  ${base.padStart(9)}  ${now.padStart(9)}  ${verdict}`,
+	);
+}
+
+if (added.length) {
+	console.log(
+		`\n${added.length} new benchmark(s) with no baseline — run \`npm run bench:update\`.`,
+	);
+}
+if (missing.length) {
+	console.log(`\nMissing from this run: ${missing.join(", ")}`);
+}
+if (improvements.length) {
+	console.log(
+		`\n${improvements.length} benchmark(s) got faster by more than ${TOLERANCE * 100}%.` +
+			" Refresh the baseline so the gain is locked in.",
+	);
+}
+
+if (regressions.length) {
+	console.error(`\n${regressions.length} performance regression(s):`);
+	for (const r of regressions) {
+		console.error(
+			`  ${r.name}: ${(r.delta * 100).toFixed(1)}% slower ` +
+				`(${r.base.toPrecision(4)} -> ${r.cost.toPrecision(4)})`,
+		);
+	}
+	process.exit(1);
+}
+
+console.log("\nNo regressions beyond the tolerance.");

--- a/src/__bench__/control.ts
+++ b/src/__bench__/control.ts
@@ -1,0 +1,24 @@
+/**
+ * Fixed reference workload used to normalise every other benchmark.
+ *
+ * CI runners vary by a factor of two or more between runs, so absolute
+ * wall-clock numbers cannot gate a pull request. Every benchmark is therefore
+ * reported as a *cost ratio* against this control, which is executed in the
+ * same process on the same machine in the same run. A slower runner slows the
+ * control by the same factor, so the ratio stays stable and a genuine
+ * regression still moves it.
+ *
+ * The body must stay untouched: changing it invalidates every committed
+ * baseline. It is deliberately simple, branch-free and allocation-free so that
+ * it measures raw scalar throughput rather than any library behaviour.
+ */
+
+export const CONTROL_ITERATIONS = 200_000;
+
+export function controlWorkload(): number {
+	let acc = 0;
+	for (let i = 1; i <= CONTROL_ITERATIONS; i++) {
+		acc += Math.sqrt(i) * 0.5 - acc * 0.000001;
+	}
+	return acc;
+}

--- a/src/__bench__/decimation.bench.ts
+++ b/src/__bench__/decimation.bench.ts
@@ -1,0 +1,56 @@
+import { bench, describe } from "vitest";
+import { m4ByXFloat32, m4Float32, m4MergeOctave } from "../utils/decimation";
+import { controlWorkload } from "./control";
+import { LARGE, makeSeries, SMALL } from "./fixtures";
+
+/**
+ * Decimation is the reason a million-point series can be panned at all: it is
+ * on every frame, for every visible series. A regression here is felt directly
+ * as dropped frames.
+ */
+
+const small = makeSeries(SMALL);
+const large = makeSeries(LARGE);
+
+// Reusable output buffers, matching how the renderer calls these in the hot
+// path — benchmarking the allocating variant would measure the wrong thing.
+const outSmall = { x: new Float32Array(4096), y: new Float32Array(4096) };
+const outLarge = { x: new Float32Array(16384), y: new Float32Array(16384) };
+
+describe("control", () => {
+	bench("reference workload", () => {
+		controlWorkload();
+	});
+});
+
+describe("decimation", () => {
+	bench("m4Float32 10k -> 512", () => {
+		m4Float32(small.x, small.y, 512, outSmall);
+	});
+
+	bench("m4Float32 1M -> 2048", () => {
+		m4Float32(large.x, large.y, 2048, outLarge);
+	});
+
+	bench("m4ByXFloat32 1M full span", () => {
+		m4ByXFloat32(large.x, large.y, 0, 0, LARGE, LARGE / 2048, outLarge);
+	});
+
+	bench("m4ByXFloat32 1M zoomed to 1%", () => {
+		// The common interactive case: a narrow window over a large column.
+		m4ByXFloat32(large.x, large.y, 0, 400_000, 410_000, 10, outLarge);
+	});
+});
+
+describe("decimation — octave merge", () => {
+	// A prepared fine level, merged one octave up. This is the pyramid build
+	// step, so it runs whenever a series or its bucket ladder changes.
+	const width = 64;
+	const level = m4ByXFloat32(large.x, large.y, 0, 0, LARGE, width);
+	const levelX = new Float32Array(level.x);
+	const levelY = new Float32Array(level.y);
+
+	bench("m4MergeOctave", () => {
+		m4MergeOctave(levelX, levelY, 0, width * 2);
+	});
+});

--- a/src/__bench__/fixtures.ts
+++ b/src/__bench__/fixtures.ts
@@ -1,0 +1,47 @@
+/**
+ * Deterministic data for the benchmarks. No Math.random: a benchmark that
+ * measures a different dataset on every run cannot be compared to a baseline.
+ */
+
+/** Cheap deterministic PRNG (mulberry32), stable across Node versions. */
+function prng(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a = (a + 0x6d2b79f5) >>> 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+export interface Series {
+	x: Float32Array;
+	y: Float32Array;
+}
+
+/**
+ * A monotonic x column with a noisy sine on y — the shape of a typical
+ * imported time series, including the spikes that make M4 decimation matter.
+ */
+export function makeSeries(n: number, seed = 12345): Series {
+	const rand = prng(seed);
+	const x = new Float32Array(n);
+	const y = new Float32Array(n);
+	for (let i = 0; i < n; i++) {
+		x[i] = i;
+		y[i] = Math.sin(i * 0.01) * 100 + (rand() - 0.5) * 20;
+	}
+	return { x, y };
+}
+
+/** Same shape, but with NaN runs so the segment splitting has work to do. */
+export function makeGappySeries(n: number, seed = 999): Series {
+	const { x, y } = makeSeries(n, seed);
+	for (let i = 0; i < n; i += 1000) {
+		for (let j = i; j < Math.min(i + 25, n); j++) y[j] = NaN;
+	}
+	return { x, y };
+}
+
+export const SMALL = 10_000;
+export const LARGE = 1_000_000;

--- a/src/__bench__/formula.bench.ts
+++ b/src/__bench__/formula.bench.ts
@@ -1,0 +1,70 @@
+import { bench, describe } from "vitest";
+import { findClosest, findFirstGE, findLastLE } from "../utils/binarySearch";
+import { compileFormula } from "../utils/formula";
+import { LARGE, makeSeries } from "./fixtures";
+
+/**
+ * Formula evaluation runs once per row over a whole column, so its per-row
+ * cost is multiplied by the dataset size. Binary search sits underneath the
+ * decimation and crosshair paths and runs several times per frame.
+ */
+
+const { x } = makeSeries(LARGE);
+const columns = ["Time", "Value"];
+const ROWS = 100_000;
+
+describe("formula — compile", () => {
+	bench("compile a mixed expression", () => {
+		compileFormula(
+			"([Value] * 2 + sqrt(abs([Time]))) / max(1, [Value])",
+			columns,
+		);
+	});
+});
+
+describe("formula — evaluate", () => {
+	const simple = compileFormula("[Value] * 2 + 1", columns);
+	const mixed = compileFormula(
+		"([Value] * 2 + sqrt(abs([Time]))) / max(1, [Value])",
+		columns,
+	);
+	const row = [1.5, 2.5];
+
+	bench(`simple expression x${ROWS} rows`, () => {
+		const ctx = simple.createContext?.();
+		for (let i = 0; i < ROWS; i++) {
+			row[0] = i * 0.001;
+			simple.evaluate(row, ctx);
+		}
+	});
+
+	bench(`mixed expression x${ROWS} rows`, () => {
+		const ctx = mixed.createContext?.();
+		for (let i = 0; i < ROWS; i++) {
+			row[0] = i * 0.001;
+			mixed.evaluate(row, ctx);
+		}
+	});
+});
+
+describe("binarySearch", () => {
+	const targets = [0, 250_000, 500_000, 750_000, 999_999];
+
+	bench("findFirstGE x1000", () => {
+		for (let i = 0; i < 1000; i++) {
+			findFirstGE(x, targets[i % targets.length], 0, x.length);
+		}
+	});
+
+	bench("findLastLE x1000", () => {
+		for (let i = 0; i < 1000; i++) {
+			findLastLE(x, targets[i % targets.length], 0, x.length);
+		}
+	});
+
+	bench("findClosest x1000", () => {
+		for (let i = 0; i < 1000; i++) {
+			findClosest(x, targets[i % targets.length], 0);
+		}
+	});
+});

--- a/src/__bench__/seriesPrep.bench.ts
+++ b/src/__bench__/seriesPrep.bench.ts
@@ -1,0 +1,53 @@
+import { bench, describe } from "vitest";
+import {
+	computeDataSlice,
+	computeDrawRanges,
+	getOrComputeMonotonicity,
+	getOrComputeSegments,
+} from "../components/Plot/seriesPrep";
+import { LARGE, makeGappySeries, makeSeries } from "./fixtures";
+
+/**
+ * Per-frame series preparation: which slice of the column is on screen, and
+ * which NaN-free runs inside it become draw ranges. Runs once per visible
+ * series per frame.
+ */
+
+const clean = makeSeries(LARGE);
+const gappy = makeGappySeries(LARGE);
+
+describe("seriesPrep", () => {
+	// Cache-hit path: what actually happens on every frame after the first.
+	const warmMono = new WeakMap<Float32Array, boolean>();
+	const warmSeg = new WeakMap<Float32Array, { start: number; end: number }[]>();
+	getOrComputeMonotonicity(clean.x, warmMono);
+	getOrComputeSegments(gappy.x, gappy.y, warmSeg);
+
+	bench("monotonicity scan 1M (cold)", () => {
+		getOrComputeMonotonicity(clean.x, new WeakMap());
+	});
+
+	bench("monotonicity lookup (warm)", () => {
+		getOrComputeMonotonicity(clean.x, warmMono);
+	});
+
+	bench("segment split 1M with NaN runs (cold)", () => {
+		getOrComputeSegments(gappy.x, gappy.y, new WeakMap());
+	});
+
+	bench("computeDataSlice 1M monotonic", () => {
+		computeDataSlice(clean.x, 400_000, 410_000, 0, true);
+	});
+
+	bench("computeDataSlice 1M non-monotonic", () => {
+		// Falls back to a linear scan, so it is the pessimistic case.
+		computeDataSlice(clean.x, 400_000, 410_000, 0, false);
+	});
+
+	const segments = getOrComputeSegments(gappy.x, gappy.y, warmSeg);
+	const scratch: { start: number; count: number }[] = [];
+
+	bench("computeDrawRanges over gappy slice", () => {
+		computeDrawRanges(segments, true, 400_000, 410_000, scratch);
+	});
+});


### PR DESCRIPTION
Closes #710.

17 benchmarks over the pure hot-path modules — M4 decimation and octave merge, per-frame series prep, formula compile/evaluate, binary search — plus a `bench` job in CI.

### The design problem, and the fix

Absolute wall-clock numbers cannot gate a PR: the same code varies by 2x between GitHub runners. So every benchmark is reported as a **cost ratio against a control workload measured in the same process, in the same run** (`control_hz / bench_hz`). A slow runner slows the control by the same factor and the ratio is unchanged; a real regression still moves it.

Fixtures are seeded (mulberry32, no `Math.random`) so two runs measure the same data.

### Evidence it works

Two consecutive local runs against a fresh baseline — spread is **±8.5 % worst case**, well inside the 25 % tolerance:

```
m4Float32 1M -> 2048                       9.925      10.07  +1.4%  ok
m4ByXFloat32 1M full span                  7.808      7.674  -1.7%  ok
findLastLE x1000                         0.07835    0.07172  -8.5%  ok
computeDrawRanges over gappy slice     0.0004579  0.0004191  -8.5%  ok
```

### Evidence the gate bites

Per the ticket's last acceptance criterion, I slowed the `m4Float32` bucket loop by a factor of three and re-ran. Exit code 1, and exactly the two affected benchmarks fired — no false positives among the other 15:

```
m4Float32 10k -> 512                      0.1277     0.1980  +55.1%  REGRESSION
m4Float32 1M -> 2048                       9.925      17.28  +74.1%  REGRESSION
```

### Notes

- Runs as a **separate CI job**, so a noisy benchmark can never block the deploy pipeline and it runs concurrently with the quality gates.
- Tolerance starts at 25 % on purpose. A gate that cries wolf gets disabled; it can be tightened once a few weeks of CI runs show the real spread. Benchmarks whose own rme exceeds 8 % are reported but never fail the build.
- `npm run bench:update` refreshes the baseline after a deliberate perf change. Coverage is unaffected — `.bench.ts` files are outside the test include pattern (verified: 91.73 %/80.28 % unchanged).