### PR TITLE
perf: add a gzipped size budget and drop the Excel worker from precache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         run: npx vitest run --coverage
       - name: Build
         run: npm run build
+      - name: Size budget
+        # Operates on the build produced above; gzipped bytes, per entry plus
+        # the PWA precache total.
+        run: node scripts/size-check.mjs
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v5

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ graphify-out/
 
 # Benchmark run output; the committed baseline is bench-baseline.json.
 bench-result.json
+
+# Bundle composition report from `npm run analyze`.
+dist/bundle-report.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Package manager is **npm** (ships with Node >=24). CI runs `npm ci`; locally use
 - `npm run lint` — ESLint over the repo.
 - `npm run format` / `npm run format:check` — Biome formatter (tabs, 80 cols); CI enforces `format:check`.
 - `npm test` — Vitest run (one-shot).
+- `npm run size:check` — production build vs. the gzipped size budget in `size-budget.json` (what CI runs). `npm run size:update` re-records it; `npm run analyze` writes a per-module composition report to `dist/bundle-report.html`.
 - `npm run bench:check` — hot-path benchmarks vs. the committed baseline (what CI runs). Results are normalised against a control workload measured in the same run, so they survive runner noise. Refresh with `npm run bench:update` after a deliberate perf change; benchmarks live in `src/__bench__/`.
 - `npx vitest run --coverage` — tests with coverage thresholds enforced (what CI runs). Thresholds live in `vitest.config.ts`; the build fails if coverage drops below them. Ratchet up, never down.
 - Single test file: `npx vitest run src/utils/__tests__/formula.test.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
 				"eslint-plugin-react-refresh": "^0.5.2",
 				"globals": "^17.8.0",
 				"jsdom": "^30.0.1",
+				"rollup-plugin-visualizer": "^7.0.1",
 				"typescript": "^6.0.3",
 				"typescript-eslint": "^8.65.0",
 				"vite": "^8.1.5",
@@ -4035,6 +4036,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -4114,6 +4131,39 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/commander": {
@@ -4317,6 +4367,36 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/default-browser": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4333,6 +4413,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/define-properties": {
@@ -4417,6 +4510,13 @@
 			"integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/entities": {
 			"version": "8.0.0",
@@ -5112,6 +5212,29 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-intrinsic": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5581,6 +5704,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-document.all": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -5654,6 +5793,38 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-in-ssh": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+			"integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-map": {
@@ -5889,6 +6060,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-wsl": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/isarray": {
@@ -6680,6 +6867,27 @@
 				"node": ">=12.20.0"
 			}
 		},
+		"node_modules/open": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+			"integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.4.0",
+				"define-lazy-prop": "^3.0.0",
+				"is-in-ssh": "^1.0.0",
+				"is-inside-container": "^1.0.0",
+				"powershell-utils": "^0.1.0",
+				"wsl-utils": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6886,6 +7094,19 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/powershell-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+			"integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -7189,6 +7410,60 @@
 				"@rollup/rollup-win32-x64-gnu": "4.62.2",
 				"@rollup/rollup-win32-x64-msvc": "4.62.2",
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/rollup-plugin-visualizer": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+			"integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"open": "^11.0.0",
+				"picomatch": "^4.0.2",
+				"source-map": "^0.7.4",
+				"yargs": "^18.0.0"
+			},
+			"bin": {
+				"rollup-plugin-visualizer": "dist/bin/cli.js"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"peerDependencies": {
+				"rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+				"rollup": "2.x || 3.x || 4.x"
+			},
+			"peerDependenciesMeta": {
+				"rolldown": {
+					"optional": true
+				},
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/safe-array-concat": {
@@ -7565,6 +7840,23 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/string.prototype.matchall": {
 			"version": "4.0.12",
 			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -7666,6 +7958,35 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
 		"node_modules/strip-comments": {
@@ -8832,6 +9153,72 @@
 				"workbox-core": "7.4.1"
 			}
 		},
+		"node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wsl-utils": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+			"integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-wsl": "^3.1.0",
+				"powershell-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/xlsx": {
 			"version": "0.20.3",
 			"resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
@@ -8861,12 +9248,50 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/yallist": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/yargs": {
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^8.2.1",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
 		"test": "vitest run",
 		"bench": "vitest bench --run --outputJson=bench-result.json",
 		"bench:check": "npm run bench && node scripts/bench-check.mjs",
-		"bench:update": "npm run bench && node scripts/bench-check.mjs --update"
+		"bench:update": "npm run bench && node scripts/bench-check.mjs --update",
+		"size:check": "npm run build && node scripts/size-check.mjs",
+		"size:update": "npm run build && node scripts/size-check.mjs --update",
+		"analyze": "ANALYZE=1 npm run build"
 	},
 	"dependencies": {
 		"@fontsource/comic-neue": "^5.3.0",
@@ -50,6 +53,7 @@
 		"eslint-plugin-react-refresh": "^0.5.2",
 		"globals": "^17.8.0",
 		"jsdom": "^30.0.1",
+		"rollup-plugin-visualizer": "^7.0.1",
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.65.0",
 		"vite": "^8.1.5",

--- a/scripts/size-check.mjs
+++ b/scripts/size-check.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Enforces the bundle size budget against a production build.
+ *
+ * Measures gzipped bytes, because that is what users actually download, and
+ * groups files by their stable entry name (the content hash changes on every
+ * build). The precache total is budgeted separately: it is the real
+ * cold-start cost of the PWA, and it is what silently grows when an asset is
+ * added without anyone noticing.
+ *
+ *   node scripts/size-check.mjs            compare against size-budget.json
+ *   node scripts/size-check.mjs --update   rewrite the budget from this build
+ */
+
+import {
+	existsSync,
+	readFileSync,
+	readdirSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { gzipSync } from "node:zlib";
+import { join } from "node:path";
+
+const DIST = "dist";
+const BUDGET_FILE = "size-budget.json";
+
+/** Headroom over the measured size when writing a new budget. */
+const HEADROOM = 0.05;
+
+const update = process.argv.includes("--update");
+
+if (!existsSync(join(DIST, "index.html"))) {
+	console.error(`No build found in ${DIST}/ — run \`npm run build\` first.`);
+	process.exit(1);
+}
+
+const gzipOf = (path) => gzipSync(readFileSync(path), { level: 9 }).length;
+
+/** Strips Vite's content hash so the name is stable across builds. */
+const entryName = (file) =>
+	file.replace(/-[A-Za-z0-9_-]{8,}(\.[a-z0-9]+)$/, "$1");
+
+function measure() {
+	const assets = {};
+	const dir = join(DIST, "assets");
+	for (const file of readdirSync(dir)) {
+		if (!/\.(js|css)$/.test(file)) continue;
+		assets[entryName(file)] = gzipOf(join(dir, file));
+	}
+
+	// Everything the service worker pulls down before the app is usable.
+	const sw = readFileSync(join(DIST, "sw.js"), "utf8");
+	const manifest = sw.match(/\[\{[^\]]*\}\]/);
+	let precacheGzip = 0;
+	let precacheCount = 0;
+	if (manifest) {
+		const entries = JSON.parse(
+			manifest[0].replace(/url:/g, '"url":').replace(/revision:/g, '"revision":'),
+		);
+		precacheCount = entries.length;
+		for (const e of entries) {
+			const p = join(DIST, e.url);
+			if (existsSync(p) && statSync(p).isFile()) precacheGzip += gzipOf(p);
+		}
+	}
+
+	return { assets, precacheGzip, precacheCount };
+}
+
+const { assets, precacheGzip, precacheCount } = measure();
+const kb = (b) => `${(b / 1024).toFixed(1)} KB`;
+
+if (update) {
+	const withHeadroom = (b) => Math.ceil((b * (1 + HEADROOM)) / 1024) * 1024;
+	const budget = {
+		note:
+			"Gzipped byte budgets, roughly 5% above the measured build." +
+			" Regenerate with `npm run size:update` and justify any increase" +
+			" in the pull request.",
+		precacheGzip: withHeadroom(precacheGzip),
+		assets: Object.fromEntries(
+			Object.entries(assets)
+				.sort((a, b) => b[1] - a[1])
+				.map(([name, bytes]) => [name, withHeadroom(bytes)]),
+		),
+	};
+	writeFileSync(BUDGET_FILE, `${JSON.stringify(budget, null, "\t")}\n`);
+	console.log(
+		`Budget written: ${Object.keys(budget.assets).length} assets,` +
+			` precache ${kb(budget.precacheGzip)}.`,
+	);
+	process.exit(0);
+}
+
+if (!existsSync(BUDGET_FILE)) {
+	console.error(
+		`Missing ${BUDGET_FILE} — create it with \`npm run size:update\`.`,
+	);
+	process.exit(1);
+}
+
+const budget = JSON.parse(readFileSync(BUDGET_FILE, "utf8"));
+const failures = [];
+const unbudgeted = [];
+
+const rows = [["asset", "size", "budget", ""]];
+for (const [name, bytes] of Object.entries(assets).sort(
+	(a, b) => b[1] - a[1],
+)) {
+	const limit = budget.assets[name];
+	if (limit === undefined) {
+		unbudgeted.push(name);
+		rows.push([name, kb(bytes), "—", "unbudgeted"]);
+		continue;
+	}
+	const over = bytes > limit;
+	if (over) failures.push({ name, bytes, limit });
+	rows.push([
+		name,
+		kb(bytes),
+		kb(limit),
+		over
+			? `OVER by ${kb(bytes - limit)}`
+			: `${((bytes / limit) * 100).toFixed(0)}%`,
+	]);
+}
+
+const precacheOver = precacheGzip > budget.precacheGzip;
+if (precacheOver) {
+	failures.push({
+		name: `precache total (${precacheCount} entries)`,
+		bytes: precacheGzip,
+		limit: budget.precacheGzip,
+	});
+}
+rows.push([
+	`precache total (${precacheCount} entries)`,
+	kb(precacheGzip),
+	kb(budget.precacheGzip),
+	precacheOver
+		? `OVER by ${kb(precacheGzip - budget.precacheGzip)}`
+		: `${((precacheGzip / budget.precacheGzip) * 100).toFixed(0)}%`,
+]);
+
+const w0 = Math.max(...rows.map((r) => r[0].length));
+for (const [a, b, c, d] of rows) {
+	console.log(`${a.padEnd(w0)}  ${b.padStart(9)}  ${c.padStart(9)}  ${d}`);
+}
+
+if (unbudgeted.length) {
+	console.log(
+		`\n${unbudgeted.length} asset(s) with no budget entry.` +
+			" Run `npm run size:update` to record them.",
+	);
+}
+
+if (failures.length) {
+	console.error(`\n${failures.length} size budget violation(s):`);
+	for (const f of failures) {
+		console.error(`  ${f.name}: ${kb(f.bytes)} exceeds ${kb(f.limit)}`);
+	}
+	console.error(
+		"\nIf the growth is intended, run `npm run size:update` and say why in" +
+			" the pull request.",
+	);
+	process.exit(1);
+}
+
+console.log("\nAll assets within budget.");

--- a/size-budget.json
+++ b/size-budget.json
@@ -1,0 +1,14 @@
+{
+	"note": "Gzipped byte budgets, roughly 5% above the measured build. Regenerate with `npm run size:update` and justify any increase in the pull request.",
+	"precacheGzip": 551936,
+	"assets": {
+		"excel.worker.js": 167936,
+		"index.js": 158720,
+		"render.worker.js": 18432,
+		"formula.worker.js": 11264,
+		"index.css": 5120,
+		"parser.worker.js": 4096,
+		"workbox-window.prod.es5.js": 3072,
+		"latin.css": 1024
+	}
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import react from "@vitejs/plugin-react";
+import { visualizer } from "rollup-plugin-visualizer";
 import { VitePWA } from "vite-plugin-pwa";
 import { defineConfig } from "vitest/config";
 import { resolveAppVersion } from "./appVersion";
@@ -31,6 +32,16 @@ export default defineConfig({
 			},
 		},
 		react(),
+		// Opt-in bundle composition report: ANALYZE=1 npm run build
+		...(process.env.ANALYZE
+			? [
+					visualizer({
+						filename: "dist/bundle-report.html",
+						gzipSize: true,
+						brotliSize: true,
+					}),
+				]
+			: []),
 		VitePWA({
 			registerType: "autoUpdate",
 			injectRegister: null,
@@ -39,6 +50,21 @@ export default defineConfig({
 			// theme's typography is available fully offline.
 			workbox: {
 				globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+				// The Excel worker carries the whole spreadsheet library and is
+				// only constructed on the first .xlsx import, which most sessions
+				// never do. Precaching it would put that cost on every cold load,
+				// so it is fetched on demand and cached from then on instead.
+				globIgnores: ["**/excel.worker-*.js"],
+				runtimeCaching: [
+					{
+						urlPattern: /\/assets\/excel\.worker-.*\.js$/,
+						handler: "CacheFirst",
+						options: {
+							cacheName: "excel-worker",
+							expiration: { maxEntries: 2 },
+						},
+					},
+				],
 			},
 			manifest: {
 				name: "WebGraphy",


### PR DESCRIPTION
Closes #713.

### The Excel worker was in the precache

Confirmed from the generated `sw.js` manifest: `excel.worker-*.js` was one of the 45 precached entries, so every cold visit downloaded 156 KB gzip of spreadsheet library — for a worker that is only constructed on the first `.xlsx` import, which most sessions never perform. The dynamic `import("xlsx")` inside the worker did not help, because Vite inlines it into the worker chunk.

It now uses `globIgnores` plus a `CacheFirst` runtime rule, so it is fetched on demand and cached from then on.

| | before | after |
|---|---|---|
| Precache entries | 45 | 44 |
| Precache raw | 1406 KB | **940 KB** (−33 %) |
| Precache gzip | — | 513 KB |

### What actually dominates the main chunk

Measured, not guessed — via the new `npm run analyze` report (gzip, main chunk):

| | gzip | share |
|---|---|---|
| react-dom | 85.1 KB | 33.6 % |
| app code (`src/components`) | 69.7 KB | 27.5 % |
| zod | 26.5 KB | 10.4 % |
| app code (`src/utils`) | 18.7 KB | 7.4 % |
| lucide-react | 10.8 KB | 4.3 % |

Nothing here is obviously wasteful. `react-dom` is irreducible; `zod` at 26.5 KB is the price of validating everything loaded out of IndexedDB, which seems a fair trade for a client-only app where corrupt persisted state is otherwise unrecoverable. Noted rather than acted on — no speculative changes in this PR.

### The budget

`scripts/size-check.mjs` measures **gzipped** bytes (what users download), strips Vite's content hash so entry names stay stable, and budgets the precache total separately — that is the number that grows silently when an asset is added.

```
asset                             size     budget
excel.worker.js               156.0 KB   164.0 KB  95%
index.js                      147.3 KB   155.0 KB  95%
render.worker.js               16.9 KB    18.0 KB  94%
precache total (44 entries)   513.2 KB   539.0 KB  95%
```

Verified the gate bites: tightening `index.js` to 48.8 KB gives exit 1 with `OVER by 98.5 KB`.

`npm run size:update` re-records the budget (5 % headroom) when an increase is intended and justified.