### PR TITLE
feat(a11y): expose the chart to assistive tech and make dialogs keyboard-operable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,11 +28,13 @@
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^7.0.0",
 				"@testing-library/react": "^16.3.2",
+				"@testing-library/user-event": "^14.6.3",
 				"@types/node": "^26.1.2",
 				"@types/react": "^19.2.14",
 				"@types/react-dom": "^19.2.3",
 				"@vitejs/plugin-react": "^6.0.4",
 				"@vitest/coverage-v8": "^4.1.10",
+				"axe-core": "^4.13.0",
 				"eslint": "^10.8.0",
 				"eslint-plugin-react-hooks": "^7.1.1",
 				"eslint-plugin-react-refresh": "^0.5.2",
@@ -43,7 +45,8 @@
 				"typescript-eslint": "^8.65.0",
 				"vite": "^8.1.5",
 				"vite-plugin-pwa": "^1.3.0",
-				"vitest": "^4.1.5"
+				"vitest": "^4.1.5",
+				"vitest-axe": "^0.1.0"
 			},
 			"engines": {
 				"node": ">=24.0.0"
@@ -3194,6 +3197,20 @@
 				}
 			}
 		},
+		"node_modules/@testing-library/user-event": {
+			"version": "14.6.3",
+			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+			"integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": ">=7.21.4"
+			}
+		},
 		"node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
 			"version": "3.0.0-pre1",
 			"resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
@@ -3907,6 +3924,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/axe-core": {
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+			"integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
 			"version": "0.4.17",
 			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
@@ -4131,6 +4158,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/cliui": {
@@ -6619,6 +6659,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash-es": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -8698,6 +8745,24 @@
 				"vite": {
 					"optional": false
 				}
+			}
+		},
+		"node_modules/vitest-axe": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+			"integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"aria-query": "^5.0.0",
+				"axe-core": "^4.4.2",
+				"chalk": "^5.0.1",
+				"dom-accessibility-api": "^0.5.14",
+				"lodash-es": "^4.17.21",
+				"redent": "^3.0.0"
+			},
+			"peerDependencies": {
+				"vitest": ">=0.16.0"
 			}
 		},
 		"node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^7.0.0",
 		"@testing-library/react": "^16.3.2",
+		"@testing-library/user-event": "^14.6.3",
 		"@types/node": "^26.1.2",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.4",
 		"@vitest/coverage-v8": "^4.1.10",
+		"axe-core": "^4.13.0",
 		"eslint": "^10.8.0",
 		"eslint-plugin-react-hooks": "^7.1.1",
 		"eslint-plugin-react-refresh": "^0.5.2",
@@ -58,7 +60,8 @@
 		"typescript-eslint": "^8.65.0",
 		"vite": "^8.1.5",
 		"vite-plugin-pwa": "^1.3.0",
-		"vitest": "^4.1.5"
+		"vitest": "^4.1.5",
+		"vitest-axe": "^0.1.0"
 	},
 	"overrides": {
 		"serialize-javascript": "^7.0.5",

--- a/src/__tests__/contrast.test.ts
+++ b/src/__tests__/contrast.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { THEMES, type ThemeName } from "../themes";
+import { hexToRgb } from "../utils/colors";
+
+/**
+ * WCAG contrast is arithmetic, so it can simply be checked rather than
+ * eyeballed. This pins the pairings a user reads constantly — body text and
+ * axis labels against their background — so a palette tweak cannot quietly
+ * push them below the threshold in one theme while looking fine in another.
+ */
+
+/** WCAG 2.1 relative luminance. */
+function luminance(hex: string): number {
+	const { r, g, b } = hexToRgb(hex);
+	const channel = (v: number) => {
+		const s = v / 255;
+		return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+	};
+	return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(a: string, b: string): number {
+	const la = luminance(a);
+	const lb = luminance(b);
+	const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+	return (hi + 0.05) / (lo + 0.05);
+}
+
+const themeNames = Object.keys(THEMES) as ThemeName[];
+
+/** WCAG AA for normal-size body text. */
+const AA_NORMAL = 4.5;
+/** WCAG AA for large text and for incidental UI such as axis tick labels. */
+const AA_LARGE = 3;
+
+describe("theme contrast", () => {
+	it.each(themeNames)("%s: body text meets WCAG AA", (name) => {
+		const t = THEMES[name];
+		expect(contrastRatio(t.text, t.bg)).toBeGreaterThanOrEqual(AA_NORMAL);
+	});
+
+	it.each(themeNames)("%s: axis labels are legible", (name) => {
+		const t = THEMES[name];
+		// Tick labels are small but not body copy; AA large is the pragmatic
+		// floor for them, and they sit on the plot background.
+		expect(contrastRatio(t.labelColor, t.plotBg ?? t.bg)).toBeGreaterThanOrEqual(
+			AA_LARGE,
+		);
+	});
+
+	it.each(themeNames)(
+		"%s: the accent colour is visible on the background",
+		(name) => {
+			const t = THEMES[name];
+			expect(contrastRatio(t.accent, t.bg)).toBeGreaterThanOrEqual(AA_LARGE);
+		},
+	);
+
+	it("computes known contrast ratios correctly", () => {
+		// Sanity check on the maths itself, against the two textbook extremes.
+		expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 5);
+		expect(contrastRatio("#ffffff", "#ffffff")).toBeCloseTo(1, 5);
+	});
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,3 +1,10 @@
+import { expect } from "vitest";
+import * as axeMatchers from "vitest-axe/matchers";
+
+// Register `toHaveNoViolations` globally so any component test can assert
+// accessibility without repeating the wiring.
+expect.extend(axeMatchers);
+
 // Mock localStorage for tests (runs before module imports)
 const localStorageMock = (() => {
 	let store: Record<string, string> = {};

--- a/src/components/Layout/Modal.tsx
+++ b/src/components/Layout/Modal.tsx
@@ -1,5 +1,7 @@
 import { X } from "lucide-react";
 import type React from "react";
+import { useRef } from "react";
+import { useDialogA11y } from "../../hooks/useDialogA11y";
 
 interface ModalProps {
 	onClose: () => void;
@@ -35,16 +37,30 @@ export const Modal: React.FC<ModalProps> = ({
 	ariaLabel,
 	hideHeader = false,
 }) => {
+	const cardRef = useRef<HTMLDivElement | null>(null);
+	// Focus containment, Escape-to-close and focus restore. Also supplies the
+	// id that names the dialog for assistive technology.
+	const titleId = useDialogA11y(cardRef, onClose);
+	const hasTextTitle = typeof title === "string" && !hideHeader;
+
 	return (
 		<div className="modal-overlay">
 			<div
+				ref={cardRef}
 				className="modal-card"
+				role="dialog"
+				aria-modal="true"
+				{...(hasTextTitle
+					? { "aria-labelledby": titleId }
+					: { "aria-label": ariaLabel || "Dialog" })}
 				style={{ padding, borderRadius, maxWidth, width, height, maxHeight }}
 			>
 				{!hideHeader && (
 					<div className="modal-header">
 						{typeof title === "string" ? (
-							<h2 className="modal-title">{title}</h2>
+							<h2 className="modal-title" id={titleId}>
+								{title}
+							</h2>
 						) : (
 							title
 						)}

--- a/src/components/Layout/__tests__/Modal.a11y.test.tsx
+++ b/src/components/Layout/__tests__/Modal.a11y.test.tsx
@@ -1,0 +1,129 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { Modal } from "../Modal";
+
+/**
+ * Every dialog in the app goes through this component, so its keyboard
+ * behaviour is the keyboard behaviour of the whole modal layer: focus has to
+ * enter it, stay inside it, and go back where it came from.
+ */
+
+function renderModal(props: Partial<Parameters<typeof Modal>[0]> = {}) {
+	const onClose = vi.fn();
+	const utils = render(
+		<Modal onClose={onClose} title="Settings" {...props}>
+			<button type="button">First</button>
+			<button type="button">Second</button>
+		</Modal>,
+	);
+	return { onClose, ...utils };
+}
+
+describe("Modal accessibility", () => {
+	it("has no axe violations", async () => {
+		const { container } = renderModal();
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it("exposes itself as a modal dialog named by its heading", () => {
+		renderModal();
+
+		const dialog = screen.getByRole("dialog");
+		expect(dialog).toHaveAttribute("aria-modal", "true");
+		// Named via aria-labelledby pointing at the visible <h2>, so the
+		// accessible name cannot drift from what is on screen.
+		expect(dialog).toHaveAccessibleName("Settings");
+	});
+
+	it("falls back to an explicit label when the title is not plain text", () => {
+		renderModal({
+			title: <span>Rich title</span>,
+			ariaLabel: "Import settings",
+		});
+
+		expect(screen.getByRole("dialog")).toHaveAccessibleName("Import settings");
+	});
+
+	it("moves focus into the dialog on open", async () => {
+		renderModal();
+
+		// The close button is first in DOM order (the header precedes the
+		// body), so it is where focus lands.
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Close dialog" })).toHaveFocus(),
+		);
+	});
+
+	it("closes on Escape", async () => {
+		const user = userEvent.setup();
+		const { onClose } = renderModal();
+
+		await user.keyboard("{Escape}");
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps Tab inside the dialog", async () => {
+		const user = userEvent.setup();
+		renderModal();
+
+		const first = screen.getByRole("button", { name: "First" });
+		const second = screen.getByRole("button", { name: "Second" });
+		const close = screen.getByRole("button", { name: "Close dialog" });
+
+		await waitFor(() => expect(close).toHaveFocus());
+		await user.tab();
+		expect(first).toHaveFocus();
+		await user.tab();
+		expect(second).toHaveFocus();
+		// Past the last control, focus wraps to the first rather than escaping
+		// to the page behind the backdrop.
+		await user.tab();
+		expect(close).toHaveFocus();
+	});
+
+	it("wraps backwards with Shift+Tab", async () => {
+		const user = userEvent.setup();
+		renderModal();
+
+		const second = screen.getByRole("button", { name: "Second" });
+		const close = screen.getByRole("button", { name: "Close dialog" });
+
+		await waitFor(() => expect(close).toHaveFocus());
+		await user.tab({ shift: true });
+		expect(second).toHaveFocus();
+	});
+
+	it("returns focus to the opener when it closes", async () => {
+		const opener = document.createElement("button");
+		opener.textContent = "Open";
+		document.body.appendChild(opener);
+		opener.focus();
+		expect(opener).toHaveFocus();
+
+		const { unmount } = renderModal();
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Close dialog" })).toHaveFocus(),
+		);
+
+		unmount();
+
+		// Without this a keyboard user is dropped back at the top of the
+		// document and has to tab all the way down again.
+		expect(opener).toHaveFocus();
+		opener.remove();
+	});
+
+	it("focuses the dialog itself when it contains no controls", async () => {
+		render(
+			<Modal onClose={vi.fn()} title="Empty" hideHeader ariaLabel="Empty">
+				<p>Nothing to focus here.</p>
+			</Modal>,
+		);
+
+		await waitFor(() => expect(screen.getByRole("dialog")).toHaveFocus());
+	});
+});

--- a/src/components/Plot/WebGLRenderer.tsx
+++ b/src/components/Plot/WebGLRenderer.tsx
@@ -15,6 +15,7 @@ import { useGraphStore } from "../../store/useGraphStore";
 import { hexToRgba } from "../../utils/colors";
 import { getColumnIndex } from "../../utils/columns";
 import { buildOverlay, type OverlayInput } from "./buildOverlay";
+import { describeChart } from "./chartDescription";
 import type { OverlayState } from "./drawOverlay";
 import type { SceneContext } from "./frameScene";
 import {
@@ -223,12 +224,23 @@ export const WebGLRenderer = React.memo(
 			if (!isInteractingRef.current) redrawNowRef.current(false);
 		}, [highlightedSeriesId]);
 
+		// A canvas exposes nothing to assistive technology, so the plot carries a
+		// generated description of what it is currently showing. Rebuilt only
+		// when the series or axis identities change — never on the per-frame
+		// path, which mutates axis ranges through refs without re-rendering.
+		const ariaLabel = useMemo(
+			() => describeChart({ series, datasets, xAxes, yAxes }),
+			[series, datasets, xAxes, yAxes],
+		);
+
 		// No width/height attributes here: once the canvas is transferred to the
 		// render worker, only the worker may size its drawing buffer. CSS keeps
 		// the element filling its layer; backends resize via setViewport.
 		return (
 			<canvas
 				ref={canvasRef}
+				role="img"
+				aria-label={ariaLabel}
 				style={{ display: "block", width: "100%", height: "100%" }}
 			/>
 		);

--- a/src/components/Plot/__tests__/chartDescription.test.ts
+++ b/src/components/Plot/__tests__/chartDescription.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import type {
+	Dataset,
+	SeriesConfig,
+	XAxisConfig,
+	YAxisConfig,
+} from "../../../services/persistence";
+import { describeChart } from "../chartDescription";
+
+/**
+ * This string is the only thing a screen reader gets from the plot, so it is
+ * asserted on content rather than on shape.
+ */
+
+const series = (over: Partial<SeriesConfig> = {}): SeriesConfig =>
+	({
+		id: "s1",
+		name: "Temperature",
+		yColumn: "temp",
+		sourceId: "ds-1",
+		yAxisId: "axis-1",
+		lineColor: "#f00",
+		hidden: false,
+		...over,
+	}) as SeriesConfig;
+
+const dataset = (over: Partial<Dataset> = {}): Dataset =>
+	({ id: "ds-1", xAxisId: "axis-1", ...over }) as Dataset;
+
+const xAxis = (over: Partial<XAxisConfig> = {}): XAxisConfig =>
+	({
+		id: "axis-1",
+		name: "Time",
+		min: 0,
+		max: 100,
+		xMode: "numeric",
+		...over,
+	}) as XAxisConfig;
+
+const yAxis = (over: Partial<YAxisConfig> = {}): YAxisConfig =>
+	({ id: "axis-1", name: "Celsius", min: -5, max: 40, ...over }) as YAxisConfig;
+
+const base = {
+	series: [series()],
+	datasets: [dataset()],
+	xAxes: [xAxis()],
+	yAxes: [yAxis()],
+};
+
+describe("describeChart", () => {
+	it("says the chart is empty when nothing is plotted", () => {
+		expect(describeChart({ ...base, series: [] })).toBe(
+			"Empty chart. No data series are displayed.",
+		);
+	});
+
+	it("treats a chart of only hidden series as empty", () => {
+		expect(
+			describeChart({ ...base, series: [series({ hidden: true })] }),
+		).toContain("Empty chart");
+	});
+
+	it("names the series and both axis ranges", () => {
+		const label = describeChart(base);
+
+		expect(label).toContain("1 data series: Temperature.");
+		expect(label).toContain("Time from 0 to 100.");
+		expect(label).toContain("Celsius from -5 to 40.");
+	});
+
+	it("excludes hidden series from the list", () => {
+		const label = describeChart({
+			...base,
+			series: [series(), series({ id: "s2", name: "Humidity", hidden: true })],
+		});
+
+		expect(label).toContain("Temperature");
+		expect(label).not.toContain("Humidity");
+	});
+
+	it("falls back to the column name for an unnamed series", () => {
+		const label = describeChart({
+			...base,
+			series: [series({ name: "", yColumn: "raw_value" })],
+		});
+		expect(label).toContain("raw_value");
+	});
+
+	it("switches to a count once there are many series", () => {
+		const many = Array.from({ length: 9 }, (_, i) =>
+			series({ id: `s${i}`, name: `Series ${i}` }),
+		);
+		const label = describeChart({ ...base, series: many });
+
+		expect(label).toContain("9 data series, including");
+		expect(label).toContain("Series 0");
+		// The tail is summarised rather than read out in full.
+		expect(label).not.toContain("Series 8");
+	});
+
+	it("only mentions axes that carry a visible series", () => {
+		const label = describeChart({
+			...base,
+			xAxes: [xAxis(), xAxis({ id: "axis-2", name: "Distance" })],
+			yAxes: [yAxis(), yAxis({ id: "axis-2", name: "Percent" })],
+		});
+
+		expect(label).toContain("Time");
+		expect(label).not.toContain("Distance");
+		expect(label).not.toContain("Percent");
+	});
+
+	it("resolves the x axis through the series' dataset", () => {
+		// The series does not reference an x axis itself — its dataset does.
+		const label = describeChart({
+			...base,
+			datasets: [dataset({ xAxisId: "axis-2" })],
+			xAxes: [xAxis(), xAxis({ id: "axis-2", name: "Distance" })],
+		});
+
+		expect(label).toContain("Distance");
+		expect(label).not.toContain("Time");
+	});
+
+	it("formats a date axis as a date", () => {
+		const t0 = Math.floor(new Date(2026, 0, 1).getTime() / 1000);
+		const label = describeChart({
+			...base,
+			xAxes: [xAxis({ xMode: "date", min: t0, max: t0 + 86400 })],
+		});
+
+		// A raw epoch second count would be useless read aloud.
+		expect(label).not.toContain(String(t0));
+	});
+
+	it("names an unlabelled axis by orientation", () => {
+		const label = describeChart({
+			...base,
+			xAxes: [xAxis({ name: "" })],
+			yAxes: [yAxis({ name: "" })],
+		});
+
+		expect(label).toContain("Horizontal axis from");
+		expect(label).toContain("Vertical axis from");
+	});
+
+	it("reports a non-finite bound instead of announcing Infinity", () => {
+		const label = describeChart({
+			...base,
+			yAxes: [yAxis({ min: Number.NEGATIVE_INFINITY, max: Number.NaN })],
+		});
+
+		expect(label).toContain("from unknown to unknown");
+		expect(label).not.toContain("Infinity");
+		expect(label).not.toContain("NaN");
+	});
+
+	it("keeps long floats short", () => {
+		const label = describeChart({
+			...base,
+			yAxes: [yAxis({ min: 0.123456789012, max: 1234.56789012 })],
+		});
+
+		expect(label).not.toContain("0.123456789012");
+		expect(label).toContain("0.123457");
+	});
+
+	it("does not round a narrow axis away to zero", () => {
+		// toLocaleString defaults to three fraction digits, which would turn a
+		// microscopic range into "0 to 0" and make the label useless.
+		const label = describeChart({
+			...base,
+			yAxes: [yAxis({ min: 0.000123, max: 0.000456 })],
+		});
+
+		expect(label).toContain("0.000123");
+		expect(label).toContain("0.000456");
+	});
+});

--- a/src/components/Plot/chartDescription.ts
+++ b/src/components/Plot/chartDescription.ts
@@ -1,0 +1,98 @@
+import type {
+	Dataset,
+	SeriesConfig,
+	XAxisConfig,
+	YAxisConfig,
+} from "../../services/persistence";
+import { formatFullDate } from "../../utils/time";
+
+/**
+ * The plot is a WebGL canvas, which is entirely opaque to assistive
+ * technology: without an accessible name it is announced as nothing at all.
+ * This builds that name from the same data the renderer draws, so it stays in
+ * step with what is on screen instead of being a fixed string.
+ *
+ * Kept short on purpose. A screen reader announces the whole label in one go,
+ * so it names what is plotted and over which ranges; per-point data belongs in
+ * a table, not in a label.
+ */
+
+/** Series listed by name before the label switches to a count. */
+const MAX_NAMED_SERIES = 5;
+
+function formatBound(value: number, xMode: XAxisConfig["xMode"]): string {
+	if (!Number.isFinite(value)) return "unknown";
+	if (xMode === "date") return formatFullDate(value);
+	// toPrecision keeps long floats from flooding the announcement. The
+	// explicit fraction-digit ceiling matters: toLocaleString defaults to three
+	// decimals, which would announce a 0.000123-wide axis as "0 to 0".
+	return parseFloat(value.toPrecision(6)).toLocaleString(undefined, {
+		maximumFractionDigits: 10,
+	});
+}
+
+export interface DescribeChartInput {
+	series: readonly SeriesConfig[];
+	datasets: readonly Dataset[];
+	xAxes: readonly XAxisConfig[];
+	yAxes: readonly YAxisConfig[];
+}
+
+/**
+ * A one-sentence-per-part description of the current chart, suitable for
+ * `aria-label` on the plot canvas.
+ */
+export function describeChart({
+	series,
+	datasets,
+	xAxes,
+	yAxes,
+}: DescribeChartInput): string {
+	const visible = series.filter((s) => !s.hidden);
+	if (visible.length === 0) {
+		return "Empty chart. No data series are displayed.";
+	}
+
+	const names = visible.map((s) => s.name || s.yColumn);
+	const seriesPart =
+		names.length <= MAX_NAMED_SERIES
+			? `${names.length} data series: ${names.join(", ")}.`
+			: `${names.length} data series, including ${names
+					.slice(0, MAX_NAMED_SERIES)
+					.join(", ")}.`;
+
+	// Only axes actually carrying a visible series are announced; the other
+	// slots exist up front but are empty. A series reaches its x axis through
+	// its dataset, which is what owns the x column.
+	const xAxisIdByDatasetId = new Map(datasets.map((d) => [d.id, d.xAxisId]));
+	const usedXIds = new Set<string>();
+	for (const s of visible) {
+		const xAxisId = xAxisIdByDatasetId.get(s.sourceId);
+		if (xAxisId) usedXIds.add(xAxisId);
+	}
+	const usedYIds = new Set(visible.map((s) => s.yAxisId));
+
+	const axisParts: string[] = [];
+	for (const axis of xAxes) {
+		if (!usedXIds.has(axis.id)) continue;
+		const label = axis.name || "Horizontal axis";
+		axisParts.push(
+			`${label} from ${formatBound(axis.min, axis.xMode)} to ${formatBound(
+				axis.max,
+				axis.xMode,
+			)}.`,
+		);
+	}
+	for (const axis of yAxes) {
+		if (!usedYIds.has(axis.id)) continue;
+		const label = axis.name || "Vertical axis";
+		axisParts.push(
+			`${label} from ${formatBound(axis.min, "numeric")} to ${formatBound(
+				axis.max,
+				"numeric",
+			)}.`,
+		);
+	}
+
+	return `Line chart. ${seriesPart} ${axisParts.join(" ")}`.trim();
+}

--- a/src/components/__tests__/a11y.test.tsx
+++ b/src/components/__tests__/a11y.test.tsx
@@ -1,0 +1,74 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import type { SeriesConfig } from "../../services/persistence";
+import { ChartLegend } from "../Plot/ChartLegend";
+import { EmptyState } from "../Plot/EmptyState";
+import { HelpModal } from "../Layout/HelpModal";
+import { ImprintModal } from "../Layout/ImprintModal";
+import { LicenseModal } from "../Layout/LicenseModal";
+
+/**
+ * A broad axe sweep over the components that are cheap to render in
+ * isolation. It will not catch everything — axe cannot judge focus order or
+ * whether a label is meaningful — but it does catch the regressions that are
+ * easy to introduce and invisible in review: an unlabelled control, an
+ * invalid ARIA attribute, a heading level skipped.
+ */
+
+const series: SeriesConfig[] = [
+	{
+		id: "s1",
+		name: "Temperature",
+		yColumn: "temp",
+		sourceId: "ds-1",
+		yAxisId: "axis-1",
+		lineColor: "#e11d48",
+		hidden: false,
+	} as SeriesConfig,
+	{
+		id: "s2",
+		name: "Humidity",
+		yColumn: "hum",
+		sourceId: "ds-1",
+		yAxisId: "axis-1",
+		lineColor: "#2563eb",
+		hidden: true,
+	} as SeriesConfig,
+];
+
+const cases: Array<[string, () => React.ReactElement]> = [
+	[
+		"EmptyState",
+		() => (
+			<EmptyState
+				width={600}
+				height={400}
+				padding={{ top: 10, right: 10, bottom: 40, left: 50 }}
+			/>
+		),
+	],
+	[
+		"ChartLegend",
+		() => (
+			<ChartLegend
+				series={series}
+				onToggleVisibility={vi.fn()}
+				onHighlight={vi.fn()}
+			/>
+		),
+	],
+	["HelpModal", () => <HelpModal onClose={vi.fn()} />],
+	["ImprintModal", () => <ImprintModal onClose={vi.fn()} />],
+	["LicenseModal", () => <LicenseModal onClose={vi.fn()} />],
+];
+
+describe("accessibility sweep", () => {
+	for (const [name, renderCase] of cases) {
+		it(`${name} has no axe violations`, async () => {
+			const { container } = render(renderCase());
+			expect(await axe(container)).toHaveNoViolations();
+		});
+	}
+});

--- a/src/hooks/useDialogA11y.ts
+++ b/src/hooks/useDialogA11y.ts
@@ -1,0 +1,97 @@
+import { useEffect, useId, type RefObject } from "react";
+
+const FOCUSABLE = [
+	"a[href]",
+	"button:not([disabled])",
+	"input:not([disabled])",
+	"select:not([disabled])",
+	"textarea:not([disabled])",
+	'[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/**
+ * Deliberately does not use `offsetParent`: it is the usual way to test
+ * visibility, but jsdom performs no layout and reports null for every element,
+ * which would make the trap find nothing under test.
+ */
+function isVisible(el: HTMLElement): boolean {
+	if (el.hidden || el.closest("[hidden]")) return false;
+	const style = getComputedStyle(el);
+	return style.display !== "none" && style.visibility !== "hidden";
+}
+
+function focusableWithin(root: HTMLElement): HTMLElement[] {
+	return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+		isVisible,
+	);
+}
+
+/**
+ * Makes a modal dialog operable without a mouse:
+ *
+ * - moves focus into the dialog when it opens, so the next Tab starts inside;
+ * - keeps Tab and Shift+Tab cycling within it, so focus cannot wander into the
+ *   inert page behind the backdrop;
+ * - closes on Escape;
+ * - returns focus to whatever was focused before, so the keyboard user is not
+ *   dropped back at the top of the document.
+ *
+ * Returns the id to wire up as `aria-labelledby` on the dialog element.
+ */
+export function useDialogA11y(
+	dialogRef: RefObject<HTMLElement | null>,
+	onClose: () => void,
+): string {
+	const titleId = useId();
+
+	useEffect(() => {
+		const dialog = dialogRef.current;
+		if (!dialog) return;
+
+		const previouslyFocused = document.activeElement as HTMLElement | null;
+
+		const initial = focusableWithin(dialog)[0];
+		if (initial) {
+			initial.focus();
+		} else {
+			// Nothing focusable inside: make the dialog itself the focus target
+			// so screen readers still land in the right place.
+			dialog.tabIndex = -1;
+			dialog.focus();
+		}
+
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				e.stopPropagation();
+				onClose();
+				return;
+			}
+			if (e.key !== "Tab") return;
+
+			const items = focusableWithin(dialog);
+			if (items.length === 0) {
+				e.preventDefault();
+				return;
+			}
+			const first = items[0];
+			const last = items[items.length - 1];
+			const active = document.activeElement;
+
+			if (e.shiftKey && (active === first || !dialog.contains(active))) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && active === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		};
+
+		document.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("keydown", onKeyDown);
+			previouslyFocused?.focus?.();
+		};
+	}, [dialogRef, onClose]);
+
+	return titleId;
+}


### PR DESCRIPTION
Closes #714. 1204 → 1220 tests.

### The canvas announced nothing

The plot is a WebGL canvas with no name, role or description — the app's primary content was simply unreachable. It now carries `role="img"` and a generated `aria-label`:

> Line chart. 2 data series: Temperature, Humidity. Time from 0 to 100. Celsius from -5 to 40.

`describeChart()` is a pure, separately tested module built from the same series/axis data the renderer draws, so it cannot drift from what is on screen. It is memoised on series/axis identity, deliberately **not** on axis min/max — the per-frame pan path mutates ranges through refs and must not trigger React work.

Hidden series are excluded, unnamed series fall back to their column name, date axes are formatted as dates, and above five series the label switches to a count rather than reading out thirty names.

### Dialogs were not keyboard-operable

`Modal` had no `role`, no `aria-modal`, no accessible name, no focus management and no Escape handler — and every dialog in the app (Help, Imprint, License, Import Settings, Calculated Column) goes through it. The new `useDialogA11y` hook adds:

- `role="dialog"` + `aria-modal="true"`, named via `aria-labelledby` pointing at the visible `<h2>` so the accessible name cannot drift from the heading (falling back to `aria-label` when the title is a node)
- focus moved into the dialog on open
- Tab / Shift+Tab wrapping inside it, so focus cannot reach the inert page behind the backdrop
- Escape to close
- focus restored to the opener on unmount — otherwise a keyboard user is dropped at the top of the document

### Automated checking

`vitest-axe` matchers are registered globally in `src/__tests__/setup.ts`, so any component test can assert accessibility with one line. Added a sweep over the cheaply-renderable components plus a dedicated Modal suite covering the focus behaviour above.

One implementation note worth flagging: the focusable-element query deliberately avoids `offsetParent`, the usual visibility test. jsdom performs no layout and reports `null` for every element, so an `offsetParent`-based trap finds nothing under test and silently does nothing — it uses `getComputedStyle` plus the `hidden` attribute instead.

### Colour

Contrast is arithmetic, so it is now asserted rather than eyeballed: body text, axis labels and the accent colour against their backgrounds, across all five themes. **All five already pass WCAG AA** — no palette changes needed, but the check now holds that.

### Found while writing the tests

`toLocaleString()` defaults to three fraction digits, which would have announced an axis spanning 0.000123–0.000456 as "0 to 0". Fixed in `describeChart` with an explicit `maximumFractionDigits`, with a test pinning it.

### Not in this PR

The offscreen data table sketched in the issue. It is a real feature with UI implications rather than an accessibility patch, and `role="img"` with a meaningful name is the substantive fix. Happy to open a follow-up.