### PR TITLE
build: let Biome honour .gitignore

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,10 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
 	"files": {
 		"includes": ["**", "!dist", "!coverage", "!.remember", "!package-lock.json"]
 	},


### PR DESCRIPTION
A papercut introduced by the benchmark work in #718.

`npm run bench` writes `bench-result.json`. It is gitignored, but Biome does not consult `.gitignore` unless told to, so `npm run format:check` failed for anyone who had run the benchmarks locally:

```
$ npm run bench:check && npm run format:check
...
Found 1 error.   # bench-result.json
```

CI never caught this because the `bench` job runs in a separate job from `quality`, so the artefact does not exist where `format:check` runs. It only bites developers.

`vcs.useIgnoreFile` fixes it generally and also subsumes the hand-maintained exclusions for `dist/`, `coverage/`, `test-results/` and `playwright-report/`.

Verified with the artefact present: `format:check` exits 0, and the file count drops from 246 to 243.