### PR TITLE
Rework #706, #701 and #697: take the ideas, drop the problems

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -105,6 +105,49 @@ test("dragging pans the viewport", async ({ page }) => {
 	expect(errors, `console errors: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("ctrl-drag zooms to the selected box", async ({ page }) => {
+	const { errors } = await freshApp(page);
+
+	const before = await axisLabel(page);
+	const box = await page.locator(".plot-area").boundingBox();
+	const cx = box!.x + box!.width / 2;
+	const cy = box!.y + box!.height / 2;
+
+	await page.keyboard.down("Control");
+	await page.mouse.move(cx - 120, cy - 80);
+	await page.mouse.down();
+	await page.mouse.move(cx + 120, cy + 80, { steps: 10 });
+	await page.mouse.up();
+	await page.keyboard.up("Control");
+
+	await expect.poll(() => axisLabel(page), { timeout: 5_000 }).not.toBe(before);
+	expect(errors, `console errors: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("a ctrl-click without a drag leaves the viewport alone", async ({
+	page,
+}) => {
+	const { errors } = await freshApp(page);
+
+	const before = await axisLabel(page);
+	const box = await page.locator(".plot-area").boundingBox();
+	const cx = box!.x + box!.width / 2;
+	const cy = box!.y + box!.height / 2;
+
+	// Below the minimum drag size: a mis-click must not throw the viewport
+	// somewhere arbitrary.
+	await page.keyboard.down("Control");
+	await page.mouse.move(cx, cy);
+	await page.mouse.down();
+	await page.mouse.move(cx + 2, cy + 2);
+	await page.mouse.up();
+	await page.keyboard.up("Control");
+
+	await page.waitForTimeout(500);
+	expect(await axisLabel(page)).toBe(before);
+	expect(errors, `console errors: ${errors.join(" | ")}`).toEqual([]);
+});
+
 test("exports a well-formed SVG", async ({ page }) => {
 	await freshApp(page);
 

--- a/src/components/Plot/__tests__/dashInstances.test.ts
+++ b/src/components/Plot/__tests__/dashInstances.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildDashInstances,
+	computeDashSteps,
+	dashCacheParams,
+	dashParamsEqual,
+	type SegParams,
+	type SeriesDrawBundle,
+} from "../drawSeries";
+
+/**
+ * The dashed-line instance buffer used to be built inline inside a GL call, so
+ * the only way to reach it was through a mocked WebGL context. These are the
+ * pure pieces of that path, checked directly: the striding, the cache key, and
+ * the packed geometry.
+ */
+
+const FLOATS_PER_INSTANCE = 5;
+
+function bundleWith(
+	overrides: Partial<SeriesDrawBundle> = {},
+): SeriesDrawBundle {
+	const n = 8;
+	return {
+		xData: Float32Array.from({ length: n }, (_, i) => i),
+		yData: Float32Array.from({ length: n }, (_, i) => i * 2),
+		xRef: 0,
+		yRef: 0,
+		xAxisMin: 0,
+		xAxisMax: 7,
+		xRange: 7,
+		yRange: 14,
+		chartWidth: 700,
+		chartHeight: 140,
+		padding: { top: 0, right: 0, bottom: 0, left: 0 },
+		height: 140,
+		dpr: 1,
+		xScale: 1,
+		xOff: 0,
+		drawRanges: [{ start: 0, count: n }],
+		...overrides,
+	} as SeriesDrawBundle;
+}
+
+describe("computeDashSteps", () => {
+	it("emits one instance per segment for a short range", () => {
+		// 8 points -> 7 segments, no striding needed.
+		expect(computeDashSteps([{ start: 0, count: 8 }])).toBe(7);
+	});
+
+	it("sums across ranges", () => {
+		expect(
+			computeDashSteps([
+				{ start: 0, count: 5 },
+				{ start: 10, count: 3 },
+			]),
+		).toBe(4 + 2);
+	});
+
+	it("ignores ranges that cannot form a segment", () => {
+		expect(computeDashSteps([{ start: 0, count: 1 }])).toBe(0);
+		expect(computeDashSteps([{ start: 0, count: 0 }])).toBe(0);
+	});
+
+	it("strides long ranges down to the per-range cap", () => {
+		// A dash shorter than a pixel is invisible, so long ranges are strided
+		// instead of emitting an instance per sample.
+		const total = computeDashSteps([{ start: 0, count: 1_000_001 }]);
+		expect(total).toBeLessThanOrEqual(4000);
+		expect(total).toBeGreaterThan(3000);
+	});
+});
+
+describe("dashCacheParams / dashParamsEqual", () => {
+	const bundle = bundleWith();
+
+	it("treats a missing previous entry as a miss", () => {
+		expect(dashParamsEqual(undefined, dashCacheParams(bundle, 7))).toBe(false);
+	});
+
+	it("hits when nothing relevant changed", () => {
+		const a = dashCacheParams(bundle, 7);
+		const b = dashCacheParams(bundleWith(), 7);
+		expect(dashParamsEqual(a, b)).toBe(true);
+	});
+
+	it("hits across a pan, which is the case that matters", () => {
+		// Panning shifts the axis window but leaves the span untouched, so the
+		// packed geometry is still valid and must not be rebuilt every frame.
+		const before = dashCacheParams(bundle, 7);
+		const panned = dashCacheParams(
+			bundleWith({ xAxisMin: 100, xAxisMax: 107, xOff: -100 }),
+			7,
+		);
+		expect(dashParamsEqual(before, panned)).toBe(true);
+	});
+
+	it.each([
+		["xRange", { xRange: 14 }],
+		["yRange", { yRange: 28 }],
+		["chartWidth", { chartWidth: 800 }],
+		["chartHeight", { chartHeight: 200 }],
+		["dpr", { dpr: 2 }],
+	])("misses when %s changes", (_name, override) => {
+		const before = dashCacheParams(bundle, 7);
+		const after = dashCacheParams(bundleWith(override), 7);
+		expect(dashParamsEqual(before, after)).toBe(false);
+	});
+
+	it("misses when the instance count or range layout changes", () => {
+		const before = dashCacheParams(bundle, 7);
+		expect(dashParamsEqual(before, dashCacheParams(bundle, 8))).toBe(false);
+		expect(
+			dashParamsEqual(
+				before,
+				dashCacheParams(
+					bundleWith({
+						drawRanges: [
+							{ start: 0, count: 4 },
+							{ start: 5, count: 3 },
+						],
+					}),
+					7,
+				),
+			),
+		).toBe(false);
+	});
+
+	it("misses when the range starts somewhere else", () => {
+		const before = dashCacheParams(bundle, 7);
+		const after = dashCacheParams(
+			bundleWith({ drawRanges: [{ start: 3, count: 8 }] }),
+			7,
+		);
+		expect(dashParamsEqual(before, after)).toBe(false);
+	});
+
+	it("records every field it compares", () => {
+		// Guards against a field being added to SegParams but not to the
+		// comparison, which would silently serve stale geometry.
+		const params = dashCacheParams(bundle, 7);
+		for (const key of Object.keys(params) as (keyof SegParams)[]) {
+			const mutated = { ...params, [key]: params[key] + 1 };
+			expect(dashParamsEqual(params, mutated), key).toBe(false);
+		}
+	});
+});
+
+describe("buildDashInstances", () => {
+	it("packs endpoints and a running distance per segment", () => {
+		const bundle = bundleWith();
+		const total = computeDashSteps(bundle.drawRanges);
+		const out = buildDashInstances(bundle, total);
+
+		expect(out.length).toBe(total * FLOATS_PER_INSTANCE);
+
+		// First instance spans points 0 and 1, starting at distance zero.
+		expect(Array.from(out.slice(0, 5))).toEqual([0, 0, 1, 2, 0]);
+
+		// scaleX = 700/7 = 100, scaleY = 140/14 = 10, so each segment is
+		// hypot(1*100, 2*10) = hypot(100, 20) device px long.
+		const segLen = Math.hypot(100, 20);
+		expect(out[9]).toBeCloseTo(segLen, 3);
+		expect(out[14]).toBeCloseTo(segLen * 2, 3);
+	});
+
+	it("restarts the distance at each range", () => {
+		// A gap breaks the line, so continuing the phase across it would make
+		// the dash pattern jump.
+		const bundle = bundleWith({
+			drawRanges: [
+				{ start: 0, count: 3 },
+				{ start: 4, count: 3 },
+			],
+		});
+		const total = computeDashSteps(bundle.drawRanges);
+		const out = buildDashInstances(bundle, total);
+
+		expect(total).toBe(4);
+		expect(out[4]).toBe(0);
+		// Third instance is the first of the second range.
+		expect(out[2 * FLOATS_PER_INSTANCE + 4]).toBe(0);
+	});
+
+	it("clamps the final segment of a strided range to the last sample", () => {
+		// With a stride the last step can overshoot; it must land exactly on
+		// the range's final point rather than reading past it.
+		const n = 10_000;
+		const bundle = bundleWith({
+			xData: Float32Array.from({ length: n }, (_, i) => i),
+			yData: Float32Array.from({ length: n }, (_, i) => i),
+			drawRanges: [{ start: 0, count: n }],
+		});
+		const total = computeDashSteps(bundle.drawRanges);
+		const out = buildDashInstances(bundle, total);
+
+		const lastX1 = out[(total - 1) * FLOATS_PER_INSTANCE + 2];
+		expect(lastX1).toBe(n - 1);
+		for (let i = 0; i < out.length; i++) {
+			expect(Number.isFinite(out[i])).toBe(true);
+		}
+	});
+
+	it("respects the reference frame of an offset range", () => {
+		const bundle = bundleWith({ drawRanges: [{ start: 3, count: 3 }] });
+		const total = computeDashSteps(bundle.drawRanges);
+		const out = buildDashInstances(bundle, total);
+
+		expect(total).toBe(2);
+		// Starts at index 3, not 0.
+		expect(out[0]).toBe(3);
+		expect(out[1]).toBe(6);
+	});
+});

--- a/src/components/Plot/drawSeries.ts
+++ b/src/components/Plot/drawSeries.ts
@@ -164,16 +164,84 @@ const STEPS_SCRATCH: number[] = [];
 const DASH_FLOATS = 5;
 const DASH_STRIDE = DASH_FLOATS * 4;
 
-function drawDashedLines(
-	st: GLStateCache,
+// Upper bound on instances contributed by a single draw range; longer ranges
+// are strided down to it, since a dash shorter than a pixel is invisible.
+const DASH_MAX_SEGS_PER_RANGE = 4000;
+
+/**
+ * Picks a stride per draw range so no range contributes more than ~4000
+ * instances, writes it into STEPS_SCRATCH, and returns the total instance
+ * count. Must run before `buildDashInstances`, which reads the same scratch.
+ */
+export function computeDashSteps(drawRanges: readonly DrawRange[]): number {
+	STEPS_SCRATCH.length = drawRanges.length;
+	let totalLineSegs = 0;
+	for (let i = 0; i < drawRanges.length; i++) {
+		const n = Math.max(0, drawRanges[i].count - 1);
+		const step = Math.max(1, Math.floor(n / DASH_MAX_SEGS_PER_RANGE));
+		STEPS_SCRATCH[i] = step;
+		totalLineSegs += Math.ceil(n / step);
+	}
+	return totalLineSegs;
+}
+
+/**
+ * Everything the packed instance buffer depends on. Built once and used both
+ * to compare against the previous frame and to record the new state, so the
+ * field list cannot drift between the two.
+ */
+export function dashCacheParams(
 	bundle: SeriesDrawBundle,
-	segBuffersRef: Map<string, WebGLBuffer>,
-	segParamsRef: Map<string, SegParams>,
-	segBufferKey: string,
-): void {
-	const { gl } = st;
-	const lineLocs = st.lineLocs;
-	if (!lineLocs) return;
+	totalLineSegs: number,
+): SegParams {
+	return {
+		xRange: bundle.xRange,
+		yRange: bundle.yRange,
+		chartWidth: bundle.chartWidth,
+		chartHeight: bundle.chartHeight,
+		dpr: bundle.dpr,
+		totalLineSegs,
+		rangesLen: bundle.drawRanges.length,
+		firstStart: bundle.drawRanges[0]?.start ?? 0,
+	};
+}
+
+/**
+ * Pan is a pure translation, so xRange/yRange are unchanged and this hits
+ * every frame. Zoom does change them, but that miss is amortized over the many
+ * frames that follow. Exact `===` is deliberate rather than an epsilon
+ * comparison: panning preserves the range exactly in floating point, so there
+ * is nothing to tolerate.
+ */
+export function dashParamsEqual(
+	a: SegParams | undefined,
+	b: SegParams,
+): boolean {
+	return (
+		a !== undefined &&
+		a.xRange === b.xRange &&
+		a.yRange === b.yRange &&
+		a.chartWidth === b.chartWidth &&
+		a.chartHeight === b.chartHeight &&
+		a.dpr === b.dpr &&
+		a.totalLineSegs === b.totalLineSegs &&
+		a.rangesLen === b.rangesLen &&
+		a.firstStart === b.firstStart
+	);
+}
+
+/**
+ * Packs one instance per dash segment as (x0, y0, x1, y1, cumulative distance).
+ * The distance runs in device pixels along each range so the fragment shader
+ * can phase the dash pattern; it restarts at every range because a gap breaks
+ * the line anyway.
+ *
+ * Pure and GL-free, which is what makes it testable in isolation.
+ */
+export function buildDashInstances(
+	bundle: SeriesDrawBundle,
+	totalLineSegs: number,
+): Float32Array {
 	const {
 		drawRanges,
 		xData,
@@ -184,31 +252,69 @@ function drawDashedLines(
 		chartHeight,
 		dpr,
 	} = bundle;
-	STEPS_SCRATCH.length = drawRanges.length;
-	let totalLineSegs = 0;
-	for (let i = 0; i < drawRanges.length; i++) {
-		const n = Math.max(0, drawRanges[i].count - 1);
-		const step = Math.max(1, Math.floor(n / 4000));
-		STEPS_SCRATCH[i] = step;
-		totalLineSegs += Math.ceil(n / step);
+	const out = new Float32Array(totalLineSegs * DASH_FLOATS);
+	const scaleX = (chartWidth * dpr) / xRange;
+	const scaleY = (chartHeight * dpr) / yRange;
+
+	let outIdx = 0;
+	for (let rIdx = 0; rIdx < drawRanges.length; rIdx++) {
+		const r = drawRanges[rIdx];
+		const step = STEPS_SCRATCH[rIdx];
+		let cumDist = 0;
+		const n = r.count - 1;
+		for (let i = 0; i < n; i += step) {
+			const ai = r.start + i;
+			let bi = ai + step;
+			if (bi > r.start + n) bi = r.start + n;
+
+			const ax = xData[ai];
+			const ay = yData[ai];
+			const bx = xData[bi];
+			const by = yData[bi];
+			const off = outIdx * DASH_FLOATS;
+			out[off] = ax;
+			out[off + 1] = ay;
+			out[off + 2] = bx;
+			out[off + 3] = by;
+			out[off + 4] = cumDist;
+			cumDist += Math.sqrt(((bx - ax) * scaleX) ** 2 + ((by - ay) * scaleY) ** 2);
+			outIdx++;
+		}
 	}
+	return out;
+}
+
+/** Points the five per-instance attributes at the packed buffer. */
+function bindDashAttributes(
+	st: GLStateCache,
+	lineLocs: NonNullable<GLStateCache["lineLocs"]>,
+): void {
+	const { gl } = st;
+	const locs = [
+		lineLocs.x0Loc,
+		lineLocs.y0Loc,
+		lineLocs.x1Loc,
+		lineLocs.y1Loc,
+		lineLocs.dist0Loc,
+	];
+	for (let i = 0; i < locs.length; i++) {
+		st.enableAttrib(locs[i], 1);
+		gl.vertexAttribPointer(locs[i], 1, gl.FLOAT, false, DASH_STRIDE, i * 4);
+	}
+}
+
+function drawDashedLines(
+	st: GLStateCache,
+	bundle: SeriesDrawBundle,
+	segBuffersRef: Map<string, WebGLBuffer>,
+	segParamsRef: Map<string, SegParams>,
+	segBufferKey: string,
+): void {
+	const { gl, lineLocs } = st;
+	if (!lineLocs) return;
+
+	const totalLineSegs = computeDashSteps(bundle.drawRanges);
 	if (totalLineSegs === 0) return;
-	const rangesLen = drawRanges.length;
-	const firstStart = drawRanges[0]?.start ?? 0;
-	// Pan = translation (xRange/yRange constant) so cache hits every frame.
-	// Zoom changes them, miss is amortized over many frames. Exact === is
-	// fine because pan preserves range exactly in floating point.
-	const prev = segParamsRef.get(segBufferKey);
-	const needsRebuild =
-		!prev ||
-		prev.xRange !== xRange ||
-		prev.yRange !== yRange ||
-		prev.chartWidth !== chartWidth ||
-		prev.chartHeight !== chartHeight ||
-		prev.dpr !== dpr ||
-		prev.totalLineSegs !== totalLineSegs ||
-		prev.rangesLen !== rangesLen ||
-		prev.firstStart !== firstStart;
 
 	let segBuffer = segBuffersRef.get(segBufferKey);
 	if (!segBuffer) {
@@ -218,61 +324,18 @@ function drawDashedLines(
 		segBuffersRef.set(segBufferKey, segBuffer);
 	}
 
-	if (needsRebuild) {
-		const sharedArr = new Float32Array(totalLineSegs * DASH_FLOATS);
-		const scaleX = (chartWidth * dpr) / xRange;
-		const scaleY = (chartHeight * dpr) / yRange;
-
-		let outIdx = 0;
-		for (let rIdx = 0; rIdx < drawRanges.length; rIdx++) {
-			const r = drawRanges[rIdx];
-			const step = STEPS_SCRATCH[rIdx];
-			let cumDist = 0;
-			const n = r.count - 1;
-			for (let i = 0; i < n; i += step) {
-				const ai = r.start + i;
-				let bi = ai + step;
-				if (bi > r.start + n) bi = r.start + n;
-
-				const ax = xData[ai];
-				const ay = yData[ai];
-				const bx = xData[bi];
-				const by = yData[bi];
-				const off = outIdx * DASH_FLOATS;
-				sharedArr[off] = ax;
-				sharedArr[off + 1] = ay;
-				sharedArr[off + 2] = bx;
-				sharedArr[off + 3] = by;
-				sharedArr[off + 4] = cumDist;
-				cumDist += Math.sqrt(((bx - ax) * scaleX) ** 2 + ((by - ay) * scaleY) ** 2);
-				outIdx++;
-			}
-		}
-		gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
-		gl.bufferData(gl.ARRAY_BUFFER, sharedArr, gl.STREAM_DRAW);
-		segParamsRef.set(segBufferKey, {
-			xRange,
-			yRange,
-			chartWidth,
-			chartHeight,
-			dpr,
-			totalLineSegs,
-			rangesLen,
-			firstStart,
-		});
-	} else {
-		gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
+	const params = dashCacheParams(bundle, totalLineSegs);
+	gl.bindBuffer(gl.ARRAY_BUFFER, segBuffer);
+	if (!dashParamsEqual(segParamsRef.get(segBufferKey), params)) {
+		gl.bufferData(
+			gl.ARRAY_BUFFER,
+			buildDashInstances(bundle, totalLineSegs),
+			gl.STREAM_DRAW,
+		);
+		segParamsRef.set(segBufferKey, params);
 	}
-	st.enableAttrib(lineLocs.x0Loc, 1);
-	gl.vertexAttribPointer(lineLocs.x0Loc, 1, gl.FLOAT, false, DASH_STRIDE, 0);
-	st.enableAttrib(lineLocs.y0Loc, 1);
-	gl.vertexAttribPointer(lineLocs.y0Loc, 1, gl.FLOAT, false, DASH_STRIDE, 4);
-	st.enableAttrib(lineLocs.x1Loc, 1);
-	gl.vertexAttribPointer(lineLocs.x1Loc, 1, gl.FLOAT, false, DASH_STRIDE, 8);
-	st.enableAttrib(lineLocs.y1Loc, 1);
-	gl.vertexAttribPointer(lineLocs.y1Loc, 1, gl.FLOAT, false, DASH_STRIDE, 12);
-	st.enableAttrib(lineLocs.dist0Loc, 1);
-	gl.vertexAttribPointer(lineLocs.dist0Loc, 1, gl.FLOAT, false, DASH_STRIDE, 16);
+
+	bindDashAttributes(st, lineLocs);
 	gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, totalLineSegs);
 }
 

--- a/src/hooks/__tests__/useZoomBox.test.ts
+++ b/src/hooks/__tests__/useZoomBox.test.ts
@@ -1,0 +1,221 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	isInsidePlot,
+	isZoomBoxUsable,
+	MIN_ZOOM_BOX_PX,
+	normalizeZoomBox,
+	useZoomBox,
+} from "../useZoomBox";
+
+/**
+ * The zoom rectangle used to live as three refs plus an inline DOM writer
+ * inside usePanZoom, reachable only by driving window events. Owning it here
+ * makes the geometry directly checkable — including the drag-backwards and
+ * too-small-to-count cases, which are easy to get wrong and invisible until a
+ * user's viewport jumps somewhere unexpected.
+ */
+
+const bounds = {
+	width: 400,
+	height: 300,
+	padding: { top: 10, right: 20, bottom: 30, left: 40 },
+};
+
+describe("normalizeZoomBox", () => {
+	it("orders the corners for a forward drag", () => {
+		expect(
+			normalizeZoomBox({ startX: 10, startY: 20, endX: 100, endY: 200 }),
+		).toEqual({ minX: 10, maxX: 100, minY: 20, maxY: 200 });
+	});
+
+	it("orders the corners for a drag up and to the left", () => {
+		// Dragging back towards the origin must produce the same rectangle.
+		expect(
+			normalizeZoomBox({ startX: 100, startY: 200, endX: 10, endY: 20 }),
+		).toEqual({ minX: 10, maxX: 100, minY: 20, maxY: 200 });
+	});
+});
+
+describe("isZoomBoxUsable", () => {
+	it("accepts a deliberate drag", () => {
+		expect(isZoomBoxUsable({ startX: 0, startY: 0, endX: 50, endY: 50 })).toBe(
+			true,
+		);
+	});
+
+	it("rejects a stray click", () => {
+		expect(isZoomBoxUsable({ startX: 7, startY: 7, endX: 7, endY: 7 })).toBe(
+			false,
+		);
+	});
+
+	it("rejects a drag that is thin in only one axis", () => {
+		// A horizontal smear would otherwise zoom y to nothing.
+		expect(isZoomBoxUsable({ startX: 0, startY: 0, endX: 100, endY: 2 })).toBe(
+			false,
+		);
+	});
+
+	it("requires strictly more than the minimum in both axes", () => {
+		const exactly = MIN_ZOOM_BOX_PX;
+		expect(
+			isZoomBoxUsable({ startX: 0, startY: 0, endX: exactly, endY: exactly }),
+		).toBe(false);
+		expect(
+			isZoomBoxUsable({
+				startX: 0,
+				startY: 0,
+				endX: exactly + 1,
+				endY: exactly + 1,
+			}),
+		).toBe(true);
+	});
+});
+
+describe("isInsidePlot", () => {
+	it("accepts a point in the plot area", () => {
+		expect(isInsidePlot(200, 150, bounds)).toBe(true);
+	});
+
+	it("rejects points in the gutters", () => {
+		expect(isInsidePlot(5, 150, bounds)).toBe(false); // left
+		expect(isInsidePlot(395, 150, bounds)).toBe(false); // right
+		expect(isInsidePlot(200, 5, bounds)).toBe(false); // top
+		expect(isInsidePlot(200, 295, bounds)).toBe(false); // bottom
+	});
+
+	it("accepts the boundary itself", () => {
+		expect(isInsidePlot(bounds.padding.left, bounds.padding.top, bounds)).toBe(
+			true,
+		);
+	});
+});
+
+describe("useZoomBox", () => {
+	function setup() {
+		const { result } = renderHook(() => useZoomBox());
+		const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+		result.current.rectRef.current = rect;
+		return { box: result.current, rect };
+	}
+
+	const attrs = (rect: SVGRectElement) => ({
+		x: rect.getAttribute("x"),
+		y: rect.getAttribute("y"),
+		width: rect.getAttribute("width"),
+		height: rect.getAttribute("height"),
+	});
+
+	it("starts inactive", () => {
+		const { box } = setup();
+		expect(box.isDragging()).toBe(false);
+		expect(box.end()).toBeNull();
+	});
+
+	it("refuses to start a drag outside the plot", () => {
+		const { box } = setup();
+		// Ctrl-dragging on an axis gutter must not open a zoom rectangle.
+		expect(box.begin(5, 150, bounds)).toBe(false);
+		expect(box.isDragging()).toBe(false);
+	});
+
+	it("starts a drag inside the plot and paints a zero-size rectangle", () => {
+		const { box, rect } = setup();
+
+		expect(box.begin(100, 100, bounds)).toBe(true);
+		expect(box.isDragging()).toBe(true);
+		expect(attrs(rect)).toEqual({
+			x: "100",
+			y: "100",
+			width: "0",
+			height: "0",
+		});
+	});
+
+	it("paints the rectangle as it is dragged", () => {
+		const { box, rect } = setup();
+		box.begin(100, 100, bounds);
+
+		box.dragTo(200, 180, bounds);
+
+		expect(attrs(rect)).toEqual({
+			x: "100",
+			y: "100",
+			width: "100",
+			height: "80",
+		});
+	});
+
+	it("paints correctly when dragged back past the origin", () => {
+		const { box, rect } = setup();
+		box.begin(200, 200, bounds);
+
+		box.dragTo(120, 150, bounds);
+
+		// SVG rects cannot have negative width; the corners must be ordered.
+		expect(attrs(rect)).toEqual({
+			x: "120",
+			y: "150",
+			width: "80",
+			height: "50",
+		});
+	});
+
+	it("clamps the drag to the plot area", () => {
+		const { box, rect } = setup();
+		box.begin(100, 100, bounds);
+
+		box.dragTo(10_000, 10_000, bounds);
+
+		// Right edge is width - padding.right = 380, bottom is 300 - 30 = 270.
+		expect(attrs(rect)).toEqual({
+			x: "100",
+			y: "100",
+			width: "280",
+			height: "170",
+		});
+	});
+
+	it("ignores a drag that was never started", () => {
+		const { box, rect } = setup();
+		box.dragTo(200, 200, bounds);
+		expect(attrs(rect).width).toBeNull();
+	});
+
+	it("returns normalised bounds when the drag ends", () => {
+		const { box } = setup();
+		box.begin(200, 200, bounds);
+		box.dragTo(120, 150, bounds);
+
+		expect(box.end()).toEqual({ minX: 120, maxX: 200, minY: 150, maxY: 200 });
+		expect(box.isDragging()).toBe(false);
+	});
+
+	it("returns null for a drag too small to be deliberate", () => {
+		const { box } = setup();
+		box.begin(100, 100, bounds);
+		box.dragTo(102, 102, bounds);
+
+		// The caller still needs isDragging() to have been true, so it can clear
+		// its zooming flag without moving the viewport.
+		expect(box.isDragging()).toBe(true);
+		expect(box.end()).toBeNull();
+		expect(box.isDragging()).toBe(false);
+	});
+
+	it("survives a missing rect element", () => {
+		const { result } = renderHook(() => useZoomBox());
+		// The overlay is only mounted while zooming; the refs can be null.
+		expect(() => {
+			result.current.begin(100, 100, bounds);
+			result.current.dragTo(200, 200, bounds);
+		}).not.toThrow();
+		expect(result.current.end()).toEqual({
+			minX: 100,
+			maxX: 200,
+			minY: 100,
+			maxY: 200,
+		});
+	});
+});

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -1,5 +1,6 @@
 // src/hooks/usePanZoom.ts
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useZoomBox } from "./useZoomBox";
 import { hitTestXAxis, hitTestYAxis } from "../components/Plot/axisHitTest";
 import {
 	type PanTarget,
@@ -101,27 +102,18 @@ export function usePanZoom({
 	const [isWheeling, setIsWheeling] = useState(false);
 	const wheelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const containerRectRef = useRef<DOMRect | null>(null);
-	const zoomBoxSvgRef = useRef<SVGSVGElement | null>(null);
-	const zoomBoxRectRef = useRef<SVGRectElement | null>(null);
+	// Owns the ctrl-drag rectangle: its DOM refs, the in-flight drag and the
+	// geometry. Nothing about it leaks back into this hook.
+	const zoomBox = useZoomBox();
 	const panTargetRef = useRef<PanTarget | null>(null);
 	const isShiftPressedRef = useRef(false);
 
 	const isInteracting = !!panTarget || isZooming || isWheeling;
 
-	const updateZoomBoxDom = useCallback(
-		(box: { startX: number; startY: number; endX: number; endY: number }) => {
-			const rect = zoomBoxRectRef.current;
-			if (!rect) return;
-			const x = Math.min(box.startX, box.endX);
-			const y = Math.min(box.startY, box.endY);
-			const w = Math.abs(box.endX - box.startX);
-			const h = Math.abs(box.endY - box.startY);
-			rect.setAttribute("x", String(x));
-			rect.setAttribute("y", String(y));
-			rect.setAttribute("width", String(w));
-			rect.setAttribute("height", String(h));
-		},
-		[],
+	// Plot rectangle, shared by the zoom-box calls below.
+	const plotBounds = useMemo(
+		() => ({ width, height, padding }),
+		[width, height, padding],
 	);
 
 	// Track shift state in a ref so updatePan (called from rAF/event handlers) sees the latest value.
@@ -218,12 +210,6 @@ export function usePanZoom({
 	);
 	const lastTouchTime = useRef<number>(0);
 	const lastMousePos = useRef<{ x: number; y: number } | null>(null);
-	const zoomBoxStartRef = useRef<{
-		startX: number;
-		startY: number;
-		endX: number;
-		endY: number;
-	} | null>(null);
 	const hoveredAxisIdRef = useRef<string | null>(null);
 	const hoveredXAxisIdRef = useRef<string | null>(null);
 
@@ -395,17 +381,7 @@ export function usePanZoom({
 			const x = e.clientX - rect.left,
 				y = e.clientY - rect.top;
 			if (e.ctrlKey && target === "all") {
-				if (
-					x >= padding.left &&
-					x <= width - padding.right &&
-					y >= padding.top &&
-					y <= height - padding.bottom
-				) {
-					const box = { startX: x, startY: y, endX: x, endY: y };
-					zoomBoxStartRef.current = box;
-					setIsZooming(true);
-					updateZoomBoxDom(box);
-				}
+				if (zoomBox.begin(x, y, plotBounds)) setIsZooming(true);
 			} else {
 				// A drag must track the cursor 1:1 — stop any running zoom easing.
 				smoothZoomRef.current = false;
@@ -415,7 +391,7 @@ export function usePanZoom({
 				lastMousePos.current = { x: e.clientX, y: e.clientY };
 			}
 		},
-		[containerRef, padding, width, height, updateZoomBoxDom, smoothZoomRef],
+		[containerRef, plotBounds, zoomBox, smoothZoomRef],
 	);
 
 	const handleTouchStart = useCallback(
@@ -597,16 +573,13 @@ export function usePanZoom({
 
 			const target = panTargetRef.current;
 			// Only update hover state when not actively panning — saves work per frame.
-			if (!target && !zoomBoxStartRef.current) {
+			if (!target && !zoomBox.isDragging()) {
 				hoveredAxisIdRef.current = getHoveredYAxis(mx, my);
 				hoveredXAxisIdRef.current = getHoveredXAxis(mx, my);
 			}
 
-			if (zoomBoxStartRef.current) {
-				const box = zoomBoxStartRef.current;
-				box.endX = Math.max(padding.left, Math.min(width - padding.right, mx));
-				box.endY = Math.max(padding.top, Math.min(height - padding.bottom, my));
-				updateZoomBoxDom(box);
+			if (zoomBox.isDragging()) {
+				zoomBox.dragTo(mx, my, plotBounds);
 				return;
 			}
 			if (!target || !lastMousePos.current) return;
@@ -642,17 +615,14 @@ export function usePanZoom({
 			panStateRef.current.active = false;
 			containerRectRef.current = null;
 
-			if (zoomBoxStartRef.current) {
-				const box = zoomBoxStartRef.current;
-				zoomBoxStartRef.current = null;
+			// isDragging before end(): a drag that was too small still has to
+			// clear the zooming flag, it just must not move the viewport.
+			if (zoomBox.isDragging()) {
+				const bounds = zoomBox.end();
 				setIsZooming(false);
-				const minX = Math.min(box.startX, box.endX);
-				const maxX = Math.max(box.startX, box.endX);
-				const minY = Math.min(box.startY, box.endY);
-				const maxY = Math.max(box.startY, box.endY);
-				if (maxX - minX > 5 && maxY - minY > 5) {
+				if (bounds) {
 					applyZoomBoxToAxes(
-						{ minX, maxX, minY, maxY },
+						bounds,
 						activeXAxes,
 						activeYAxes,
 						width,
@@ -705,7 +675,8 @@ export function usePanZoom({
 		updatePan,
 		onPanEnd,
 		panStateRef,
-		updateZoomBoxDom,
+		zoomBox,
+		plotBounds,
 		chartWidth,
 		chartHeight,
 	]);
@@ -723,8 +694,8 @@ export function usePanZoom({
 		isShiftPressed,
 		isInteracting,
 		isZooming,
-		zoomBoxSvgRef,
-		zoomBoxRectRef,
+		zoomBoxSvgRef: zoomBox.svgRef,
+		zoomBoxRectRef: zoomBox.rectRef,
 		handleMouseDown,
 		handleTouchStart,
 		handleWheel,

--- a/src/hooks/useZoomBox.ts
+++ b/src/hooks/useZoomBox.ts
@@ -1,0 +1,139 @@
+import { useCallback, useRef } from "react";
+
+/** Drag rectangle in container-local pixels; end may lie before start. */
+export interface ZoomBoxRect {
+	startX: number;
+	startY: number;
+	endX: number;
+	endY: number;
+}
+
+/** Axis-aligned bounds, always normalised so min <= max. */
+export interface ZoomBoxBounds {
+	minX: number;
+	maxX: number;
+	minY: number;
+	maxY: number;
+}
+
+export interface PlotBounds {
+	width: number;
+	height: number;
+	padding: { top: number; right: number; bottom: number; left: number };
+}
+
+/**
+ * A drag shorter than this in either axis is treated as a stray click rather
+ * than a zoom, so a mis-click does not throw the viewport somewhere useless.
+ */
+export const MIN_ZOOM_BOX_PX = 5;
+
+/** Corner-order-independent bounds of a drag rectangle. */
+export function normalizeZoomBox(box: ZoomBoxRect): ZoomBoxBounds {
+	return {
+		minX: Math.min(box.startX, box.endX),
+		maxX: Math.max(box.startX, box.endX),
+		minY: Math.min(box.startY, box.endY),
+		maxY: Math.max(box.startY, box.endY),
+	};
+}
+
+/** True when the drag is large enough to be a deliberate zoom. */
+export function isZoomBoxUsable(box: ZoomBoxRect): boolean {
+	const { minX, maxX, minY, maxY } = normalizeZoomBox(box);
+	return maxX - minX > MIN_ZOOM_BOX_PX && maxY - minY > MIN_ZOOM_BOX_PX;
+}
+
+/** Whether a point lies inside the plot rectangle (excluding the gutters). */
+export function isInsidePlot(
+	x: number,
+	y: number,
+	{ width, height, padding }: PlotBounds,
+): boolean {
+	return (
+		x >= padding.left &&
+		x <= width - padding.right &&
+		y >= padding.top &&
+		y <= height - padding.bottom
+	);
+}
+
+export interface ZoomBoxController {
+	/** Attach to the overlay `<svg>` and its `<rect>`. */
+	svgRef: React.RefObject<SVGSVGElement | null>;
+	rectRef: React.RefObject<SVGRectElement | null>;
+	/** True while a drag is in progress. */
+	isDragging: () => boolean;
+	/**
+	 * Starts a drag at a container-local point, if it is inside the plot.
+	 * Returns whether a drag was started.
+	 */
+	begin: (x: number, y: number, bounds: PlotBounds) => boolean;
+	/** Extends the drag, clamped to the plot, and updates the overlay. */
+	dragTo: (x: number, y: number, bounds: PlotBounds) => void;
+	/**
+	 * Ends the drag. Returns the bounds to zoom to, or null when there was no
+	 * drag or it was too small to count. Callers that need to distinguish
+	 * "no drag" from "drag too small" should check `isDragging()` first.
+	 */
+	end: () => ZoomBoxBounds | null;
+}
+
+/**
+ * Owns the ctrl-drag zoom rectangle: its two DOM refs, the in-flight drag, and
+ * the geometry.
+ *
+ * The rectangle is written straight to SVG attributes rather than through
+ * React state — it updates on every mouse move, and the surrounding pan/zoom
+ * machinery deliberately keeps per-frame work off the render path. Keeping
+ * that here means the caller never sees the refs at all; it only starts,
+ * extends and ends a drag.
+ */
+export function useZoomBox(): ZoomBoxController {
+	const svgRef = useRef<SVGSVGElement | null>(null);
+	const rectRef = useRef<SVGRectElement | null>(null);
+	const dragRef = useRef<ZoomBoxRect | null>(null);
+
+	const paint = useCallback((box: ZoomBoxRect) => {
+		const rect = rectRef.current;
+		if (!rect) return;
+		const { minX, maxX, minY, maxY } = normalizeZoomBox(box);
+		rect.setAttribute("x", String(minX));
+		rect.setAttribute("y", String(minY));
+		rect.setAttribute("width", String(maxX - minX));
+		rect.setAttribute("height", String(maxY - minY));
+	}, []);
+
+	const isDragging = useCallback(() => dragRef.current !== null, []);
+
+	const begin = useCallback(
+		(x: number, y: number, bounds: PlotBounds) => {
+			if (!isInsidePlot(x, y, bounds)) return false;
+			const box = { startX: x, startY: y, endX: x, endY: y };
+			dragRef.current = box;
+			paint(box);
+			return true;
+		},
+		[paint],
+	);
+
+	const dragTo = useCallback(
+		(x: number, y: number, { width, height, padding }: PlotBounds) => {
+			const box = dragRef.current;
+			if (!box) return;
+			box.endX = Math.max(padding.left, Math.min(width - padding.right, x));
+			box.endY = Math.max(padding.top, Math.min(height - padding.bottom, y));
+			paint(box);
+		},
+		[paint],
+	);
+
+	const end = useCallback(() => {
+		const box = dragRef.current;
+		dragRef.current = null;
+		if (!box || !isZoomBoxUsable(box)) return null;
+		return normalizeZoomBox(box);
+	}, []);
+
+	return { svgRef, rectRef, isDragging, begin, dragTo, end };
+}

--- a/src/services/__tests__/export.test.ts
+++ b/src/services/__tests__/export.test.ts
@@ -608,6 +608,52 @@ describe("downloadFile", () => {
 		);
 	});
 
+	/** The bytes handed to the Blob for the most recent download. */
+	const lastBlobBytes = (): Uint8Array => {
+		const created = (
+			URL.createObjectURL as unknown as ReturnType<typeof vi.fn>
+		).mock.calls.at(-1)?.[0] as { content: unknown[] };
+		return created.content[0] as Uint8Array;
+	};
+
+	it("encodes a percent-escaped data URL as UTF-8", () => {
+		// decodeURIComponent turns the escapes back into text, so the bytes have
+		// to be re-encoded. Reading char codes instead would emit Latin-1 here.
+		const text = "Grüße";
+		downloadFile(
+			`data:application/json,${encodeURIComponent(text)}`,
+			"test.json",
+			"application/json",
+		);
+
+		const bytes = lastBlobBytes();
+		expect(new TextDecoder().decode(bytes)).toBe(text);
+		// "ü" is two bytes in UTF-8 and one in Latin-1; the length pins which.
+		expect(bytes.length).toBe(new TextEncoder().encode(text).length);
+	});
+
+	it("keeps characters above U+00FF intact in a data URL", () => {
+		// A char-code loop truncates these to a single byte, silently corrupting
+		// the file rather than failing.
+		const text = "温度 → 25°C";
+		downloadFile(
+			`data:application/json,${encodeURIComponent(text)}`,
+			"test.json",
+			"application/json",
+		);
+
+		expect(new TextDecoder().decode(lastBlobBytes())).toBe(text);
+	});
+
+	it("still reads base64 data URLs as raw bytes", () => {
+		// The binary path must not be re-encoded: atob already yields bytes.
+		const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff]);
+		const base64 = btoa(String.fromCharCode(...bytes));
+		downloadFile(`data:image/png;base64,${base64}`, "test.png", "image/png");
+
+		expect(Array.from(lastBlobBytes())).toEqual(Array.from(bytes));
+	});
+
 	it("should throw an error if atob fails on invalid base64 data", () => {
 		expect(() =>
 			downloadFile(

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -118,10 +118,24 @@ export const downloadFile = (
 			const data = url.pathname.slice(commaIndex + 1);
 			const isBase64 = parts.includes("base64");
 
-			const byteString = isBase64 ? atob(data) : decodeURIComponent(data);
-			const arrayBuffer = new Uint8Array(byteString.length);
-			for (let i = 0; i < byteString.length; i++) {
-				arrayBuffer[i] = byteString.charCodeAt(i);
+			let arrayBuffer: Uint8Array<ArrayBuffer>;
+			if (isBase64) {
+				// atob yields a binary string — one byte per code unit — so
+				// charCodeAt is the correct way to recover the bytes.
+				const byteString = atob(data);
+				arrayBuffer = new Uint8Array(byteString.length);
+				for (let i = 0; i < byteString.length; i++) {
+					arrayBuffer[i] = byteString.charCodeAt(i);
+				}
+			} else {
+				// decodeURIComponent has already decoded the percent-escapes as
+				// UTF-8, so `data` is text, not bytes. Re-encoding it keeps that
+				// intact; a charCodeAt loop would emit Latin-1 for U+0080..U+00FF
+				// and truncate anything above U+00FF outright.
+				// Copied into a plain ArrayBuffer because TextEncoder returns an
+				// ArrayBufferLike view, which Blob does not accept.
+				const encoded = new TextEncoder().encode(decodeURIComponent(data));
+				arrayBuffer = new Uint8Array(encoded);
 			}
 
 			const blob = new Blob([arrayBuffer], { type: contentType || mimeType });


### PR DESCRIPTION
Supersedes #706, #701 and #697. Each was rejected as submitted; this implements the salvageable idea from each on current `main`, as discussed on those PRs.

Three separate commits, one per source PR.

---

### From #706 — the UTF-8 bug, not the sanitizer

`downloadFile` fed `decodeURIComponent` output through a `charCodeAt` loop. That is correct for `atob` output (a binary string) but wrong for text: it emits Latin-1 for U+0080..U+00FF and truncates anything above U+00FF outright. The two branches are now separated, with the loop kept only where it belongs.

The new tests **fail against the previous implementation** (2 failures), and the base64 path is asserted to still round-trip raw bytes.

**Not taken:** the DOMPurify pass. I checked every interpolation in `svgExport.ts` — every user-controlled value already goes through `escapeHTML` at construction, so there is nothing left to sanitize. And the sanitizer as written was self-defeating: it carved out `<!-- payload-start -->…<!-- payload-end -->` *before* sanitizing and re-appended it unsanitized, after the closing tag.

**Worth knowing:** the buggy branch is not currently reachable from the app — SVG export passes a plain string (which goes to the Blob path) and PNG passes a base64 data URL. `downloadFile` is a general-purpose exported helper, so it should still be correct, but this is a latent bug rather than a user-visible one.

---

### From #697 — the readability split, keeping the reasoning

Same goal as #697, three differences:

1. The comment explaining why the cache key uses exact `===` (pan preserves the range bit-for-bit; zoom misses amortise) moves onto the function it describes instead of being deleted.
2. `buildDashInstances` takes the bundle, not eight positional parameters.
3. `dashCacheParams` builds the key used **both** for the comparison and for the recorded state. Previously the eight-field list was written out twice and could drift; a test now asserts every field in `SegParams` actually participates in the comparison.

`buildDashInstances` is pure and GL-free, so the packed geometry is testable directly rather than only through a mocked WebGL context. 19 new tests cover the striding, the per-range distance reset, and the strided-tail clamp.

---

### From #701 — a cut by concern, not by parameter forwarding

`useZoomBox` owns both DOM refs and the in-flight drag, exposing `begin` / `dragTo` / `end` / `isDragging`. The zoom-box logic moves from three separate sites inside the events effect into one place, and `usePanZoom` loses three refs (15 → 12) plus the inline geometry.

The geometry is now pure and tested: corner ordering for a backwards drag, clamping to the plot rectangle, and the too-small-to-count threshold — including the exact boundary. Two new e2e tests drive ctrl-drag zoom and the mis-click case in a real browser.

**Honest accounting:** this is **+110 lines net** and the effect's dependency array grew by **one** entry (`updateZoomBoxDom` → `zoomBox`, `plotBounds`). So it is not a size win, and I am not going to claim one. The win is that the state has an owner, the logic has one home, and the geometry is testable. That was the actual complaint about #701 — a 30-field options object with a hand-maintained 30-entry dependency array — and this does not repeat it.

I deliberately did **not** split the window-events effect. That is what made #701 risky, and it is the part CLAUDE.md asks to leave alone.

---

### Verification

`format:check`, `lint`, `build`, `size-check` and `bench:check` all pass; **1261 unit tests** (up from 1223) and **7 e2e tests** green. Benchmarks show no regression on the hot path — relevant for the `drawSeries` and `usePanZoom` changes.